### PR TITLE
bytecode-viewer_git: init at unstable-20230721003750-eda6416

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,22 @@
 {
   "nodes": {
+    "bytecode-viewer-git-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1689899870,
+        "narHash": "sha256-DBggGJDJp2P0jJVhyW+lxT+16PXoN9CY4bQzVZPE5wQ=",
+        "owner": "Konloch",
+        "repo": "bytecode-viewer",
+        "rev": "eda6416609c2f2833b17608f6d58f3cd7c574cd9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "Konloch",
+        "ref": "master",
+        "repo": "bytecode-viewer",
+        "type": "github"
+      }
+    },
     "compare-to": {
       "locked": {
         "lastModified": 1682262834,
@@ -139,6 +156,7 @@
     },
     "root": {
       "inputs": {
+        "bytecode-viewer-git-src": "bytecode-viewer-git-src",
         "compare-to": "compare-to",
         "gamescope-git-src": "gamescope-git-src",
         "home-manager": "home-manager",

--- a/flake.nix
+++ b/flake.nix
@@ -16,6 +16,11 @@
     # --- PKGS SOURCES ---
     # Please, sort them in alphabetical order
 
+    bytecode-viewer-git-src = {
+      url = "github:Konloch/bytecode-viewer/master";
+      flake = false;
+    };
+
     input-leap-git-src = {
       url = "github:input-leap/input-leap/master";
       flake = false;

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -73,6 +73,10 @@ in
     { enableAppletSymlinks = false; }
     (overrideDescription (old: old + " (without applets' symlinks)"));
 
+  bytecode-viewer_git = final.callPackage ../pkgs/bytecode-viewer {
+    inherit (flakes) bytecode-viewer-git-src;
+  };
+
   dr460nized-kde-theme = final.callPackage ../pkgs/dr460nized-kde-theme { };
 
   droid-sans-mono-nerdfont = multiOverrides

--- a/pkgs/bytecode-viewer/default.nix
+++ b/pkgs/bytecode-viewer/default.nix
@@ -1,0 +1,27 @@
+{ lib, bytecode-viewer-git-src, jre, nyxUtils, makeWrapper, maven }:
+
+maven.buildMavenPackage rec {
+  pname = "bytecode-viewer";
+  version = nyxUtils.gitToVersion bytecode-viewer-git-src;
+
+  src = bytecode-viewer-git-src;
+
+  mvnHash = "sha256-VHepIRJGTj6gPKtsDgOHXTtw2dklwi2mALTaWzto/S4=";
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  installPhase = ''
+    mkdir -p $out/bin $out/lib/bytecode-viewer
+    install -Dm644 target/Bytecode-Viewer-*.jar $out/lib/bytecode-viewer/bytecode-viewer.jar
+
+    makeWrapper ${jre}/bin/java $out/bin/bytecode-viewer \
+      --add-flags "-jar $out/lib/bytecode-viewer/bytecode-viewer.jar"
+  '';
+
+  meta = with lib; {
+    description = "An advanced yet user friendly Java reverse engineering suite";
+    homepage = "https://bytecodeviewer.com/";
+    license = licenses.gpl3Plus;
+    maintainers = with maintainers; [ pedrohlc ];
+  };
+}


### PR DESCRIPTION
### :fish: What?

Add `bytecode-viewer_git` package.

### :fishing_pole_and_fish: Why?

They don't do newer release in a year, mostly it only had dependencies bumps, but I prefer that.