### PR TITLE
linux_cachyos: 6.3.9-> 6.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,9 +72,9 @@ Commands like `nix run ...`, `nix develop ...`, and others, when using our flake
   gamescope_git
   input-leap_git
   latencyflex-vulkan
-  linux_cachyos # the default BORE scheduler
+  linux_cachyos # the default bore-eevdf scheduler
   linux_hdr # recommended option: chaotic.linux_hdr.specialisation.enable
-  linuxPackages_cachyos # the default BORE scheduler
+  linuxPackages_cachyos # bore-eevdf, includes their always-working ZFS module
   linuxPackages_hdr # recommended option: chaotic.linux_hdr.specialisation.enable
   luxtorpeda # recommended option: chaotic.steam.extraCompatPackages
   mangohud_git

--- a/devshells/failures.nix
+++ b/devshells/failures.nix
@@ -1,10 +1,18 @@
 {
-  "linuxPackages_cachyos.dpdk" = "/nix/store/2jzsmdvi7j0rwmqlh4dxlynpfv4gbaqf-dpdk-22.11.1-6.3.9";
-  "linuxPackages_cachyos.evdi" = "/nix/store/bs6x4x3g0sqbsk56904g5i1rqbdvfcb5-evdi-unstable-2022-10-13";
-  "linuxPackages_cachyos.isgx" = "/nix/store/iy1yfc1l2qjs9xir8maa6bcdjdsd40ci-isgx-2.14-6.3.9";
-  "linuxPackages_cachyos.lttng-modules" = "/nix/store/xxjmdih9bq4nxca1h5sxzyqijys71al9-lttng-modules-6.3.9-2.13.8";
-  "linuxPackages_cachyos.mba6x_bl" = "/nix/store/4sbm3rir1ay5v9z1b89a355zl5rx2xkw-mba6x_bl-unstable-2016-12-08";
-  "linuxPackages_cachyos.system76-acpi" = "/nix/store/kx0jlv0fng1ddilb5cpr2rk8pbzzlmim-system76-acpi-module-1.0.2-6.3.9";
+  "linuxPackages_cachyos.ax99100" = "/nix/store/zwnmmz6rra1iv6vkqad17gk5ypzm3yrk-ax99100-1.8.0";
+  "linuxPackages_cachyos.ddcci-driver" = "/nix/store/s4vk767xs3ci74wq0zr8v13s8kqp9730-ddcci-driver-6.4-0.4.3";
+  "linuxPackages_cachyos.dpdk" = "/nix/store/srxvb8frzpadpn6vlqww0m18nlfpacrj-dpdk-22.11.1-6.4";
+  "linuxPackages_cachyos.evdi" = "/nix/store/qaqqmbvwp0vzdbcq8qff5rf8bd7csrrv-evdi-unstable-2022-10-13";
+  "linuxPackages_cachyos.isgx" = "/nix/store/2sqm21j9jgwp52xzx6dfqldb8sjl3b10-isgx-2.14-6.4";
+  "linuxPackages_cachyos.kvmfr" = "/nix/store/m9hy6pjsn23d0y1s30qhgnickg093rn3-kvmfr-B6";
+  "linuxPackages_cachyos.lttng-modules" = "/nix/store/4vjlfmnay7afp9is2hpi4jizmgql2p5s-lttng-modules-6.4-2.13.8";
+  "linuxPackages_cachyos.mba6x_bl" = "/nix/store/wxgnxlnf9dri8wi3rxxrsw4c9szvinwq-mba6x_bl-unstable-2016-12-08";
+  "linuxPackages_cachyos.mbp2018-bridge-drv" = "/nix/store/bx3l9y7vlfk4sb5d0cb9q3jba7wlsk89-mbp2018-bridge-drv-2020-01-31";
+  "linuxPackages_cachyos.openafs" = "/nix/store/00sdinf7f5ls7q6br29rb2r9yl27lwnb-openafs-1.8.9-6.4.0-cachyos";
+  "linuxPackages_cachyos.system76-acpi" = "/nix/store/vkqxsk15lqhpp0pd2dj4j8p0p37jajdb-system76-acpi-module-1.0.2-6.4";
+  "linuxPackages_cachyos.tp_smapi" = "/nix/store/ydsx9dj4sk064r551pszfrgi8f0zkd2y-tp_smapi-0.43-6.4";
+  "linuxPackages_cachyos.tuxedo-keyboard" = "/nix/store/n6nzzdhxgzh7ka1s5shx4aa3x96ai00f-tuxedo-keyboard-6.4-3.2.5";
+  "linuxPackages_cachyos.virtualboxGuestAdditions" = "/nix/store/x2d5269pynwsy7jqxhqqpvgwmphpsdxb-VirtualBox-GuestAdditions-7.0.8-6.4";
   "linuxPackages_hdr.mba6x_bl" = "/nix/store/5q76s0sh5aim887x6bgnjkzzvm5jz00m-mba6x_bl-unstable-2016-12-08";
   "linuxPackages_hdr.virtualboxGuestAdditions" = "/nix/store/gy6k6n758941qws0can16v26lqbh0lnp-VirtualBox-GuestAdditions-7.0.8-6.0-unstable-2023-01-17";
 }

--- a/pkgs/linux-cachyos/versions.nix
+++ b/pkgs/linux-cachyos/versions.nix
@@ -3,18 +3,18 @@
   suffix = "-cachyos";
 
   # pkgver from config's PKGBUILD
-  linux.version = "6.3.9";
-  linux.hash = "sha256-QezyE5mxerhRY3ULoiNH0JtU+gmbgLY9Di7wBmEpsT4=";
+  linux.version = "6.4";
+  linux.hash = "sha256-j6BYjwws7KRMrHeg45ukjJ8AprncaXYcAqXT76yNp/M=";
 
   # latest commit from https://github.com/CachyOS/linux-cachyos/commits/master/linux-cachyos
-  config.rev = "42a11163665d0ff8dff6d203fabf9158f26f4680";
-  config.hash = "sha256-D5sJ14hfo7E8ky4kwGmNbqPXvahbdYCPDHHk2yi12WQ=";
+  config.rev = "b8fc9c26a208bce373c656a2ac95a66022ee31b4";
+  config.hash = "sha256-V9WG33zsta7McjqMAh6sTVb/N11H0nRRf5ajRVVr5Uc=";
 
   # latest commit from https://github.com/CachyOS/kernel-patches/commits/master/6.3
-  patches.rev = "fee3f21363842f7e559a64fe36fabe38be569d3e";
-  patches.hash = "sha256-/r4GxD0ssRhDfcy2Xb5zNKblucTDg4RCietpyTJX8SI=";
+  patches.rev = "2dadc879ebcc27defa7abea41348691212edcd63";
+  patches.hash = "sha256-ePgBb9BugyjbHhv7tkpvHaq691vw6PZ3JOdknaDRs68=";
 
   # search for git+https://github.com/cachyos/zfs.git in config's PKGBUILD
-  zfs.rev = "893549d6259a6904b7c1ee58080eb72acc4ff7aa";
-  zfs.hash = "sha256-t88f2GBeurx7ckwGCbHkC0detpgNS+Tfh13pF+FrRck=";
+  zfs.rev = "f9a2d94c957d0660ad1f4cfbb0a909eb8e6086df";
+  zfs.hash = "sha256-444f2GBeurx7ckwGCbHkC0detpgNS+Tfh13pF+FrRck=";
 }

--- a/pkgs/linux-cachyos/versions.nix
+++ b/pkgs/linux-cachyos/versions.nix
@@ -16,5 +16,5 @@
 
   # search for git+https://github.com/cachyos/zfs.git in config's PKGBUILD
   zfs.rev = "f9a2d94c957d0660ad1f4cfbb0a909eb8e6086df";
-  zfs.hash = "sha256-444f2GBeurx7ckwGCbHkC0detpgNS+Tfh13pF+FrRck=";
+  zfs.hash = "sha256-XCbFDlxowkmKDv71u00+FwBukqmMBsmY7p0BDe+IWWM=";
 }


### PR DESCRIPTION
### :fish: What?

Bumps `linux_cachyos`

### :fishing_pole_and_fish: Why?

We like having the latest version of stuff.