### PR TITLE
 modules/nyx-{cache,overlay}: init 

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ In your `configuration.nix` enable the packages and options that you prefer:
 ### Binary Cache
 
 You'll get the binary cache added to your configuration as soon as you add our default module.
-We do this automatically so we can gracefully update its address and keys without prompting you for manual work.
+We do this automatically, so we can gracefully update the cache's address and keys without prompting you for manual work.
 
 If you dislike this behavior for any reason, you can disable it with `chaotic.nyx.cache.enable = false`.
 
@@ -131,6 +131,8 @@ nix run github:chaotic-cx/nyx/nyxpkgs-unstable#input-leap_git
   chaotic.mesa-git.extraPackages = [ pkgs.mesa_git.opencl ];
   chaotic.mesa-git.extraPackages32 = [ pkgs.mesa32_git.opencl ];
   chaotic.nyx.cache.enable = false;
+  chaotic.nyx.overlay.enable = false;
+  chaotic.nyx.overlay.onTopOf = "user-pkgs";
   chaotic.steam.extraCompatPackages = with pkgs; [ luxtorpeda proton-ge-custom ];
   chaotic.zfs-impermanence-on-shutdown = {
     enable = true;
@@ -165,6 +167,14 @@ You are free to use our code, or portions of our code, following the MIT license
 ### Suggestions
 
 If you have any suggestion to enhance our packages, modules, or even the CI's codes, let us know through the GitHub repo's issues.
+
+#### Building over the user's pkgs
+
+For cache reasons, Chaotic-Nyx now defaults to always use nixpkgs as provider of its dependencies.
+
+If you need to change this behavior, set `chaotic.nyx.onTopOf = "user-pkgs".`. Be warned that you mostly won't be able to benefit from our binary cache after this change.
+
+You can also disable our overlay entirely by configuring `chaotic.nyx.overlay.enable`;
 
 ## Maintainence
 

--- a/README.md
+++ b/README.md
@@ -47,21 +47,14 @@ In your `configuration.nix` enable the packages and options that you prefer:
 
 ### Binary Cache
 
-To use our pre-build packages and speed the installation process, add these options to your configuration:
+You'll get the binary cache added to your configuration as soon as you add our default module.
+We do this automatically so we can gracefully update its address and keys without prompting you for manual work.
 
-```nix
-{
-  nix.settings = {
-    substituters = [
-      "https://nyx.chaotic.cx"
-    ];
-    trusted-public-keys = [
-      "nyx.chaotic.cx-1:HfnXSw4pj95iI/n17rIDy40agHj12WfF+Gqk6SonIT8="
-      "chaotic-nyx.cachix.org-1:HfnXSw4pj95iI/n17rIDy40agHj12WfF+Gqk6SonIT8="
-    ];
-  };
-}
-```
+If you dislike this behavior for any reason, you can disable it with `chaotic.nyx.cache.enable = false`.
+
+**Remember**: If you want to fetch derivations from our cache, you'll need to enable our module and rebuild your system **before** adding these derivations to your configuration.
+
+Commands like `nix run ...`, `nix develop ...`, and others, when using our flake as input, will ask you to add the cache interactively when missing from your user's nix settings.
 
 ## List of packages
 
@@ -121,10 +114,6 @@ nix run github:chaotic-cx/nyx/nyxpkgs-unstable#input-leap_git
 ```nix
 {
   chaotic.appmenu-gtk3-module.enable = true;
-  chaotic.mesa-git.enable = true;
-  chaotic.mesa-git.extraPackages = [ pkgs.mesa_git.opencl ];
-  chaotic.mesa-git.extraPackages32 = [ pkgs.mesa32_git.opencl ];
-  chaotic.linux_hdr.specialisation.enable = true;
   chaotic.gamescope = {
     enable = true;
     package = pkgs.gamescope_git;
@@ -137,6 +126,11 @@ nix run github:chaotic-cx/nyx/nyxpkgs-unstable#input-leap_git
       steamArgs = [ "-tenfoot" "-pipewire-dmabuf" ];
     };
   };
+  chaotic.linux_hdr.specialisation.enable = true;
+  chaotic.mesa-git.enable = true;
+  chaotic.mesa-git.extraPackages = [ pkgs.mesa_git.opencl ];
+  chaotic.mesa-git.extraPackages32 = [ pkgs.mesa32_git.opencl ];
+  chaotic.nyx.cache.enable = false;
   chaotic.steam.extraCompatPackages = with pkgs; [ luxtorpeda proton-ge-custom ];
   chaotic.zfs-impermanence-on-shutdown = {
     enable = true;

--- a/modules/default.nix
+++ b/modules/default.nix
@@ -5,6 +5,7 @@ let
     gamescope = import ./gamescope.nix fromFlakes;
     linux_hdr = import ./linux_hdr.nix fromFlakes;
     mesa_git = import ./mesa-git.nix fromFlakes;
+    nyx-cache = import ./nyx-cache.nix fromFlakes;
     steam-compat-tools = import ./steam-compat-tools.nix;
     zfs-impermanence-on-shutdown = import ./zfs-impermanence-on-shutdown.nix;
   };

--- a/modules/default.nix
+++ b/modules/default.nix
@@ -9,9 +9,16 @@ let
     zfs-impermanence-on-shutdown = import ./zfs-impermanence-on-shutdown.nix;
   };
 
-  default = { ... }: {
+  default = { pkgs, ... }: {
     config = {
-      nixpkgs.overlays = [ inputs.self.overlays.default ];
+      nixpkgs.overlays = [
+        (_: userPrev:
+          let
+          input = inputs.nixpkgs.legacyPackages.${pkgs.system};
+          ourPackages = inputs.self.overlays.default (input // ourPackages) input;
+          in userPrev // ourPackages
+        )
+      ];
     };
 
     imports = builtins.attrValues modulesPerFile;

--- a/modules/default.nix
+++ b/modules/default.nix
@@ -6,30 +6,12 @@ let
     linux_hdr = import ./linux_hdr.nix fromFlakes;
     mesa_git = import ./mesa-git.nix fromFlakes;
     nyx-cache = import ./nyx-cache.nix fromFlakes;
+    nyx-overlay = import ./nyx-overlay.nix fromFlakes;
     steam-compat-tools = import ./steam-compat-tools.nix;
     zfs-impermanence-on-shutdown = import ./zfs-impermanence-on-shutdown.nix;
   };
 
-  default = { pkgs, ... }: {
-    config = {
-      nixpkgs.overlays = [
-        (_: userPrev:
-          let
-          input = inputs.nixpkgs.legacyPackages.${pkgs.system};
-          ourPackages = inputs.self.overlays.default (input // ourPackages) input;
-          in userPrev // ourPackages
-        )
-      ];
-    };
-
-    imports = builtins.attrValues modulesPerFile;
-  };
-
-  defaultWithFollow = { ... }: {
-    config = {
-      nixpkgs.overlays = [ inputs.self.overlays.default ];
-    };
-
+  default = { ... }: {
     imports = builtins.attrValues modulesPerFile;
   };
 in

--- a/modules/default.nix
+++ b/modules/default.nix
@@ -23,5 +23,13 @@ let
 
     imports = builtins.attrValues modulesPerFile;
   };
+
+  defaultWithFollow = { ... }: {
+    config = {
+      nixpkgs.overlays = [ inputs.self.overlays.default ];
+    };
+
+    imports = builtins.attrValues modulesPerFile;
+  };
 in
 modulesPerFile // { inherit default; }

--- a/modules/nyx-cache.nix
+++ b/modules/nyx-cache.nix
@@ -1,0 +1,24 @@
+{ inputs }: { config, lib, ... }:
+let
+  cfg = config.chaotic.nyx.cache;
+in
+{
+  options = {
+    chaotic.nyx.cache.enable =
+      lib.mkOption {
+        default = true;
+        description = ''
+          Whether to add Chaotic-Nyx's binary cache to settings.
+        '';
+      };
+  };
+  config = {
+    nix.settings = lib.mkIf cfg.enable {
+      substituters = [ "https://nyx.chaotic.cx" ];
+      trusted-public-keys = [
+        "nyx.chaotic.cx-1:HfnXSw4pj95iI/n17rIDy40agHj12WfF+Gqk6SonIT8="
+        "chaotic-nyx.cachix.org-1:HfnXSw4pj95iI/n17rIDy40agHj12WfF+Gqk6SonIT8="
+      ];
+    };
+  };
+}

--- a/modules/nyx-overlay.nix
+++ b/modules/nyx-overlay.nix
@@ -35,18 +35,18 @@ in
         };
     };
   };
-  config = {
-    nixpkgs.overlays = lib.mkIf cfg.enable (
+  config = lib.mkIf cfg.enable {
+    nixpkgs.overlays =
       if cfg.onTopOf == "flake-nixpkgs" then [
         onTopOfFlakeInputs
       ] else [
         onTopOfUserPkgs
-      ]
-    );
+      ];
 
     warnings =
-      lib.mkIf (cfg.onTopOf == "user-pkgs" && cfg.enable && cacheCfg.enable) [
+      if (cfg.onTopOf == "user-pkgs" && cacheCfg.enable)
+      then [
         ''Chaotic Nyx certainly won't hit cache when using `chaotic.nyx.overlay = "user-pkgs"`.''
-      ];
+      ] else [ ];
   };
 }

--- a/modules/nyx-overlay.nix
+++ b/modules/nyx-overlay.nix
@@ -4,13 +4,12 @@ let
   cacheCfg = config.chaotic.nyx.cache;
 
   onTopOfFlakeInputs =
-    (_: userPrev:
-      let
-        input = inputs.nixpkgs.legacyPackages.${pkgs.system};
-        ourPackages = inputs.self.overlays.default (input // ourPackages) input;
-      in
-      userPrev // ourPackages
-    );
+    _: userPrev:
+    let
+      input = inputs.nixpkgs.legacyPackages.${pkgs.system};
+      ourPackages = inputs.self.overlays.default (input // ourPackages) input;
+    in
+    userPrev // ourPackages;
 
   onTopOfUserPkgs =
     [ inputs.self.overlays.default ];

--- a/modules/nyx-overlay.nix
+++ b/modules/nyx-overlay.nix
@@ -36,16 +36,17 @@ in
         };
     };
   };
-  config = lib.mkIf cfg.enable {
-    nixpkgs.overlays =
+  config = {
+    nixpkgs.overlays = lib.mkIf cfg.enable (
       if cfg.onTopOf == "flake-nixpkgs" then [
         onTopOfFlakeInputs
       ] else [
         onTopOfUserPkgs
-      ];
+      ]
+    );
 
     warnings =
-      lib.mkIf (cfg.onTopOf == "user-pkgs" && cacheCfg.enable) [
+      lib.mkIf (cfg.onTopOf == "user-pkgs" && cfg.enable && cacheCfg.enable) [
         ''Chaotic Nyx certainly won't hit cache when using `chaotic.nyx.overlay = "user-pkgs"`.''
       ];
   };

--- a/modules/nyx-overlay.nix
+++ b/modules/nyx-overlay.nix
@@ -1,0 +1,52 @@
+{ inputs }: { config, lib, pkgs, ... }:
+let
+  cfg = config.chaotic.nyx.overlay;
+  cacheCfg = config.chaotic.nyx.cache;
+
+  onTopOfFlakeInputs =
+    (_: userPrev:
+      let
+        input = inputs.nixpkgs.legacyPackages.${pkgs.system};
+        ourPackages = inputs.self.overlays.default (input // ourPackages) input;
+      in
+      userPrev // ourPackages
+    );
+
+  onTopOfUserPkgs =
+    [ inputs.self.overlays.default ];
+in
+{
+  options = {
+    chaotic.nyx.overlay = {
+      enable =
+        lib.mkOption {
+          default = true;
+          description = ''
+            Whether to add Chaotic-Nyx's overlay to system's pkgs.
+          '';
+        };
+      onTopOf =
+        lib.mkOption {
+          type = lib.types.either "flake-nixpkgs" "user-pkgs";
+          default = "flake-nixpkgs";
+          example = "user-pkgs";
+          description = ''
+            Build Chaotic-Nyx's packages based on nyx's flake inputs or the system's pkgs.
+          '';
+        };
+    };
+  };
+  config = lib.mkIf cfg.enable {
+    nixpkgs.overlays =
+      if cfg.onTopOf == "flake-nixpkgs" then [
+        onTopOfFlakeInputs
+      ] else [
+        onTopOfUserPkgs
+      ];
+
+    warnings =
+      lib.mkIf (cfg.onTopOf == "user-pkgs" && cacheCfg.enable) [
+        ''Chaotic Nyx certainly won't hit cache when using `chaotic.nyx.overlay = "user-pkgs"`.''
+      ];
+  };
+}

--- a/modules/nyx-overlay.nix
+++ b/modules/nyx-overlay.nix
@@ -26,7 +26,7 @@ in
         };
       onTopOf =
         lib.mkOption {
-          type = lib.types.either "flake-nixpkgs" "user-pkgs";
+          type = lib.types.enum [ "flake-nixpkgs" "user-pkgs" ];
           default = "flake-nixpkgs";
           example = "user-pkgs";
           description = ''
@@ -44,9 +44,8 @@ in
       ];
 
     warnings =
-      if (cfg.onTopOf == "user-pkgs" && cacheCfg.enable)
-      then [
+      lib.mkIf (cfg.onTopOf == "user-pkgs" && cacheCfg.enable) [
         ''Chaotic Nyx certainly won't hit cache when using `chaotic.nyx.overlay = "user-pkgs"`.''
-      ] else [ ];
+      ];
   };
 }


### PR DESCRIPTION
### :fish: What?

Adds the following options:
```nix
{
  chaotic.nyx.cache.enable = true;
  chaotic.nyx.overlay.enable = true;
  chaotic.nyx.overlay.onTopOf = "flake-nixpkgs"; # either this value or "user-pkgs"
}
```

### :fishing_pole_and_fish: Why?

- To have more cache hits;
- To enhance maintainability;
- To allow users to disable our default's module changes entirely.
