### PR TITLE
flake-20230521-1:mesa, sway, yuzu

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -69,11 +69,11 @@
     "mesa-git-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1684571628,
-        "narHash": "sha256-6XqjPKfmvUGBVoAipR+XkpPrzHV8eK8ywjMWgyR9cyA=",
+        "lastModified": 1684625843,
+        "narHash": "sha256-5rWUQhqhOTuobfIfTpHX7IJJ5eVjk5RNaHnQgZDBfn4=",
         "owner": "chaotic-cx",
         "repo": "mesa-mirror",
-        "rev": "a0b1aa6f00e6f811e56c4f1c024af937bbebfd09",
+        "rev": "8e53b293f88cd30e2780d73adcf7da314ce811d1",
         "type": "github"
       },
       "original": {
@@ -117,11 +117,11 @@
     "sway-git-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1683802076,
-        "narHash": "sha256-M+81OjLWFWiG1HT+KElU81Akpxl4YAPEuTctq6Yzr/g=",
+        "lastModified": 1684594585,
+        "narHash": "sha256-2ZcYiLEeyr325irTgGLBEGMBNj8pLUlfCs8O0OQFoFc=",
         "owner": "swaywm",
         "repo": "sway",
-        "rev": "01b0c11394b88fea2ec8ac691e30504f1e0800f5",
+        "rev": "48d6eda3cb0f79d2190756af44f01d028696bf0e",
         "type": "github"
       },
       "original": {
@@ -185,11 +185,11 @@
     "yuzu-ea-git-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1684464069,
-        "narHash": "sha256-RQdyeTdqFe+QaeUs5dcVwJHo1WZ73Pn5qR47dZaebjI=",
+        "lastModified": 1684650131,
+        "narHash": "sha256-Yd91sAvBuAvuVBYrzu4o/06loCHbOMoQN6faRMGOADQ=",
         "owner": "pineappleEA",
         "repo": "pineapple-src",
-        "rev": "b7e5c476fcc4ed72bcf8d08b6e1beb110781f1c5",
+        "rev": "024a301e119747f75b5eccf0efca0cd6a16b9af4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
### :fish: What?

Daily bump of our `flake.lock`.

### :fishing_pole_and_fish: Why?

Updates `mesa_git`, `sway_git` and `yuzu-ea`.

### :fish_cake: Pending

- [x] Build & Cache;
- [ ] Update `devshells/failures.nix`;
