### PR TITLE
nyx-overlay: import nixpkgs like "modules/misc/nixpkgs" does

### DIFF
--- a/modules/nyx-overlay.nix
+++ b/modules/nyx-overlay.nix
@@ -7,8 +7,7 @@ let
     _: userPrev:
     let
       prev = import "${inputs.nixpkgs}" {
-        inherit (pkgs) system;
-        inherit (config.nixpkgs) config;
+        inherit (config.nixpkgs) config localSystem crossSystem;
       };
       overlayFinal = prev // ourPackages // { callPackage = prev.newScope overlayFinal; };
       ourPackages = inputs.self.overlays.default overlayFinal prev;


### PR DESCRIPTION
### :fish: What?

Change `system` parameter with `localSystem` and `crossSystem` (like nixpkgs itself does).

### :fishing_pole_and_fish: Why?

Attempt to fix the comment https://github.com/chaotic-cx/nyx/pull/143#issuecomment-1576443907