### PR TITLE
builder: export through devShells.default and always check cache; devShells.evaluator: init

### DIFF
--- a/.github/workflows/needs-cache.yml
+++ b/.github/workflows/needs-cache.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Run GH actions cleanup
         run: sudo rm -rf /usr/share /usr/local /opt || true # https://github.com/easimon/maximize-build-space
       - name: Build packages
-        run: nix shell -c build-chaotic-nyx && exit 1 || [ $? -eq 23 ]
+        run: nix develop -c build-chaotic-nyx && exit 1 || [ $? -eq 23 ]
         env:
           NYX_UNCACHED_ONLY: 1
           NYX_WD: ${{ runner.temp }}

--- a/.github/workflows/nixpkgs-bump.yml
+++ b/.github/workflows/nixpkgs-bump.yml
@@ -27,7 +27,7 @@ jobs:
         id: bump
       - name: Build packages
         if: steps.bump.outcome == 'success'
-        run: nix shell -c build-chaotic-nyx && exit 1 || [ $? -eq 23 ]
+        run: nix develop -c build-chaotic-nyx && exit 1 || [ $? -eq 23 ]
         env:
           NYX_WD: ${{ runner.temp }}
       - name: Install Cachix

--- a/flake.nix
+++ b/flake.nix
@@ -44,6 +44,8 @@
     formatter.x86_64-linux = nixpkgs.legacyPackages.x86_64-linux.nixpkgs-fmt;
     formatter.aarch64-linux = nixpkgs.legacyPackages.aarch64-linux.nixpkgs-fmt;
 
+    # The three stars: our overlay, our modules and the packages.
+
     overlays.default = import ./overlays { inherit inputs; };
 
     nixosModules = import ./modules { inherit inputs; };
@@ -64,6 +66,7 @@
 
     hydraJobs.default = packages;
 
+    # The following shells are used to help our maintainers and CI/CDs.
     devShells =
       let
         mkShells = final: prev:
@@ -88,6 +91,7 @@
       };
   };
 
+  # Allows the user to use our cache when using `nix run <thisFlake>`.
   nixConfig = {
     extra-substituters = [ "https://nyx.chaotic.cx" ];
     extra-trusted-public-keys = [

--- a/shared/derivation-recursive-finder.nix
+++ b/shared/derivation-recursive-finder.nix
@@ -1,0 +1,45 @@
+{ lib }:
+rec {
+  join = namespace: n:
+    if namespace != "" then
+      "${namespace}.${n}"
+    else
+      n
+  ;
+
+  # warnFn: k -> v -> message -> result
+  # mapFn: k -> v -> result
+  # root: attrset | derivation
+  eval = warnFn: mapFn: root:
+    let
+      recursive =
+        namespace: n: v:
+        (if (builtins.tryEval v).success then
+          (if lib.attrsets.isDerivation v then
+            (if (v.meta.broken or true) then
+              warnFn n v "broken"
+            else if (v.meta.unfree or true) then
+              warnFn n v "unfree"
+            else
+              mapFn (join namespace n) v
+            )
+          else if builtins.isAttrs v then
+            lib.attrsets.mapAttrsToList (recursive (join namespace n)) v
+          else
+            warnFn n v "unrelated"
+          )
+        else
+          warnFn n v "not evaluating"
+        )
+      ;
+    in
+    recursive "" "" root;
+
+  evalToString = mapFn: root:
+    let
+      warnFn = k: _: message:
+        "# ${message}: ${k}";
+    in
+    lib.strings.concatStringsSep "\n"
+      (lib.lists.flatten (eval warnFn mapFn root));
+}

--- a/shared/eval.nix
+++ b/shared/eval.nix
@@ -1,0 +1,20 @@
+{ all-packages
+, derivationRecursiveFinder
+, lib
+, system
+, writeText
+}:
+let
+  evalResult = k: v:
+    "${system}\t${k}\t${builtins.unsafeDiscardStringContext v.outPath}";
+
+  warn = k: _: message:
+    "${system}\t${k}\t${message}";
+
+  packagesEval = derivationRecursiveFinder.eval warn evalResult all-packages;
+
+  packagesEvalSorted =
+    lib.lists.naturalSort (lib.lists.flatten packagesEval);
+in
+writeText "chaotic-nyx-eval.tsv"
+  (lib.strings.concatStringsSep "\n" packagesEvalSorted)


### PR DESCRIPTION
## :fish: What?

1. Always check cache before building;
2. Cached results go to `cached.txt`;
3. Migrate builder from `packages.default` to `devShells.default`;
4. Add a `devShells.evaluator`;
5. De-duplicate code into `shared/derivation-recursive-finder.nix`.

## :fishing_pole_and_fish: Why?

- (1) According to Cachix docs[1], downloading `narinfo` is enough to prioritize the cache, so we don't need to download stuff from the cache to keep it from being collected;
- (2) These random text files help debugging;
- (3) Isolate our building infrastructure from our final product;
- (4) This TSV[2] can help to identify changes when compared against our main branch;
- (5) QA.

[1]: https://docs.cachix.org/garbage-collection?highlight=narinfo
[2]: https://en.wikipedia.org/wiki/Tab-separated_values

## :fish_cake: Extra

- Now you have to use `nix develop -c build-chaotic-nyx` instead of `nix shell -c build-chaotic-nyx`.
- For diffing, you can:
```bash
_CURRENT=$(nix build --no-link --print-out-paths '.#devShells.x86_64-linux.evaluator.env.NYX_EVALUATED')
_MAIN=$(nix build --no-link --print-out-paths 'github:chaotic-cx/nyx#devShells.x86_64-linux.evaluator.env.NYX_EVALUATED')
diff -23 $_CURRENT $_MAIN
```