### PR TITLE
modules/mesa-git: fixes for browsers

### DIFF
--- a/modules/mesa-git.nix
+++ b/modules/mesa-git.nix
@@ -84,7 +84,7 @@ let
       setLdLibraryPath = mkForce false;
     };
 
-    environment.sessionVariables = {
+    environment.variables = {
       GBM_BACKENDS_PATH = "/run/opengl-driver/lib/gbm";
       GBM_BACKEND = pkgs.mesa_git.gbmBackend;
     };

--- a/modules/mesa-git.nix
+++ b/modules/mesa-git.nix
@@ -46,8 +46,10 @@ let
         )
       ];
 
-      environment.sessionVariables.LD_LIBRARY_PATH =
-        [ "/run/opengl-driver/lib" ] ++ lib.optional has32 "/run/opengl-driver-32/lib";
+      environment.variables = {
+        LD_LIBRARY_PATH = [ "/run/opengl-driver/lib" ] ++ lib.optional has32 "/run/opengl-driver-32/lib";
+        LD_PRELOAD = [ "/run/opengl-driver/lib/libglapi.so.0" ];
+      };
 
       warnings = [
         "The `chaotic.mesa-git.method = \"LD_LIBRARY_PATH\"` is known to cause problems with Steam and apps with wrappers preloading Mesa (e.g., Firefox). A refactor of this module is currently in development."
@@ -87,6 +89,7 @@ let
     environment.variables = {
       GBM_BACKENDS_PATH = "/run/opengl-driver/lib/gbm";
       GBM_BACKEND = pkgs.mesa_git.gbmBackend;
+      LD_PRELOAD = [ "${pkgs.mesa_git}/lib/libglapi.so.0" ]; # TODO: find a better solution
     };
   };
 


### PR DESCRIPTION
### :fish: What?

1. Change `environment.sessionVariables` to `environment.variables`;
2. Preload `libglapi` (I'll find a better solution later).

### :fishing_pole_and_fish: Why?

- (1) Chrome was starting without the envvar; 
- (2) Mixing drivers is exploding browser's glxtest (SISEGV at `_glapi_add_dispatch` through `eglCreateContext`).
