### PR TITLE
CI: use our service account for commiting nixpkgs updates

### DIFF
--- a/.github/workflows/nixpkgs-bump.yml
+++ b/.github/workflows/nixpkgs-bump.yml
@@ -33,7 +33,7 @@ jobs:
           set -e
           git config --global user.name 'Github Actions'
           git config --global user.email 'actions@chaotic.cx'
-          git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}
+          git remote set-url origin https://x-access-token:${{ secrets.PAT_CHAOTIC }}@github.com/${{ github.repository }}
           git add flake.lock
           git commit -m "nixpkgs: bump to $(date +%Y%m%d)"
           git push


### PR DESCRIPTION
### :fish: What?

Use the https://github.com/Chaotic-Temeraire account for committing to the repo via CI.

### :fishing_pole_and_fish: Why?

Having our own bot is for sure nicer than having the GitHub actions do it.

### :whale: Extras

Today gotta be a great day.
