### PR TITLE
nyx-cache: init

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,15 +23,21 @@ We recommend to integrate this repo using Flakes:
         system = "x86_64-linux";
         modules = [
           ./configuration.nix # Your system configuration.
-          chaotic.nixosModules.default
-          ({ pkgs, ... }: {
-            environment.systemPackages = [ pkgs.input-leap_git ];
-            chaotic.mesa-git.enable = true;
-          })
+          chaotic.nixosModules.default # OUR DEFAULT MODULE
         ];
       };
     };
   };
+}
+```
+
+In your `configuration.nix` enable the packages and options that you prefer:
+
+```nix
+{ pkgs, ... }:
+{
+  environment.systemPackages = [ pkgs.input-leap-git ];
+  chaotic.mesa-git.enable = true;
 }
 ```
 
@@ -73,8 +79,6 @@ nix run github:chaotic-cx/nyx#input-leap_git
 
 ```nix
 {
-  chaotic.mesa-git.enable = true; # requires `--impure`
-  chaotic.linux_hdr.specialisation.enable = true;
   chaotic.gamescope = {
     enable = true;
     package = pkgs.gamescope_git;
@@ -86,21 +90,19 @@ nix run github:chaotic-cx/nyx#input-leap_git
       env = { };
     };
   };
+  chaotic.linux_hdr.specialisation.enable = true;
+  chaotic.mesa-git.enable = true; # requires `--impure`
+  chaotic.nyx.cache.enable = false;
 }
 ```
 
 ## Cache
 
-```nix
-{
-  nix.settings = {
-    extra-substituters = [
-      "https://nyx.chaotic.cx"
-    ];
-    extra-trusted-public-keys = [
-      "nyx.chaotic.cx-1:HfnXSw4pj95iI/n17rIDy40agHj12WfF+Gqk6SonIT8="
-      "chaotic-nyx.cachix.org-1:HfnXSw4pj95iI/n17rIDy40agHj12WfF+Gqk6SonIT8="
-    ];
-  };
-}
-```
+You'll get the binary cache added to your configuration as soon as you add our default module.
+We do this automatically so we can gracefully update its address and keys without prompting you for manual work.
+
+If you dislike this behavior for any reason, you can disable it with `chaotic.nyx.cache.enable = false`.
+
+**Remember**: If you want to fetch derivations from our cache, you'll need to enable our module and rebuild your system **before** adding these derivations to your configuration.
+
+Commands like `nix run ...`, `nix develop ...`, and others, when using our flake as input, will ask you to add the cache interactively when missing from your user's nix-settings.

--- a/modules/default.nix
+++ b/modules/default.nix
@@ -5,9 +5,10 @@ rec {
       nixpkgs.overlays = [ inputs.self.overlays.default ];
     };
 
-    imports = [ gamescope linux_hdr mesa_git ];
+    imports = [ gamescope linux_hdr mesa_git nyx-cache ];
   };
   gamescope = import ./gamescope.nix fromFlakes;
   linux_hdr = import ./linux_hdr.nix fromFlakes;
   mesa_git = import ./mesa-git.nix fromFlakes;
+  nyx-cache = import ./nyx-cache.nix fromFlakes;
 }

--- a/modules/nyx-cache.nix
+++ b/modules/nyx-cache.nix
@@ -1,0 +1,24 @@
+{ inputs }: { config, lib, ... }:
+let
+  cfg = config.chaotic.nyx.cache;
+in
+{
+  options = {
+    chaotic.nyx.cache.enable =
+      lib.mkOption {
+        default = true;
+        description = ''
+          Whether to add Chaotic-Nyx's binary cache to settings.
+        '';
+      };
+  };
+  config = {
+    nix.settings = lib.mkIf cfg.enable {
+      extra-substituters = [ "https://nyx.chaotic.cx" ];
+      extra-trusted-public-keys = [
+        "nyx.chaotic.cx-1:HfnXSw4pj95iI/n17rIDy40agHj12WfF+Gqk6SonIT8="
+        "chaotic-nyx.cachix.org-1:HfnXSw4pj95iI/n17rIDy40agHj12WfF+Gqk6SonIT8="
+      ];
+    };
+  };
+}


### PR DESCRIPTION
### :fish: What?

1. Enable the cache and its trusted key by default into the `chaotic.nixosModules.default`;
2. Allow the user to disable (1) with `chaotic.nyx.cache.enable = false`;
3. Update the README to reflect the changes;
4. Remove some `internal = true`;
5. Cleanup usage instructions.

### :fishing_pole_and_fish: Why?

- With (1) and (2), it will be easier for us to update later;
- About (4), it was a mistake, they shouldn't be there to start with;
- (3) and (5) are docs.