### PR TITLE
gamescope_git: update buildInputs

### DIFF
--- a/pkgs/gamescope-git/default.nix
+++ b/pkgs/gamescope-git/default.nix
@@ -4,5 +4,5 @@ prev.gamescope.overrideAttrs (pa: {
   version = nyxUtils.gitToVersion inputs.gamescope-git-src;
   src = inputs.gamescope-git-src;
   patches = [ (final.lib.lists.take 1 pa.patches) ];
-  buildInputs = pa.buildInputs ++ (with final; [ glm ]);
+  buildInputs = pa.buildInputs ++ (with final; [ glm gbenchmark ]);
 })


### PR DESCRIPTION
Fixes build missing `benchmark`.
