### PR TITLE
mesa-git: fix for mesa-23 in nixpkgs

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ nix run github:chaotic-cx/nyx#input-leap_git
 
 ```nix
 {
-  chaotic.mesa-git.enable = true;
+  chaotic.mesa-git.enable = true; # requires `--impure`
   chaotic.linux_hdr.specialisation.enable = true;
   chaotic.gamescope = {
     enable = true;

--- a/flake.lock
+++ b/flake.lock
@@ -37,11 +37,11 @@
     "mesa-git-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1681556226,
-        "narHash": "sha256-PQbcq7Kqvze6Ijgb0amVshQcXDJ6EogKVZ85pJucM3Y=",
+        "lastModified": 1681592821,
+        "narHash": "sha256-qrpRZ/EOroOx4THnlk0OOC2OZMvRMm4IKgSrLv4kS9c=",
         "owner": "chaotic-cx",
         "repo": "mesa-mirror",
-        "rev": "c6906448425a03163c029a0c2c12c632a0b49f98",
+        "rev": "60cfe15d799fdc5a57a691844cc30e49b3f74a47",
         "type": "github"
       },
       "original": {

--- a/modules/mesa-git.nix
+++ b/modules/mesa-git.nix
@@ -1,6 +1,8 @@
 { inputs }: { config, lib, pkgs, ... }:
 let
   cfg = config.chaotic;
+
+  replacement = ({ original = pkgs.mesa; replacement = pkgs.mesa_git; });
 in
 {
   options = {
@@ -10,10 +12,14 @@ in
         internal = true;
         description = ''
           Whether to use latest Mesa drivers.
+
+          NOTE: Since Mesa 23.0+ loaders prohibit verison mixing, you'll now need `--impure`.
         '';
       };
   };
   config = {
+    system.replaceRuntimeDependencies = [ replacement ];
+
     hardware.opengl = lib.mkIf cfg.mesa-git.enable {
       package = pkgs.mesa_git.drivers;
       package32 = lib.mkIf (pkgs.stdenv.hostPlatform.isLinux && pkgs.stdenv.hostPlatform.isx86) pkgs.mesa32_git.drivers;
@@ -25,6 +31,7 @@ in
         system.nixos.tags = [ "stable-mesa" ];
         hardware.opengl.package = lib.mkForce pkgs.mesa.drivers;
         hardware.opengl.package32 = lib.mkForce pkgs.pkgsi686Linux.mesa.drivers;
+        system.replaceRuntimeDependencies = lib.mkForce [ ];
       };
     };
   };

--- a/pkgs/ananicy-cpp-rules/default.nix
+++ b/pkgs/ananicy-cpp-rules/default.nix
@@ -1,7 +1,6 @@
 { fetchFromGitHub
 , lib
 , stdenvNoCC
-,
 }:
 stdenvNoCC.mkDerivation {
   pname = "ananicy-cpp-rules";

--- a/pkgs/applet-window-appmenu/default.nix
+++ b/pkgs/applet-window-appmenu/default.nix
@@ -11,7 +11,6 @@
 , plasma-workspace
 , stdenv
 , wrapQtAppsHook
-,
 }:
 stdenv.mkDerivation rec {
   pname = "applet-window-appmenu";

--- a/pkgs/applet-window-title/default.nix
+++ b/pkgs/applet-window-title/default.nix
@@ -1,7 +1,6 @@
 { fetchFromGitHub
 , lib
 , stdenvNoCC
-,
 }:
 stdenvNoCC.mkDerivation rec {
   pname = "applet-window-title";

--- a/pkgs/beautyline-icons/default.nix
+++ b/pkgs/beautyline-icons/default.nix
@@ -5,7 +5,6 @@
 , jdupes
 , lib
 , stdenvNoCC
-,
 }:
 stdenvNoCC.mkDerivation rec {
   pname = "BeautyLine";

--- a/pkgs/dr460nized-kde-theme/default.nix
+++ b/pkgs/dr460nized-kde-theme/default.nix
@@ -3,7 +3,6 @@
 , lib
 , stdenvNoCC
 , sweet-nova
-,
 }:
 stdenvNoCC.mkDerivation rec {
   pname = "dr460nized-kde-theme";

--- a/pkgs/firedragon/default.nix
+++ b/pkgs/firedragon/default.nix
@@ -3,7 +3,6 @@
 , lib
 , nixosTests
 , stdenv
-,
 }:
 let
   firedragon-src = callPackage ./firedragon.nix { };

--- a/pkgs/gamescope-git/default.nix
+++ b/pkgs/gamescope-git/default.nix
@@ -1,6 +1,6 @@
-{ gamescope, gamescope-git-src, lib }:
+{ gamescope, gamescope-git-src, lib, nyxUtils }:
 gamescope.overrideAttrs (pa: {
-  version = "3.11.52-unstable";
+  version = nyxUtils.gitToVersion gamescope-git-src;
   src = gamescope-git-src;
   patches = [ (lib.lists.take 1 pa.patches) ];
 })

--- a/pkgs/input-leap-git/default.nix
+++ b/pkgs/input-leap-git/default.nix
@@ -4,12 +4,14 @@
 , input-leap-git-src
 , libei
 , libportal
+, nyxUtils
 , pkg-config
 , qttools
 }:
 barrier.overrideAttrs (pa: {
   pname = "input-leap";
   src = input-leap-git-src;
+  version = nyxUtils.gitToVersion input-leap-git-src;
   nativeBuildInputs = pa.nativeBuildInputs ++ [
     pkg-config
     gtest

--- a/pkgs/mesa-git/default.nix
+++ b/pkgs/mesa-git/default.nix
@@ -4,16 +4,16 @@
 , lm_sensors
 , mesa
 , mesa-git-src
-, utils
+, nyxUtils
 }:
 (mesa.override {
   directx-headers = directx-headers_next;
 }).overrideAttrs (fa: {
-  version = "23.1.99";
+  version = builtins.substring 0 (builtins.stringLength fa.version) mesa-git-src.rev;
   src = mesa-git-src;
   buildInputs = fa.buildInputs ++ [ libunwind lm_sensors ];
   mesonFlags =
     lib.lists.remove "-Dgallium-rusticl=true" fa.mesonFlags # fails to find "valgrind.h"
     ++ [ "-Dandroid-libbacktrace=disabled" ];
-  patches = utils.dropN 2 fa.patches ++ [ ./disk_cache-include-dri-driver-path-in-cache-key.patch ];
+  patches = nyxUtils.dropN 2 fa.patches ++ [ ./disk_cache-include-dri-driver-path-in-cache-key.patch ];
 })

--- a/pkgs/wlroots-git/default.nix
+++ b/pkgs/wlroots-git/default.nix
@@ -2,6 +2,7 @@
 , hwdata
 , lib
 , libdisplay-info
+, nyxUtils
 , wayland_next
 , wlroots_0_16
 , wlroots-git-src
@@ -10,7 +11,7 @@
   inherit enableXWayland;
   wayland = wayland_next;
 }).overrideAttrs (pa: {
-  version = "0.17-unstable";
+  version = nyxUtils.gitToVersion wlroots-git-src;
   src = wlroots-git-src;
   buildInputs = pa.buildInputs ++ [ hwdata libdisplay-info ];
   postPatch = "";

--- a/shared/utils.nix
+++ b/shared/utils.nix
@@ -1,4 +1,12 @@
 { lib }:
-{
+rec {
   dropN = n: list: lib.lists.take (builtins.length list - n) list;
+
+  gitToVersion = src: "unstable-${src.lastModifiedDate}-${src.shortRev}";
+
+  gitOverride = src: drv:
+    drv.overrideAttrs (_: {
+      version = gitToVersion src;
+      inherit src;
+    });
 }


### PR DESCRIPTION
Also bumps `mesa_git` version.

Unrelated changes:
- packages: remove new lines;
- nyxUtils: promote to an attrset accessible from `pkgs`;
- packages: make a standard for unstable versions originating from git flakes.