### PR TITLE
builder: some enhancements

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -72,15 +72,21 @@
         mkShells = final: prev:
           let
             overlayFinal = prev // final // { callPackage = prev.newScope final; };
-            derivationRecursiveFinder = overlayFinal.callPackage ./shared/derivation-recursive-finder.nix { };
             builder = overlayFinal.callPackage ./shared/builder.nix
-              { all-packages = final; flakeSelf = self; inherit derivationRecursiveFinder; };
+              {
+                all-packages = final;
+                flakeSelf = self;
+                inherit (overlayFinal.nyxUtils) derivationRecursiveFinder;
+              };
             evaluated = overlayFinal.callPackage ./shared/eval.nix
-              { all-packages = final; inherit derivationRecursiveFinder; };
+              {
+                all-packages = final;
+                inherit (overlayFinal.nyxUtils) derivationRecursiveFinder;
+              };
           in
           {
             default = overlayFinal.mkShell { buildInputs = [ builder ]; };
-            evaluator = { env.NYX_EVALUATED = evaluated; };
+            evaluator = overlayFinal.mkShell { env.NYX_EVALUATED = evaluated; };
           };
       in
       {

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -11,9 +11,7 @@
 
 { inputs }: final: prev:
 let
-  nyxUtils = import ../shared/utils.nix {
-    inherit (final) lib;
-  };
+  nyxUtils = final.callPackage ../shared/utils.nix { };
 in
 {
   inherit nyxUtils;

--- a/shared/builder.nix
+++ b/shared/builder.nix
@@ -2,10 +2,10 @@
 { all-packages
 , cachix
 , derivationRecursiveFinder
+, flakeSelf
 , jq
 , lib
 , nix
-, flakeSelf
 , writeShellScriptBin
 }:
 let
@@ -20,7 +20,7 @@ let
         ${lib.strings.concatStringsSep " \\\n  " outputs}
     '';
 
-  packagesEval = derivationRecursiveFinder.evalToString evalCommand;
+  packagesEval = derivationRecursiveFinder.evalToString evalCommand all-packages;
 in
 writeShellScriptBin "build-chaotic-nyx" ''
   NYX_SOURCE="''${NYX_SOURCE:-${flakeSelf}}"
@@ -76,7 +76,7 @@ writeShellScriptBin "build-chaotic-nyx" ''
     fi
   }
 
-  ${packagesEval all-packages}
+  ${packagesEval}
 
   if [ -z "$CACHIX_AUTH_TOKEN" ] && [ -z "$CACHIX_SIGNING_KEY" ]; then
     echo_error "No key for cachix -- failing to deploy."

--- a/shared/utils.nix
+++ b/shared/utils.nix
@@ -1,5 +1,7 @@
-{ lib }:
+{ lib, callPackage }:
 rec {
+  derivationRecursiveFinder = callPackage ../shared/derivation-recursive-finder.nix { };
+
   dropN = n: list: lib.lists.take (builtins.length list - n) list;
 
   gitToVersion = src: "unstable-${src.lastModifiedDate}-${src.shortRev}";
@@ -9,4 +11,7 @@ rec {
       version = gitToVersion src;
       inherit src;
     });
+
+  # We don't want builders playing around here.
+  recurseForDerivations = false;
 }


### PR DESCRIPTION
I'm backporting these enhancements from #40 to clean up that one.

Flake:
- fix evaluator devShell;
- move derivationRecursiveFinder to nyxUtils;

Builder:
- full derivation's key on warnings;
- don't recurse inside nyxUtils.