### PR TITLE
bump-20230528-1; README: move cache and update

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,24 @@ In your `configuration.nix` enable the packages and options that you prefer:
 }
 ```
 
+### Binary Cache
+
+To use our pre-build packages and speed the installation process, add these options to your configuration:
+
+```nix
+{
+  nix.settings = {
+    substituters = [
+      "https://nyx.chaotic.cx"
+    ];
+    trusted-public-keys = [
+      "nyx.chaotic.cx-1:HfnXSw4pj95iI/n17rIDy40agHj12WfF+Gqk6SonIT8="
+      "chaotic-nyx.cachix.org-1:HfnXSw4pj95iI/n17rIDy40agHj12WfF+Gqk6SonIT8="
+    ];
+  };
+}
+```
+
 ## List of packages
 
 ```nix
@@ -124,24 +142,6 @@ nix run github:chaotic-cx/nyx/nyxpkgs-unstable#input-leap_git
     enable = true;
     volume = "zroot/ROOT/empty";
     snapshot = "start";
-  };
-}
-```
-
-## Cache
-
-To use our pre-build packages and speed the installation process, add these options to your configuration:
-
-```nix
-{
-  nix.settings = {
-    extra-substituters = [
-      "https://nyx.chaotic.cx"
-    ];
-    extra-trusted-public-keys = [
-      "nyx.chaotic.cx-1:HfnXSw4pj95iI/n17rIDy40agHj12WfF+Gqk6SonIT8="
-      "chaotic-nyx.cachix.org-1:HfnXSw4pj95iI/n17rIDy40agHj12WfF+Gqk6SonIT8="
-    ];
   };
 }
 ```

--- a/flake.lock
+++ b/flake.lock
@@ -18,11 +18,11 @@
     "gamescope-git-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1685117204,
-        "narHash": "sha256-Z4Zn9OSTvt0sYQGjSFYNBwExHD7cxy2qpTaxTyU1hFE=",
+        "lastModified": 1685205317,
+        "narHash": "sha256-/9NGlM1FaDfdFkyIjbbJ39GB5JkkIFeZXQwtCvFUuX4=",
         "owner": "ValveSoftware",
         "repo": "gamescope",
-        "rev": "29710fb2ececee980e3923ed8f5f002ce219aa94",
+        "rev": "9282a715a1ff8b0f639645d2619899c3152b58df",
         "type": "github"
       },
       "original": {
@@ -52,11 +52,11 @@
     "mangohud-git-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1684996040,
-        "narHash": "sha256-+fQiYqnwifrak4Z7mDut6xlR2cYQrlhx4/dxoz54bMo=",
+        "lastModified": 1685267165,
+        "narHash": "sha256-VM91+CwNvS+/YmIkYThvlSp0LRz1sznEgJcXjMsoK3E=",
         "owner": "flightlessmango",
         "repo": "MangoHud",
-        "rev": "5fde8749afc5d3f8c20abc66c3e16fb426dd82cc",
+        "rev": "6306fed7f749837f2a780c883743af3a116a5465",
         "type": "github"
       },
       "original": {
@@ -185,11 +185,11 @@
     "yuzu-ea-git-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1685149205,
-        "narHash": "sha256-KhHiqhYFyyz/wrSrqA2mB4naJmZn698q5ePyZqm4w6Q=",
+        "lastModified": 1685212536,
+        "narHash": "sha256-zann39rAwRAmHy5WA3l4w1wVnZiwipmcZoe+cDInrP8=",
         "owner": "pineappleEA",
         "repo": "pineapple-src",
-        "rev": "35537936b52b5b60e571585060168fe6471cfb3e",
+        "rev": "c6c10a4fa2e261f513fd59d110e51502e93a3f6c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
### :fish: What?

1. Puts our binary cache's information as a subtopic in "How to use";
2. Changes "extra-substituters" to "substituters;
3. Changes "trusted-public-keys" to "trusted-public-keys;
4. Bumps the `flake.lock`.

### :fishing_pole_and_fish: Why?

- (1) It's more commonsense to add the cache while installing;
- (2) and (3) -- it seems this is the proper way to do inside the `configuration.nix`;
- (4) Brings the packages to their latest version.