### PR TITLE
Fix syntax error in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ nix run github:chaotic-cx/nyx/nyxpkgs-unstable#input-leap_git
   chaotic.mesa-git.extraPackages32 = [ pkgs.mesa32_git.opencl ];
   chaotic.nyx.cache.enable = false;
   chaotic.nyx.overlay.enable = false;
-  chaotic.nyx.overlay.flakeNixpkgs.config = { allowUnfree = true };
+  chaotic.nyx.overlay.flakeNixpkgs.config = { allowUnfree = true; };
   chaotic.nyx.overlay.onTopOf = "user-pkgs"; # defaults to "flake-nixpkgs"
   chaotic.steam.extraCompatPackages = with pkgs; [ luxtorpeda proton-ge-custom ];
   chaotic.zfs-impermanence-on-shutdown = {


### PR DESCRIPTION
### :fish: What?

fixed syntax error in readme example

### :fishing_pole_and_fish: Why?

because people will add broken code if they copy from it lol