### PR TITLE
nyx-overlay: fix wrong definition of callPackage

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -73,10 +73,10 @@
       let
         applyOverlay = prev:
           let
-            overlayFinal = prev // final // { callPackage = prev.newScope final; };
-            final = overlays.default overlayFinal prev;
+            overlayFinal = prev // ourPackages // { callPackage = prev.newScope overlayFinal; };
+            ourPackages = overlays.default overlayFinal prev;
           in
-          final;
+          ourPackages;
       in
       {
         x86_64-linux = applyOverlay nixpkgs.legacyPackages.x86_64-linux;

--- a/modules/nyx-overlay.nix
+++ b/modules/nyx-overlay.nix
@@ -7,11 +7,10 @@ let
     _: userPrev:
     let
       prev = inputs.nixpkgs.legacyPackages.${pkgs.system};
-      ourPackages = inputs.self.overlays.default overlayFinal input;
       overlayFinal = prev // ourPackages // { callPackage = prev.newScope overlayFinal; };
-      userFinal = userPrev // ourPackages // { callPackage = userFinal.newScope userFinal; };
+      ourPackages = inputs.self.overlays.default overlayFinal prev;
     in
-    userFinal;
+    ourPackages;
 
   onTopOfUserPkgs =
     [ inputs.self.overlays.default ];

--- a/modules/nyx-overlay.nix
+++ b/modules/nyx-overlay.nix
@@ -6,10 +6,12 @@ let
   onTopOfFlakeInputs =
     _: userPrev:
     let
-      input = inputs.nixpkgs.legacyPackages.${pkgs.system};
-      ourPackages = inputs.self.overlays.default (input // ourPackages) input;
+      prev = inputs.nixpkgs.legacyPackages.${pkgs.system};
+      ourPackages = inputs.self.overlays.default overlayFinal input;
+      overlayFinal = prev // ourPackages // { callPackage = prev.newScope overlayFinal; };
+      userFinal = userPrev // ourPackages // { callPackage = userFinal.newScope userFinal; };
     in
-    userPrev // ourPackages;
+    userFinal;
 
   onTopOfUserPkgs =
     [ inputs.self.overlays.default ];


### PR DESCRIPTION
### :fish: What?

Correctly set `callPackage` in each scope.

### :fishing_pole_and_fish: Why?

Fixes the mistakes I've made while fixing my other mistakes.