### PR TITLE
dr460nized-kde-theme: add skel directory in preparation for garuda flake

### DIFF
--- a/pkgs/dr460nized-kde-theme/default.nix
+++ b/pkgs/dr460nized-kde-theme/default.nix
@@ -19,6 +19,8 @@ stdenvNoCC.mkDerivation rec {
 
   installPhase = ''
     runHook preInstall
+    install -d $out/skel
+    cp -r etc/skel $out/
     install -d $out/share
     cp -r usr/share/plasma $out/share/
     install -d $out/share/icons/dr460nized

--- a/pkgs/dr460nized-kde-theme/default.nix
+++ b/pkgs/dr460nized-kde-theme/default.nix
@@ -23,8 +23,7 @@ stdenvNoCC.mkDerivation rec {
     cp -r etc/skel $out/
     install -d $out/share
     cp -r usr/share/plasma $out/share/
-    install -d $out/share/icons/dr460nized
-    cp -r usr/share/icons/garuda/* $out/share/icons/dr460nized
+    cp -r usr/share/icons $out/share/
     runHook postInstall
   '';
 


### PR DESCRIPTION
We use it to create the home directories files (no home-manager in the flake), therefore this ships the dotfiles.