### PR TITLE
yuzu-early-access_git: init

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ We recommend to integrate this repo using Flakes:
   sway_git
   waynergy_git
   wlroots_git
+  yuzu-early-access_git
 ]
 ```
 

--- a/flake.lock
+++ b/flake.lock
@@ -75,7 +75,8 @@
         "nixpkgs": "nixpkgs",
         "sway-git-src": "sway-git-src",
         "waynergy-git-src": "waynergy-git-src",
-        "wlroots-git-src": "wlroots-git-src"
+        "wlroots-git-src": "wlroots-git-src",
+        "yuzu-ea-git-src": "yuzu-ea-git-src"
       }
     },
     "sway-git-src": {
@@ -127,6 +128,23 @@
         "ref": "master",
         "type": "git",
         "url": "https://gitlab.freedesktop.org/wlroots/wlroots.git"
+      }
+    },
+    "yuzu-ea-git-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1682177268,
+        "narHash": "sha256-Ld4chW2yxpFDtZvZIWmps0GBtiGWbS0FZjGieDzg1e8=",
+        "owner": "pineappleEA",
+        "repo": "pineapple-src",
+        "rev": "ab28951bc09ca5ac85760a19ad1b7ea34803e1a9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "pineappleEA",
+        "ref": "main",
+        "repo": "pineapple-src",
+        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -36,6 +36,11 @@
       url = "git+https://gitlab.freedesktop.org/wlroots/wlroots.git?ref=master";
       flake = false;
     };
+
+    yuzu-ea-git-src = {
+      url = "github:pineappleEA/pineapple-src/main";
+      flake = false;
+    };
   };
 
   outputs = { nixpkgs, self, ... }@inputs: rec {

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -105,6 +105,31 @@ in
     sway-unwrapped = final.sway-unwrapped_git;
   };
 
+  vulkan-headers_next =
+    prev.vulkan-headers.overrideAttrs (_: rec {
+      version = "v1.3.248";
+      src = final.fetchFromGitHub {
+        owner = "KhronosGroup";
+        repo = "Vulkan-Headers";
+        rev = "v1.3.248";
+        hash = "sha256-bilEf59jBDgl5WUgOZpRSMkp33C/rssj37rdvHaxRGU=";
+      };
+    });
+
+  vulkan-loader_next =
+    (prev.vulkan-loader.override {
+      vulkan-headers = final.vulkan-headers_next;
+    }).overrideAttrs (pa: rec {
+      version = "v1.3.248";
+      src = final.fetchFromGitHub {
+        owner = "KhronosGroup";
+        repo = "Vulkan-Loader";
+        rev = "v1.3.248";
+        hash = "sha256-4Qy71oeni3kBln7htrV5QBTjGktrVH9IiaPOCUn0Mjs=";
+      };
+      meta = pa.meta // { broken = false; };
+    });
+
   wayland_next = prev.wayland.overrideAttrs (_: rec {
     version = "1.22.0";
     src = final.fetchurl {
@@ -118,4 +143,6 @@ in
   wlroots_git = callOverride ../pkgs/wlroots-git {
     wayland = final.wayland_next;
   };
+
+  yuzu-early-access_git = callOverride ../pkgs/yuzu-ea-git { };
 }

--- a/pkgs/yuzu-ea-git/default.nix
+++ b/pkgs/yuzu-ea-git/default.nix
@@ -1,0 +1,83 @@
+{ final, inputs, nyxUtils, prev, ... }:
+
+# nixpkgs has cpp-httplib, but it's outdated
+# yuzu doesn't seem to recognize our mbedtls_2 and cpp-jwt
+let
+  dynarmic = final.fetchFromGitHub {
+    owner = "merryhime";
+    repo = "dynarmic";
+    rev = "6.4.6";
+    hash = "sha256-DIcyI0Sqw+J3Dhqk4MugIXsSZmSS0PaGjSqIfmVuQXc=";
+  };
+  cpp-httplib = final.fetchFromGitHub {
+    owner = "yhirose";
+    repo = "cpp-httplib";
+    rev = "v0.12.2";
+    hash = "sha256-mpHw9fzGpYz04rgnfG/qTNrXIf6q+vFfIsjb56kJsLg=";
+  };
+  sirit = final.fetchFromGitHub {
+    owner = "ReinUsesLisp";
+    repo = "sirit";
+    rev = "d7ad93a88864bda94e282e95028f90b5784e4d20";
+    hash = "sha256-WDZivcYYe1qKV6IVsDPCHpAxKc+FWsSDlVw+pekCgmI=";
+  };
+  xbyak = final.fetchFromGitHub {
+    owner = "herumi";
+    repo = "xbyak";
+    rev = "v6.69.1";
+    hash = "sha256-yMArB0MmIvdqctr2bstKzREDvb7OnGXGMSCiGaQ3SmY=";
+  };
+in
+(prev.yuzu-early-access.override {
+  catch2 = final.catch2_3;
+  fmt_8 = final.fmt_9;
+  vulkan-loader = final.vulkan-loader_next;
+}).overrideAttrs (pa: rec {
+  src = inputs.yuzu-ea-git-src;
+  version = nyxUtils.gitToVersion src;
+
+  buildInputs = pa.buildInputs ++ (with final; [ cubeb discord-rpc enet httplib inih vulkan-loader_next ]);
+  nativeBuildInputs = pa.nativeBuildInputs ++ (with final; [ perl spirv-headers vulkan-headers_next ]);
+
+  cmakeFlags = pa.cmakeFlags ++ [
+    "-DYUZU_CHECK_SUBMODULES=OFF"
+    "-DYUZU_TESTS=OFF"
+
+    "-DYUZU_USE_PRECOMPILED_HEADERS=OFF"
+    "-DSIRIT_USE_SYSTEM_SPIRV_HEADERS=ON"
+    "-DYUZU_USE_EXTERNAL_VULKAN_HEADERS=OFF"
+    "-DYUZU_USE_QT_MULTIMEDIA=ON"
+  ];
+
+  postPatch = pa.postPatch + ''
+    find . -name "CMakeLists.txt" -exec sed -i 's/^.*-Werror$/-W/g' {} +
+    find . -name "CMakeLists.txt" -exec sed -i 's/^.*-Werror=.*$/ /g' {} +
+    find . -name "CMakeLists.txt" -exec sed -i 's/-Werror/-W/g' {} +
+
+    rm -r externals/{cpp-{jwt,httplib},dynarmic,mbedtls,sirit,xbyak}
+    cp --no-preserve=mode -r ${final.mbedtls_2.src} externals/mbedtls
+    ln -s ${final.cpp-jwt.src} externals/cpp-jwt
+    ln -s ${cpp-httplib} externals/cpp-httplib
+    ln -s ${dynarmic} externals/dynarmic
+    ln -s ${sirit} externals/sirit
+    ln -s ${xbyak} externals/xbyak
+  '';
+
+  preConfigure = ''
+    pushd externals/mbedtls
+    perl scripts/config.pl set MBEDTLS_THREADING_C
+    perl scripts/config.pl set MBEDTLS_THREADING_PTHREAD
+    perl scripts/config.pl set MBEDTLS_CMAC_C
+    popd
+
+    # See https://github.com/NixOS/nixpkgs/issues/114044, setting this through cmakeFlags does not work.
+    # These will fix version "formatting"
+    cmakeFlagsArray+=(
+      "-DTITLE_BAR_FORMAT_IDLE=yuzu Early Access NYX-0"
+      "-DTITLE_BAR_FORMAT_RUNNING=yuzu Early Access NYX-0 | {3}"
+    )
+  '';
+
+  # Right now crypto tests don't pass
+  doCheck = false;
+})


### PR DESCRIPTION
This is the smallest set of changes that made the latest yuzu-early-access work for me.

https://github.com/NixOS/nixpkgs/pull/224348 was a way better effort, adding the dependencies to nixpkgs and migrating to Qt6.

Our AUR buddies seem to be building it with LLVM and lto=thin, we could try that in the future.