### PR TITLE
packages: use underline convention; bump mesa_git, sway_git, and wlroots_git

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -37,11 +37,11 @@
     "mesa-git-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1681430328,
-        "narHash": "sha256-oudCy6Ffa6eSNk1xLO1ucd43SeXTKqAaLYk1naRVYcA=",
+        "lastModified": 1681556226,
+        "narHash": "sha256-PQbcq7Kqvze6Ijgb0amVshQcXDJ6EogKVZ85pJucM3Y=",
         "owner": "chaotic-cx",
         "repo": "mesa-mirror",
-        "rev": "948a122f300b3df036fea1a8e14301295062e360",
+        "rev": "c6906448425a03163c029a0c2c12c632a0b49f98",
         "type": "github"
       },
       "original": {
@@ -81,11 +81,11 @@
     "sway-git-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1680811432,
-        "narHash": "sha256-ma4kBTd5+KD6lAAM+DrlXbCEq5YKXxIUDuVOwvTcBKg=",
+        "lastModified": 1681490094,
+        "narHash": "sha256-OJP0Qsxp9oAUWe7P0wkQYb3NcQfeBjIhUzVZi79SH0o=",
         "owner": "swaywm",
         "repo": "sway",
-        "rev": "dadf3e9b7865e7a907a6d95cbb94a2e1cd8cf67f",
+        "rev": "08c1946d71039e583696842c3558b337aede1cbf",
         "type": "github"
       },
       "original": {
@@ -115,11 +115,11 @@
     "wlroots-git-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1681308265,
-        "narHash": "sha256-NBNKfc5MpFGY/Pph0cXlpGKAXPnz7r5ImWZV9UwvXvA=",
+        "lastModified": 1681504164,
+        "narHash": "sha256-gPKuujQtMSAg6rQZu37Tm+uE3+/Z47YsfiLvOi3WB0E=",
         "ref": "master",
-        "rev": "40dde59475bef1eaa7ac70786b700fb3549bb366",
-        "revCount": 6189,
+        "rev": "39be67df4605adb15e4e1673a0e8820802aeefc1",
+        "revCount": 6196,
         "type": "git",
         "url": "https://gitlab.freedesktop.org/wlroots/wlroots.git"
       },

--- a/modules/mesa-git.nix
+++ b/modules/mesa-git.nix
@@ -15,9 +15,9 @@ in
   };
   config = {
     hardware.opengl = lib.mkIf cfg.mesa-git.enable {
-      package = pkgs.mesa-git.drivers;
-      package32 = lib.mkIf (pkgs.stdenv.hostPlatform.isLinux && pkgs.stdenv.hostPlatform.isx86) pkgs.mesa-git-32.drivers;
-      extraPackages = [ pkgs.mesa-git.opencl ];
+      package = pkgs.mesa_git.drivers;
+      package32 = lib.mkIf (pkgs.stdenv.hostPlatform.isLinux && pkgs.stdenv.hostPlatform.isx86) pkgs.mesa_git-32.drivers;
+      extraPackages = [ pkgs.mesa_git.opencl ];
     };
 
     specialisation.stable-mesa = lib.mkIf cfg.mesa-git.enable {

--- a/modules/mesa-git.nix
+++ b/modules/mesa-git.nix
@@ -16,7 +16,7 @@ in
   config = {
     hardware.opengl = lib.mkIf cfg.mesa-git.enable {
       package = pkgs.mesa_git.drivers;
-      package32 = lib.mkIf (pkgs.stdenv.hostPlatform.isLinux && pkgs.stdenv.hostPlatform.isx86) pkgs.mesa_git-32.drivers;
+      package32 = lib.mkIf (pkgs.stdenv.hostPlatform.isLinux && pkgs.stdenv.hostPlatform.isx86) pkgs.mesa32_git.drivers;
       extraPackages = [ pkgs.mesa_git.opencl ];
     };
 

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -1,6 +1,9 @@
 # - Sort packages in alphabetic order.
 # - If the recipe uses `override` or `overrideAttrs`, then use `prev`,
 #   otherwise use `final`.
+# - Composed names are separated with minus: input-leap
+# - Versions/varitions are suffixed with an underline: mesa_git, libei_0_5, linux_hdr
+
 { inputs }: final: prev:
 let
   utils = import ../shared/utils.nix {
@@ -25,11 +28,11 @@ in
 
   dr460nized-kde-theme = final.callPackage ../pkgs/dr460nized-kde-theme { };
 
-  gamescope-git = prev.callPackage ../pkgs/gamescope-git {
+  gamescope_git = prev.callPackage ../pkgs/gamescope-git {
     inherit (inputs) gamescope-git-src;
   };
 
-  input-leap-git = prev.callPackage ../pkgs/input-leap-git {
+  input-leap_git = prev.callPackage ../pkgs/input-leap-git {
     inherit (inputs) input-leap-git-src;
     libei = final.libei_0_4;
     qttools = final.libsForQt5.qt5.qttools;
@@ -51,11 +54,11 @@ in
 
   linuxPackages_hdr = final.linuxPackagesFor final.linux_hdr;
 
-  mesa-git = prev.callPackage ../pkgs/mesa-git {
+  mesa_git = prev.callPackage ../pkgs/mesa-git {
     inherit (inputs) mesa-git-src;
     inherit utils;
   };
-  mesa-git-32 =
+  mesa32_git =
     if final.stdenv.hostPlatform.isLinux && final.stdenv.hostPlatform.isx86
     then
       prev.pkgsi686Linux.callPackage ../pkgs/mesa-git
@@ -63,22 +66,32 @@ in
           inherit (inputs) mesa-git-src;
           inherit utils;
         }
-    else throw "No mesa-git-32 for non-x86";
+    else throw "No mesa32_git for non-x86";
 
-  sway-unwrapped-git =
+  sway-unwrapped_git =
     (prev.sway-unwrapped.override {
-      wlroots_0_16 = final.wlroots-git;
+      wlroots_0_16 = final.wlroots_git;
+      wayland = final.wayland_next;
     }).overrideAttrs (_: {
       version = "1.9-unstable";
       src = inputs.sway-git-src;
     });
-  sway-git = prev.sway.override {
-    sway-unwrapped = final.sway-unwrapped-git;
+  sway_git = prev.sway.override {
+    sway-unwrapped = final.sway-unwrapped_git;
   };
 
-  waynergy-git = prev.waynergy.overrideAttrs (_: { src = inputs.waynergy-git-src; });
+  wayland_next = prev.wayland.overrideAttrs (_: rec {
+    version = "1.22.0";
+    src = final.fetchurl {
+      url = "https://gitlab.freedesktop.org/wayland/wayland/-/releases/${version}/downloads/wayland-${version}.tar.xz";
+      hash = "sha256-FUCvHqaYpHHC2OnSiDMsfg/TYMjx0Sk267fny8JCWEI=";
+    };
+  });
 
-  wlroots-git = prev.callPackage ../pkgs/wlroots-git {
+  waynergy_git = prev.waynergy.overrideAttrs (_: { src = inputs.waynergy-git-src; });
+
+  wlroots_git = prev.callPackage ../pkgs/wlroots-git {
     inherit (inputs) wlroots-git-src;
+    inherit (final) wayland_next;
   };
 }

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -25,7 +25,7 @@ in
 
   directx-headers_next = prev.directx-headers.overrideAttrs (_: rec {
     version = "1.610.0";
-      src = final.fetchFromGitHub {
+    src = final.fetchFromGitHub {
       owner = "microsoft";
       repo = "DirectX-Headers";
       rev = "v${version}";
@@ -36,15 +36,16 @@ in
   directx-headers32_next =
     if final.stdenv.hostPlatform.isLinux && final.stdenv.hostPlatform.isx86
     then
-      prev.pkgsi686Linux.directx-headers.overrideAttrs (_: rec {
-        version = "1.610.0";
+      prev.pkgsi686Linux.directx-headers.overrideAttrs
+        (_: rec {
+          version = "1.610.0";
           src = final.fetchFromGitHub {
-          owner = "microsoft";
-          repo = "DirectX-Headers";
-          rev = "v${version}";
-          hash = "sha256-lPYXAMFSyU3FopWdE6dDRWD6sVKcjxDVsTbgej/T2sk=";
-        };
-      })
+            owner = "microsoft";
+            repo = "DirectX-Headers";
+            rev = "v${version}";
+            hash = "sha256-lPYXAMFSyU3FopWdE6dDRWD6sVKcjxDVsTbgej/T2sk=";
+          };
+        })
     else throw "No headers32_next for non-x86";
 
   firedragon-unwrapped = final.callPackage ../pkgs/firedragon { };

--- a/pkgs/mesa-git/default.nix
+++ b/pkgs/mesa-git/default.nix
@@ -1,11 +1,14 @@
-{ lib
+{ directx-headers_next
+, lib
 , libunwind
 , lm_sensors
 , mesa
 , mesa-git-src
 , utils
 }:
-mesa.overrideAttrs (fa: {
+(mesa.override {
+  directx-headers = directx-headers_next;
+}).overrideAttrs (fa: {
   version = "23.1.99";
   src = mesa-git-src;
   buildInputs = fa.buildInputs ++ [ libunwind lm_sensors ];

--- a/pkgs/wlroots-git/default.nix
+++ b/pkgs/wlroots-git/default.nix
@@ -2,10 +2,14 @@
 , hwdata
 , lib
 , libdisplay-info
+, wayland_next
 , wlroots_0_16
 , wlroots-git-src
 }:
-(wlroots_0_16.override { inherit enableXWayland; }).overrideAttrs (pa: {
+(wlroots_0_16.override {
+  inherit enableXWayland;
+  wayland = wayland_next;
+}).overrideAttrs (pa: {
   version = "0.17-unstable";
   src = wlroots-git-src;
   buildInputs = pa.buildInputs ++ [ hwdata libdisplay-info ];


### PR DESCRIPTION
- packages: use underline convention;
- flake-20230415-1: mesa_git, sway_git, wlroots_git;
- mesa_git: use directx-headers_next;
- mesa32_git: use directx-headers32_next;
- wlroots_git: use wayland_next;
- sway_git: use wayland_next;
- directx-headers_next: init at 1.610.0;
- directx-headers32_next: init at 1.610.0;
- wayland_next: init at 1.22.0.