### PR TITLE
ci: provide more space for nix builds

### DIFF
--- a/.github/workflows/needs-cache.yml
+++ b/.github/workflows/needs-cache.yml
@@ -23,6 +23,8 @@ jobs:
         uses: actions/checkout@v3
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+      - name: Run GH actions cleanup
+        run: sudo rm -rf /usr/share /usr/local /opt || true # https://github.com/easimon/maximize-build-space
       - name: Build packages
         run: nix shell -c build-chaotic-nyx && exit 1 || [ $? -eq 23 ]
         env:


### PR DESCRIPTION
This deletes the preinstalled, unneeded tools to get more space for building (idea from here: https://github.com/easimon/maximize-build-space) Nix packages. I ran into space issues when building derivations on my own flake repo, so this will be a good idea to save us time in the future. 
