### PR TITLE
builder: expose passed-through derivations

### DIFF
--- a/devshells/derivation-recursive-finder.nix
+++ b/devshells/derivation-recursive-finder.nix
@@ -27,7 +27,15 @@ rec {
                 mapFn fullKey v
               )
             ] ++
-            [ (lib.attrsets.mapAttrsToList (recursive fullKey) (v.passthru or { })) ]
+            (if lib.strings.hasInfix ".passthru" fullKey then
+              [ ]
+            else [
+              (lib.attrsets.mapAttrsToList (recursive (join fullKey "passthru"))
+                (builtins.removeAttrs (v.passthru or { })
+                  ([ "tests" "isXen" ] ++ (lib.strings.splitString "." namespace))
+                )
+              )
+            ])
           else if builtins.isAttrs v && (v.recurseForDerivations or true) then
             lib.attrsets.mapAttrsToList (recursive fullKey) v
           else

--- a/devshells/derivation-recursive-finder.nix
+++ b/devshells/derivation-recursive-finder.nix
@@ -18,13 +18,16 @@ rec {
         in
         if (builtins.tryEval v).success then
           (if lib.attrsets.isDerivation v then
-            (if (v.meta.broken or true) then
-              warnFn fullKey v "broken"
-            else if (v.meta.unfree or true) then
-              warnFn fullKey v "unfree"
-            else
-              mapFn fullKey v
-            )
+            [
+              (if (v.meta.broken or true) then
+                warnFn fullKey v "broken"
+              else if (v.meta.unfree or true) then
+                warnFn fullKey v "unfree"
+              else
+                mapFn fullKey v
+              )
+            ] ++
+            [ (lib.attrsets.mapAttrsToList (recursive fullKey) (v.passthru or { })) ]
           else if builtins.isAttrs v && (v.recurseForDerivations or true) then
             lib.attrsets.mapAttrsToList (recursive fullKey) v
           else


### PR DESCRIPTION
### :fish: What?

Some packages passthru stuff they depend upon building and others even some runtime dependencies.

### :fishing_pole_and_fish: Why?

I was getting some cache miss and I hope this fixes it.