### PR TITLE
appmenu-gtk3-module: init at 0.7.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ We recommend to integrate this repo using Flakes:
   ananicy-cpp-rules
   applet-window-appmenu
   applet-window-title
+  appmenu-gtk3-module
   beautyline-icons # Garuda Linux's version
   firedragon
   dr460nized-kde-theme
@@ -73,7 +74,8 @@ nix run github:chaotic-cx/nyx#input-leap_git
 
 ```nix
 {
-  chaotic.mesa-git.enable = true; # requires `--impure`
+  chaotic.appmenu-gtk3-module.enable = true;
+  chaotic.mesa-git.enable = true;
   chaotic.linux_hdr.specialisation.enable = true;
   chaotic.gamescope = {
     enable = true;

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ nix run github:chaotic-cx/nyx#input-leap_git
 ```nix
 {
   chaotic.appmenu-gtk3-module.enable = true;
-  chaotic.mesa-git.enable = true;
+  chaotic.mesa-git.enable = true; # requires `--impure`
   chaotic.linux_hdr.specialisation.enable = true;
   chaotic.gamescope = {
     enable = true;

--- a/modules/appmenu-gtk3-module.nix
+++ b/modules/appmenu-gtk3-module.nix
@@ -1,0 +1,23 @@
+{ inputs }: { config, lib, pkgs, ... }:
+let
+  cfg = config.chaotic;
+in
+{
+  options = {
+    chaotic.appmenu-gtk3-module.enable =
+      lib.mkOption {
+        default = false;
+        description = ''
+          Sets the proper environment variable to use appmenu-gtk3-module.
+        '';
+      };
+  };
+  config = {
+    environment.systemPackages = with pkgs; [ appmenu-gtk3-module ];
+
+    # This ensures GTK applications can load appmenu-gtk-module
+    environment.profileRelativeSessionVariables = {
+      XDG_DATA_DIRS = [ "/share/gsettings-schemas/appmenu-gtk3-module-0.7.6" ];
+    };
+  };
+}

--- a/modules/appmenu-gtk3-module.nix
+++ b/modules/appmenu-gtk3-module.nix
@@ -17,3 +17,4 @@ in
       XDG_DATA_DIRS = [ "${pkgs.appmenu-gtk3-module}/share/gsettings-schemas/appmenu-gtk3-module-0.7.6" ];
     };
   };
+}

--- a/modules/appmenu-gtk3-module.nix
+++ b/modules/appmenu-gtk3-module.nix
@@ -1,6 +1,6 @@
 { inputs }: { config, lib, pkgs, ... }:
 let
-  cfg = config.chaotic;
+  cfg = config.chaotic.appmenu-gtk3-module;
 in
 {
   options = {
@@ -13,11 +13,7 @@ in
       };
   };
   config = {
-    environment.systemPackages = with pkgs; [ appmenu-gtk3-module ];
-
-    # This ensures GTK applications can load appmenu-gtk-module
-    environment.profileRelativeSessionVariables = {
-      XDG_DATA_DIRS = [ "/share/gsettings-schemas/appmenu-gtk3-module-0.7.6" ];
+    environment.profileRelativeSessionVariables = lib.mkIf cfg.enable {
+      XDG_DATA_DIRS = [ "${pkgs.appmenu-gtk3-module}/share/gsettings-schemas/appmenu-gtk3-module-0.7.6" ];
     };
   };
-}

--- a/modules/default.nix
+++ b/modules/default.nix
@@ -5,7 +5,7 @@ rec {
       nixpkgs.overlays = [ inputs.self.overlays.default ];
     };
 
-    imports = [ appmenu-gtk3-module gamescope linux_hdr mesa_git  ];
+    imports = [ appmenu-gtk3-module gamescope linux_hdr mesa_git ];
   };
   appmenu-gtk3-module = import ./appmenu-gtk3-module.nix fromFlakes;
   gamescope = import ./gamescope.nix fromFlakes;

--- a/modules/default.nix
+++ b/modules/default.nix
@@ -5,7 +5,7 @@ rec {
       nixpkgs.overlays = [ inputs.self.overlays.default ];
     };
 
-    imports = [ gamescope linux_hdr mesa_git ];
+    imports = [ appmenu-gtk3-module gamescope linux_hdr mesa_git  ];
   };
   appmenu-gtk3-module = import ./appmenu-gtk3-module.nix fromFlakes;
   gamescope = import ./gamescope.nix fromFlakes;

--- a/modules/default.nix
+++ b/modules/default.nix
@@ -7,6 +7,7 @@ rec {
 
     imports = [ gamescope linux_hdr mesa_git ];
   };
+  appmenu-gtk3-module = import ./appmenu-gtk3-module.nix fromFlakes;
   gamescope = import ./gamescope.nix fromFlakes;
   linux_hdr = import ./linux_hdr.nix fromFlakes;
   mesa_git = import ./mesa-git.nix fromFlakes;

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -22,6 +22,8 @@ in
 
   applet-window-title = final.callPackage ../pkgs/applet-window-title { };
 
+  appmenu-gtk3-module = final.callPackage ../pkgs/appmenu-gtk3-module { };
+
   beautyline-icons = final.callPackage ../pkgs/beautyline-icons { };
 
   directx-headers_next = prev.directx-headers.overrideAttrs (_: rec {

--- a/pkgs/appmenu-gtk3-module/default.nix
+++ b/pkgs/appmenu-gtk3-module/default.nix
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
     owner = "vala-panel-project";
     repo = "vala-panel-appmenu";
     rev = version;
-    sha256 = "sha256:1ywpygjwlbli65203ja2f8wwxh5gbavnfwcxwg25v061pcljaqmm";
+    hash = "sha256-tWIlKbvBgF3E451xZ7dar8DOOXJCyQFEMZEuyuXzl/s=";
   };
 
   sourceRoot = "source/subprojects/appmenu-gtk-module";

--- a/pkgs/appmenu-gtk3-module/default.nix
+++ b/pkgs/appmenu-gtk3-module/default.nix
@@ -52,8 +52,8 @@ stdenv.mkDerivation rec {
     "--prefix=${placeholder "out"}"
   ];
 
-  PKG_CONFIG_GTK__3_0_LIBDIR = "${placeholder "out"}/lib";
-  PKG_CONFIG_SYSTEMD_SYSTEMDUSERUNITDIR = "${placeholder "out"}/lib/systemd/user";
+  env.PKG_CONFIG_GTK__3_0_LIBDIR = "${placeholder "out"}/lib";
+  env.PKG_CONFIG_SYSTEMD_SYSTEMDUSERUNITDIR = "${placeholder "out"}/lib/systemd/user";
 
   postInstall = ''
     glib-compile-schemas "$out/share/glib-2.0/schemas"

--- a/pkgs/appmenu-gtk3-module/default.nix
+++ b/pkgs/appmenu-gtk3-module/default.nix
@@ -1,0 +1,67 @@
+{ stdenv
+, lib
+, fetchFromGitLab
+, fetchpatch
+, meson
+, cmake
+, pkg-config
+, systemd
+, gtk-doc
+, docbook-xsl-nons
+, ninja
+, glib
+, gtk3
+, wrapGAppsHook
+}:
+
+stdenv.mkDerivation rec {
+  pname = "appmenu-gtk3-module";
+  version = "0.7.6";
+
+  outputs = [ "out" "devdoc" ];
+
+  src = fetchFromGitLab {
+    owner = "vala-panel-project";
+    repo = "vala-panel-appmenu";
+    rev = version;
+    sha256 = "sha256:1ywpygjwlbli65203ja2f8wwxh5gbavnfwcxwg25v061pcljaqmm";
+  };
+
+  sourceRoot = "source/subprojects/appmenu-gtk-module";
+
+  nativeBuildInputs = [
+    glib
+    meson
+    cmake
+    pkg-config
+    systemd
+    gtk-doc
+    docbook-xsl-nons
+    ninja
+    wrapGAppsHook
+  ];
+
+  buildInputs = [ gtk3 ];
+
+  preConfigure = ''
+    substituteInPlace meson_options.txt --replace "value: ['2','3']" "value: ['3']"
+  '';
+
+  mesonFlags = [
+    "-Dgtk_doc=true"
+    "--prefix=${placeholder "out"}"
+  ];
+
+  PKG_CONFIG_GTK__3_0_LIBDIR = "${placeholder "out"}/lib";
+  PKG_CONFIG_SYSTEMD_SYSTEMDUSERUNITDIR = "${placeholder "out"}/lib/systemd/user";
+
+  postInstall = ''
+    glib-compile-schemas "$out/share/glib-2.0/schemas"
+  '';
+
+  meta = with lib; {
+    description = "Port of the Unity GTK 3 Module";
+    license = licenses.lgpl3Plus;
+    maintainers = with maintainers; [ dr460nf1r3 ];
+  };
+}


### PR DESCRIPTION
Needed to get an appmenu on KDE for a lot of GTK apps like FireDragon, I think.
Stolen from the already existing PR https://github.com/NixOS/nixpkgs/pull/95412, which sadly didn't have much traction lately.