### PR TITLE
ci: don't publish if any package fails

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -119,9 +119,9 @@ jobs:
               core.setFailed("Build failures found!")
               // Check if github actions triggered the event
               if (process.env.ACTOR == "github-actions[bot]")
-                extratext = `\nToo many build failures to deploy! Consider adding failed builds to devshells/failures.nix @chaotic-cx/nyxers`
+                extratext = `\nNew build failures found! Consider adding failed builds to devshells/failures.nix @chaotic-cx/nyxers`
               else
-                extratext = `\nToo many build failures to deploy! Consider adding failed builds to devshells/failures.nix @${process.env.ACTOR}`
+                extratext = `\nNew build failures found! Consider adding failed builds to devshells/failures.nix @${process.env.ACTOR}`
               github.rest.repos.createCommitComment({
                 owner: context.repo.owner,
                 repo: context.repo.repo,

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -116,14 +116,12 @@ jobs:
           script: |
             if (process.env.FAILED_BUILDS_COUNT > 0) {
               var extratext = "";
-              if (process.env.FAILED_BUILDS_COUNT > 3) {
-                core.setFailed("Too many build failures to deploy!")
-                // Check if github actions triggered the event
-                if (process.env.ACTOR == "github-actions[bot]")
-                  extratext = `\nToo many build failures to deploy! Consider adding failed builds to devshells/failures.nix @chaotic-cx/nyxers`
-                else
-                  extratext = `\nToo many build failures to deploy! Consider adding failed builds to devshells/failures.nix @${process.env.ACTOR}`
-              }
+              core.setFailed("Build failures found!")
+              // Check if github actions triggered the event
+              if (process.env.ACTOR == "github-actions[bot]")
+                extratext = `\nToo many build failures to deploy! Consider adding failed builds to devshells/failures.nix @chaotic-cx/nyxers`
+              else
+                extratext = `\nToo many build failures to deploy! Consider adding failed builds to devshells/failures.nix @${process.env.ACTOR}`
               github.rest.repos.createCommitComment({
                 owner: context.repo.owner,
                 repo: context.repo.repo,


### PR DESCRIPTION
### :fish: What?

Don't publish our cache if any of the builds failed.

### :fishing_pole_and_fish: Why?

We can always descriptively skip failures with our `devshell/failures.nix`