### PR TITLE
modules/steam-compat-tools: init; proton-ge-custom: init at 55; luxtorpeda: init at 63

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ We recommend to integrate this repo using Flakes:
   linux_hdr # recommended option: chaotic.linux_hdr.specialisation.enable
   linuxPackages_cachyos # the default BORE scheduler
   linuxPackages_hdr # recommended option: chaotic.linux_hdr.specialisation.enable
+  luxtorpeda # recommended option: chaotic.steam.extraCompatPackages
   mesa_git # recommended option: chaotic.mesa-git.enable
   mesa32_git # only x86, recommended option: chaotic.mesa-git.enable
   proton-ge-custom # recommended option: chaotic.steam.extraCompatPackages
@@ -98,7 +99,7 @@ nix run github:chaotic-cx/nyx/nyxpkgs-unstable#input-leap_git
       env = { };
     };
   };
-  chaotic.steam.extraCompatPackages = [ pkgs.proton-ge-custom ];
+  chaotic.steam.extraCompatPackages = with pkgs; [ luxtorpeda proton-ge-custom ];
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ nix run github:chaotic-cx/nyx/nyxpkgs-unstable#input-leap_git
       env = { };
     };
   };
+  chaotic.steam.extraCompatPackages = [ pkgs.proton-ge-custom ];
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ We recommend to integrate this repo using Flakes:
   linuxPackages_hdr # recommended option: chaotic.linux_hdr.specialisation.enable
   mesa_git # recommended option: chaotic.mesa-git.enable
   mesa32_git # only x86, recommended option: chaotic.mesa-git.enable
+  proton-ge-custom # recommended option: chaotic.steam.extraCompatPackages
   sway-unwrapped_git
   sway_git # and -unwrapped_git
   swaylock-plugin_git

--- a/modules/default.nix
+++ b/modules/default.nix
@@ -5,10 +5,11 @@ rec {
       nixpkgs.overlays = [ inputs.self.overlays.default ];
     };
 
-    imports = [ appmenu-gtk3-module gamescope linux_hdr mesa_git ];
+    imports = [ appmenu-gtk3-module gamescope linux_hdr mesa_git steam-compat-tools ];
   };
   appmenu-gtk3-module = import ./appmenu-gtk3-module.nix fromFlakes;
   gamescope = import ./gamescope.nix fromFlakes;
   linux_hdr = import ./linux_hdr.nix fromFlakes;
   mesa_git = import ./mesa-git.nix fromFlakes;
+  steam-compat-tools = import ./steam-compat-tools.nix;
 }

--- a/modules/steam-compat-tools.nix
+++ b/modules/steam-compat-tools.nix
@@ -1,17 +1,17 @@
-{
-  config,
-  lib,
-  pkgs,
-  ...
+{ config
+, lib
+, pkgs
+, ...
 }:
 with lib; let
   steamCfg = config.programs.steam;
   cfg = config.chaotic.steam;
-in {
+in
+{
   options.chaotic.steam = {
     extraCompatPackages = mkOption {
       type = with types; listOf package;
-      default = [];
+      default = [ ];
       defaultText = literalExpression "[]";
       example = literalExpression ''
         with pkgs; [
@@ -30,7 +30,7 @@ in {
   config = mkIf steamCfg.enable {
     # Append the extra compatibility packages to whatever else the env variable was populated with.
     # For more information see https://github.com/ValveSoftware/steam-for-linux/issues/6310.
-    environment.sessionVariables = mkIf (cfg.extraCompatPackages != []) {
+    environment.sessionVariables = mkIf (cfg.extraCompatPackages != [ ]) {
       STEAM_EXTRA_COMPAT_TOOLS_PATHS = makeBinPath cfg.extraCompatPackages;
     };
   };

--- a/modules/steam-compat-tools.nix
+++ b/modules/steam-compat-tools.nix
@@ -5,9 +5,10 @@
   ...
 }:
 with lib; let
-  cfg = config.programs.steam;
+  steamCfg = config.programs.steam;
+  cfg = config.chaotic.steam;
 in {
-  options.programs.steam = {
+  options.chaotic.steam = {
     extraCompatPackages = mkOption {
       type = with types; listOf package;
       default = [];
@@ -15,7 +16,7 @@ in {
       example = literalExpression ''
         with pkgs; [
           luxtorpeda
-          proton-ge
+          proton-ge-custom
         ]
       '';
       description = lib.mdDoc ''
@@ -26,7 +27,7 @@ in {
     };
   };
 
-  config = mkIf cfg.enable {
+  config = mkIf steamCfg.enable {
     # Append the extra compatibility packages to whatever else the env variable was populated with.
     # For more information see https://github.com/ValveSoftware/steam-for-linux/issues/6310.
     environment.sessionVariables = mkIf (cfg.extraCompatPackages != []) {

--- a/modules/steam-compat-tools.nix
+++ b/modules/steam-compat-tools.nix
@@ -1,0 +1,36 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+with lib; let
+  cfg = config.programs.steam;
+in {
+  options.programs.steam = {
+    extraCompatPackages = mkOption {
+      type = with types; listOf package;
+      default = [];
+      defaultText = literalExpression "[]";
+      example = literalExpression ''
+        with pkgs; [
+          luxtorpeda
+          proton-ge
+        ]
+      '';
+      description = lib.mdDoc ''
+        Extra packages to be used as compatibility tools for Steam on Linux. Packages will be included
+        in the `STEAM_EXTRA_COMPAT_TOOLS_PATHS` environmental variable. For more information see
+        <https://github.com/ValveSoftware/steam-for-linux/issues/6310">.
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    # Append the extra compatibility packages to whatever else the env variable was populated with.
+    # For more information see https://github.com/ValveSoftware/steam-for-linux/issues/6310.
+    environment.sessionVariables = mkIf (cfg.extraCompatPackages != []) {
+      STEAM_EXTRA_COMPAT_TOOLS_PATHS = makeBinPath cfg.extraCompatPackages;
+    };
+  };
+}

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -87,6 +87,8 @@ in
 
   linuxPackages_hdr = final.linuxPackagesFor final.linux_hdr;
 
+  luxtorpeda = final.callPackage ../pkgs/luxtorpeda { };
+
   mesa_git = callOverride ../pkgs/mesa-git {
     directx-headers = final.directx-headers_next;
   };

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -99,6 +99,8 @@ in
         }
     else throw "No mesa32_git for non-x86";
 
+  proton-ge-custom = final.callPackage ../pkgs/proton-ge-custom { };
+
   sway-unwrapped_git =
     nyxUtils.gitOverride inputs.sway-git-src
       (prev.sway-unwrapped.override {

--- a/pkgs/luxtorpeda/default.nix
+++ b/pkgs/luxtorpeda/default.nix
@@ -1,0 +1,28 @@
+{ stdenv
+, lib
+, fetchurl
+, writeScript
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  name = "luxtorpeda";
+  version = "63";
+
+  src = fetchurl {
+    url = "https://github.com/luxtorpeda-dev/luxtorpeda/releases/download/v${finalAttrs.version}/luxtorpeda-${finalAttrs.version}.tar.xz";
+    sha256 = "sha256-aUJa9k/GolIN6lWBjdKyaK0yOhWOinmaGn/x8It8Mhg=";
+  };
+
+  buildCommand = ''
+    mkdir -p $out/bin
+    tar -C $out/bin --strip=1 -x -f $src
+  '';
+
+  meta = with lib; {
+    description = "Steam Play compatibility tool to run games using native Linux engines";
+    homepage = "https://github.com/luxtorpeda-dev/luxtorpeda";
+    license = licenses.gpl2Plus;
+    platforms = [ "x86_64-linux" ];
+    maintainers = with maintainers; [ pedrohlc ];
+  };
+})

--- a/pkgs/proton-ge-custom/default.nix
+++ b/pkgs/proton-ge-custom/default.nix
@@ -1,0 +1,30 @@
+{ stdenv
+, lib
+, fetchurl
+, writeScript
+,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  name = "proton-ge-custom";
+  version = "GE-Proton7-55";
+
+  src = fetchurl {
+    url = "https://github.com/GloriousEggroll/proton-ge-custom/releases/download/${finalAttrs.version}/${finalAttrs.version}.tar.gz";
+    sha256 = "sha256-/70DtApcja+6U+Rb1lUcEyUSrW/LqRIOJfDVENDNBIU=";
+  };
+
+  passthru.runUpdate = true;
+
+  buildCommand = ''
+    mkdir -p $out/bin
+    tar -C $out/bin --strip=1 -x -f $src
+  '';
+
+  meta = with lib; {
+    description = "Compatibility tool for Steam Play based on Wine and additional components";
+    homepage = "https://github.com/GloriousEggroll/proton-ge-custom";
+    license = licenses.bsd3;
+    platforms = [ "x86_64-linux" ];
+    maintainers = with maintainers; [ ajs124 ];
+  };
+})

--- a/pkgs/proton-ge-custom/default.nix
+++ b/pkgs/proton-ge-custom/default.nix
@@ -2,8 +2,8 @@
 , lib
 , fetchurl
 , writeScript
-,
 }:
+
 stdenv.mkDerivation (finalAttrs: {
   name = "proton-ge-custom";
   version = "GE-Proton7-55";


### PR DESCRIPTION
NOTE: I intend to drop these when they merge into nixpkgs.

This module uses `sessionVariables`, so you have to re-login if you ran a `nixos-rebuild switch`.

Credits to Shawn8901.