### PR TITLE
document: fix responsiveness

### DIFF
--- a/devshells/document.nix
+++ b/devshells/document.nix
@@ -186,6 +186,8 @@ writeText "chaotic-documented.html" ''
         :root { font-family: 'Inter var', sans-serif; }
       }
       body .gridjs-search, body .gridjs-search-input { width: 100%; }
+      pre { overflow: auto; }
+      img { max-width: 100%; }
     </style>
     <noscript><style>.noscript-table { display: table; }</style></noscript>
   </head><body><div style="max-width: 1100px; margin: 0 auto">


### PR DESCRIPTION
### :fish: What?

1. Make code have `overflow: auto`;
2. Make images have `max-width: 100%`.

### :fishing_pole_and_fish: Why?

This fixes responsiveness, and makes it more similar to GitHub's preview.