### PR TITLE
 flake-20230604-1: mesa, nixpkgs, sway, wlroots, yuzu-ea 

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,8 +65,6 @@ Commands like `nix run ...`, `nix develop ...`, and others, when using our flake
   applet-window-title
   appmenu-gtk3-module
   beautyline-icons # Garuda Linux's version
-  directx-headers_next
-  directx-headers32_next # only x86
   dr460nized-kde-theme
   droid-sans-mono-nerdfont
   fastfetch
@@ -92,9 +90,6 @@ Commands like `nix run ...`, `nix develop ...`, and others, when using our flake
   sway-unwrapped_git
   sway_git # and -unwrapped_git
   swaylock-plugin_git
-  vulkan-headers_next
-  vulkan-loader_next
-  wayland_next
   waynergy_git
   wlroots_git
   yuzu-early-access_git

--- a/devshells/failures.nix
+++ b/devshells/failures.nix
@@ -1,5 +1,4 @@
 {
-  "linuxPackages_cachyos.apfs" = "/nix/store/5glb4ks4hp707qnixf5b2xvbnyhgl7r6-apfs-0.3.1-6.3.5";
   "linuxPackages_cachyos.digimend" = "/nix/store/z29k397dpn2wnbi3mard2v2prlfl885q-digimend-10";
   "linuxPackages_cachyos.dpdk" = "/nix/store/myscj7mfy8rl2lfpfcpq21ic4fy2g05g-dpdk-22.11.1-6.3.5";
   "linuxPackages_cachyos.evdi" = "/nix/store/1i6f6dss6rg6m3g0jm5pjc5i8c4ivz11-evdi-unstable-2022-10-13";
@@ -8,8 +7,6 @@
   "linuxPackages_cachyos.mba6x_bl" = "/nix/store/gg3zd4zk7ivpq2ij0fxmvsk1cg336x7v-mba6x_bl-unstable-2016-12-08";
   "linuxPackages_cachyos.sysdig" = "/nix/store/p2hyjf4mbahswpyqqsn9ycmdj64g8fxa-sysdig-0.31.5";
   "linuxPackages_cachyos.system76-acpi" = "/nix/store/6j770n8sjlcr45jmf44606i4npgvl4hk-system76-acpi-module-1.0.2-6.3.5";
-  "linuxPackages_cachyos.virtualbox" = "/nix/store/khilmvls6civ653p9k7c4pi4nxz5szl6-virtualbox-modules-7.0.6-6.3.5";
-  "linuxPackages_cachyos.virtualboxGuestAdditions" = "/nix/store/a6z8a6g8gb7d57kqkkpjmvhgzgm40f45-VirtualBox-GuestAdditions-7.0.6-6.3.5";
   "linuxPackages_hdr.mba6x_bl" = "/nix/store/wwpfbmv6pzxfx20m79pqj53q32r3fa24-mba6x_bl-unstable-2016-12-08";
-  "linuxPackages_hdr.virtualboxGuestAdditions" = "/nix/store/5jqb0s34zdp7zmlvnb44vakqb5yvks2z-VirtualBox-GuestAdditions-7.0.6-6.0-unstable-2023-01-17";
+  "linuxPackages_hdr.virtualboxGuestAdditions" = "/nix/store/rr4v0zny1n3f4ad2isk7b11xx404qc6g-VirtualBox-GuestAdditions-7.0.8-6.0-unstable-2023-01-17";
 }

--- a/flake.lock
+++ b/flake.lock
@@ -69,11 +69,11 @@
     "mesa-git-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1685697719,
-        "narHash": "sha256-TKcoArzXTvzuGIDEwKw3Z5Ql2kL72BP0fHbj4XXHNRU=",
+        "lastModified": 1685839378,
+        "narHash": "sha256-ghDnCe0GgIumb4GUS40wYwxY+3TeZPSRXJc2udK8lOs=",
         "owner": "chaotic-cx",
         "repo": "mesa-mirror",
-        "rev": "2d0e8e0258004f09e3e5d6b2998c2eb0110ddc7d",
+        "rev": "bfb092b955516d5ff0d1cfb73de80fed30cec6c3",
         "type": "github"
       },
       "original": {
@@ -85,11 +85,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1685655444,
-        "narHash": "sha256-6EujQNAeaUkWvpEZZcVF8qSfQrNVWFNNGbUJxv/A5a8=",
+        "lastModified": 1685836261,
+        "narHash": "sha256-rpxEPGeW4JZJcH58SQApJUtJ7w78VPtkF6Cut/Pq6Kg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e635192892f5abbc2289eaac3a73cdb249abaefd",
+        "rev": "dd4982554e18b936790da07c4ea2db7c7600f283",
         "type": "github"
       },
       "original": {
@@ -117,11 +117,11 @@
     "sway-git-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1684594585,
-        "narHash": "sha256-2ZcYiLEeyr325irTgGLBEGMBNj8pLUlfCs8O0OQFoFc=",
+        "lastModified": 1685776332,
+        "narHash": "sha256-KnqDsy5/yPkVQiSJdh8FXufbqjwf891yNSAqkV10lDk=",
         "owner": "swaywm",
         "repo": "sway",
-        "rev": "48d6eda3cb0f79d2190756af44f01d028696bf0e",
+        "rev": "b5cb49bce90bd4d37f08da6a65aba6a99cb7c608",
         "type": "github"
       },
       "original": {
@@ -168,11 +168,11 @@
     "wlroots-git-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1685608976,
-        "narHash": "sha256-LMxl8fQIFuTxnjNVHk6pIGg/B/lQUwABAHpKHdj6AD8=",
+        "lastModified": 1685803001,
+        "narHash": "sha256-yxq/U9zL1ssFZtgT27A96UKteCiKb3zSmbA/dokK76U=",
         "ref": "master",
-        "rev": "beb820b573fca805b345c6164e0f1a25256c46c4",
-        "revCount": 6309,
+        "rev": "b61d5922f1d0910a848deb100570ad8587aea38d",
+        "revCount": 6341,
         "type": "git",
         "url": "https://gitlab.freedesktop.org/wlroots/wlroots.git"
       },
@@ -185,11 +185,11 @@
     "yuzu-ea-git-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1685694494,
-        "narHash": "sha256-XjQ1MpHAU0ak1iL5qzatGJ8zzpwXfj0MxmSvIUQsqe4=",
+        "lastModified": 1685864944,
+        "narHash": "sha256-c5JcEXYg2VOoUfBDew4I2jtyAibwhsGkgYIQGGpUjUk=",
         "owner": "pineappleEA",
         "repo": "pineapple-src",
-        "rev": "5d6ba5745fbc9c802377e1e3af63dd5fdbc6a7ee",
+        "rev": "19ca7d484fd8782da85a8cfd29cae4d539c05acf",
         "type": "github"
       },
       "original": {

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -36,16 +36,6 @@ in
 
   beautyline-icons = final.callPackage ../pkgs/beautyline-icons { };
 
-  # Upstream is up-to-date (2023-05-01)
-  directx-headers_next = final.directx-headers;
-
-  # Upstream is up-to-date (2023-05-01)
-  directx-headers32_next =
-    if final.stdenv.hostPlatform.isLinux && final.stdenv.hostPlatform.isx86
-    then
-      final.pkgsi686Linux.directx-headers
-    else throw "No headers32_next for non-x86";
-
   dr460nized-kde-theme = final.callPackage ../pkgs/dr460nized-kde-theme { };
 
   # nixpkgs builds this one, but does not expose it.
@@ -120,16 +110,11 @@ in
 
   mangohud_git = callOverride ../pkgs/mangohud-git { };
 
-  mesa_git = callOverride ../pkgs/mesa-git {
-    directx-headers = final.directx-headers_next;
-  };
+  mesa_git = callOverride ../pkgs/mesa-git { };
   mesa32_git =
     if final.stdenv.hostPlatform.isLinux && final.stdenv.hostPlatform.isx86
     then
-      callOverride32 ../pkgs/mesa-git
-        {
-          directx-headers = final.directx-headers32_next;
-        }
+      callOverride32 ../pkgs/mesa-git { }
     else throw "No mesa32_git for non-x86";
 
   mpv-vapoursynth =
@@ -156,15 +141,6 @@ in
   };
 
   swaylock-plugin_git = callOverride ../pkgs/swaylock-plugin-git { };
-
-  # Upstream is up-to-date (2023-05-01)
-  vulkan-headers_next = final.vulkan-headers;
-
-  # Upstream is up-to-date (2023-05-01)
-  vulkan-loader_next = final.vulkan-loader;
-
-  # Upstream is up-to-date (2023-05-01)
-  wayland_next = final.wayland;
 
   waynergy_git = nyxUtils.gitOverride inputs.waynergy-git-src prev.waynergy;
 

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -133,9 +133,7 @@ in
     protonGeTitle = "Proton-GE";
   };
 
-  sway-unwrapped_git = callOverride ../pkgs/sway-unwrapped-git {
-    wayland = final.wayland_next;
-  };
+  sway-unwrapped_git = callOverride ../pkgs/sway-unwrapped-git { };
   sway_git = prev.sway.override {
     sway-unwrapped = final.sway-unwrapped_git;
   };
@@ -144,9 +142,7 @@ in
 
   waynergy_git = nyxUtils.gitOverride inputs.waynergy-git-src prev.waynergy;
 
-  wlroots_git = callOverride ../pkgs/wlroots-git {
-    wayland = final.wayland_next;
-  };
+  wlroots_git = callOverride ../pkgs/wlroots-git { };
 
   yuzu-early-access_git = callOverride ../pkgs/yuzu-ea-git { };
 }

--- a/pkgs/mesa-git/default.nix
+++ b/pkgs/mesa-git/default.nix
@@ -16,4 +16,4 @@ prev.mesa.overrideAttrs (pa: {
       "disk_cache-include-dri-driver-path-in-cache-key.patch"
       pa.patches
     ) ++ [ ./disk_cache-include-dri-driver-path-in-cache-key.patch ];
-}
+})

--- a/pkgs/mesa-git/default.nix
+++ b/pkgs/mesa-git/default.nix
@@ -1,8 +1,6 @@
-{ directx-headers, final, inputs, nyxUtils, prev, ... }:
+{ final, inputs, nyxUtils, prev, ... }:
 
-(prev.mesa.override {
-  inherit directx-headers;
-}).overrideAttrs (pa: {
+prev.mesa.overrideAttrs (pa: {
   version = builtins.substring 0 (builtins.stringLength pa.version) inputs.mesa-git-src.rev;
   src = inputs.mesa-git-src;
   buildInputs = pa.buildInputs ++ (with final; [ libunwind lm_sensors ]);
@@ -18,4 +16,4 @@
       "disk_cache-include-dri-driver-path-in-cache-key.patch"
       pa.patches
     ) ++ [ ./disk_cache-include-dri-driver-path-in-cache-key.patch ];
-})
+}

--- a/pkgs/sway-unwrapped-git/default.nix
+++ b/pkgs/sway-unwrapped-git/default.nix
@@ -2,13 +2,11 @@
 , inputs
 , nyxUtils
 , prev
-, wayland
 , ...
 }:
 
 (prev.sway-unwrapped.override {
   wlroots_0_16 = final.wlroots_git;
-  inherit wayland;
 }).overrideAttrs (prevAttrs: rec {
   version = nyxUtils.gitToVersion src;
   src = inputs.sway-git-src;

--- a/pkgs/wlroots-git/default.nix
+++ b/pkgs/wlroots-git/default.nix
@@ -3,12 +3,11 @@
 , inputs
 , nyxUtils
 , prev
-, wayland
 , ...
 }:
 
 (prev.wlroots_0_16.override {
-  inherit enableXWayland wayland;
+  inherit enableXWayland;
 }).overrideAttrs (pa: {
   version = nyxUtils.gitToVersion inputs.wlroots-git-src;
   src = inputs.wlroots-git-src;


### PR DESCRIPTION
- Daily builds of our packages;
- Drop `*_next` since they're up-to-date upstream.