### PR TITLE
nyx-overlay: respect user's config.nixpkgs.config

### DIFF
--- a/modules/nyx-overlay.nix
+++ b/modules/nyx-overlay.nix
@@ -6,7 +6,11 @@ let
   onTopOfFlakeInputs =
     _: userPrev:
     let
-      prev = inputs.nixpkgs.legacyPackages.${pkgs.system};
+      nixpkgs = import "${inputs.nixpkgs}" {
+        system = pkgs.system;
+        config = config.nixpkgs.config;
+      };
+      prev = nixpkgs.legacyPackages.${pkgs.system};
       overlayFinal = prev // ourPackages // { callPackage = prev.newScope overlayFinal; };
       ourPackages = inputs.self.overlays.default overlayFinal prev;
     in

--- a/modules/nyx-overlay.nix
+++ b/modules/nyx-overlay.nix
@@ -7,8 +7,8 @@ let
     _: userPrev:
     let
       prev = import "${inputs.nixpkgs}" {
-        system = pkgs.system;
-        config = config.nixpkgs.config;
+        inherit (pkgs) system;
+        inherit (config.nixpkgs) config;
       };
       overlayFinal = prev // ourPackages // { callPackage = prev.newScope overlayFinal; };
       ourPackages = inputs.self.overlays.default overlayFinal prev;

--- a/modules/nyx-overlay.nix
+++ b/modules/nyx-overlay.nix
@@ -6,11 +6,10 @@ let
   onTopOfFlakeInputs =
     _: userPrev:
     let
-      nixpkgs = import "${inputs.nixpkgs}" {
+      prev = import "${inputs.nixpkgs}" {
         system = pkgs.system;
         config = config.nixpkgs.config;
       };
-      prev = nixpkgs.legacyPackages.${pkgs.system};
       overlayFinal = prev // ourPackages // { callPackage = prev.newScope overlayFinal; };
       ourPackages = inputs.self.overlays.default overlayFinal prev;
     in


### PR DESCRIPTION
### :fish: What?

Instead of using the flake input, import it, passing the user's config forward.

### :fishing_pole_and_fish: Why?

Fixes https://github.com/chaotic-cx/nyx/issues/142