### PR TITLE
nixos/mesa-git: add DM env; add half-baked virgl-based VM nixosTest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
-.env
-result
-result-*
+/.env
+/.nixos-test-history
+/result
+/result-*

--- a/modules/nixos/mesa-git.nix
+++ b/modules/nixos/mesa-git.nix
@@ -22,7 +22,13 @@ let
     ];
   };
 
-  methodBackend = {
+  methodBackend =
+  let
+    variables = {
+      GBM_BACKENDS_PATH = "/run/opengl-driver/lib/gbm";
+      GBM_BACKEND = pkgs.mesa_git.gbmBackend;
+    };
+  in {
     hardware.opengl = with lib; {
       enable = mkForce true;
       package = mkForce pkgs.mesa_git.drivers;
@@ -34,9 +40,9 @@ let
       setLdLibraryPath = mkForce false;
     };
 
-    environment.sessionVariables = {
-      GBM_BACKENDS_PATH = "/run/opengl-driver/lib/gbm";
-      GBM_BACKEND = pkgs.mesa_git.gbmBackend;
+    systemd.services.display-manager.environment = variables;
+
+    environment.sessionVariables = variables // {
       LD_PRELOAD = [ "${pkgs.mesa_git}/lib/libglapi.so.0" ]; # TODO: find a better solution
     };
   };

--- a/modules/nixos/mesa-git.nix
+++ b/modules/nixos/mesa-git.nix
@@ -23,29 +23,30 @@ let
   };
 
   methodBackend =
-  let
-    variables = {
-      GBM_BACKENDS_PATH = "/run/opengl-driver/lib/gbm";
-      GBM_BACKEND = pkgs.mesa_git.gbmBackend;
-    };
-  in {
-    hardware.opengl = with lib; {
-      enable = mkForce true;
-      package = mkForce pkgs.mesa_git.drivers;
-      package32 = mkForce pkgs.mesa32_git.drivers;
-      extraPackages = mkForce (cfg.extraPackages ++ [ pkgs.mesa_git.gbm ]);
-      extraPackages32 = mkForce cfg.extraPackages32;
-      driSupport = mkForce true;
-      driSupport32Bit = mkForce has32;
-      setLdLibraryPath = mkForce false;
-    };
+    let
+      variables = {
+        GBM_BACKENDS_PATH = "/run/opengl-driver/lib/gbm";
+        GBM_BACKEND = pkgs.mesa_git.gbmBackend;
+      };
+    in
+    {
+      hardware.opengl = with lib; {
+        enable = mkForce true;
+        package = mkForce pkgs.mesa_git.drivers;
+        package32 = mkForce pkgs.mesa32_git.drivers;
+        extraPackages = mkForce (cfg.extraPackages ++ [ pkgs.mesa_git.gbm ]);
+        extraPackages32 = mkForce cfg.extraPackages32;
+        driSupport = mkForce true;
+        driSupport32Bit = mkForce has32;
+        setLdLibraryPath = mkForce false;
+      };
 
-    systemd.services.display-manager.environment = variables;
+      systemd.services.display-manager.environment = variables;
 
-    environment.sessionVariables = variables // {
-      LD_PRELOAD = [ "${pkgs.mesa_git}/lib/libglapi.so.0" ]; # TODO: find a better solution
+      environment.sessionVariables = variables // {
+        LD_PRELOAD = [ "${pkgs.mesa_git}/lib/libglapi.so.0" ]; # TODO: find a better solution
+      };
     };
-  };
 
   chosenMethod =
     lib.mkIf (cfg.method == "replaceRuntimeDependencies") methodReplace

--- a/pkgs/mesa-git/default.nix
+++ b/pkgs/mesa-git/default.nix
@@ -14,10 +14,9 @@ nyxUtils.multiOverride prev.mesa { inherit meson; } (prevAttrs: {
   src = flakes.mesa-git-src;
   buildInputs = prevAttrs.buildInputs ++ (with final; [ libunwind lm_sensors ]);
   mesonFlags =
-    (builtins.map
+    builtins.map
       (builtins.replaceStrings [ "virtio-experimental" ] [ "virtio" ])
-      prevAttrs.mesonFlags
-    );
+      prevAttrs.mesonFlags;
   patches =
     (nyxUtils.removeByBaseName
       "disk_cache-include-dri-driver-path-in-cache-key.patch"

--- a/pkgs/mesa-git/default.nix
+++ b/pkgs/mesa-git/default.nix
@@ -1,4 +1,13 @@
-{ final, flakes, nyxUtils, prev, gbmDriver ? false, gbmBackend ? "dri_git", meson ? final.meson, ... }:
+{ final
+, flakes
+, nyxUtils
+, prev
+, gbmDriver ? false
+, gbmBackend ? "dri_git"
+, meson ? final.meson
+, mesaTestAttrs ? final
+, ...
+}:
 
 nyxUtils.multiOverride prev.mesa { inherit meson; } (prevAttrs: {
   version = builtins.substring 0 (builtins.stringLength prevAttrs.version) flakes.mesa-git-src.rev;
@@ -8,9 +17,7 @@ nyxUtils.multiOverride prev.mesa { inherit meson; } (prevAttrs: {
     (builtins.map
       (builtins.replaceStrings [ "virtio-experimental" ] [ "virtio" ])
       prevAttrs.mesonFlags
-    ) ++ [
-      "-Dandroid-libbacktrace=disabled"
-    ];
+    );
   patches =
     (nyxUtils.removeByBaseName
       "disk_cache-include-dri-driver-path-in-cache-key.patch"
@@ -47,5 +54,11 @@ nyxUtils.multiOverride prev.mesa { inherit meson; } (prevAttrs: {
     '' else prevAttrs.postInstall;
   passthru = prevAttrs.passthru // {
     inherit gbmBackend;
+    tests.smoke-test = import ./test.nix
+      {
+        inherit (flakes) nixpkgs;
+        chaotic = flakes.self;
+      }
+      mesaTestAttrs;
   };
 })

--- a/pkgs/mesa-git/test.nix
+++ b/pkgs/mesa-git/test.nix
@@ -1,8 +1,8 @@
 { nixpkgs
 , chaotic
-, testingDM ? "sddm"
-, testingDE ? "plasma5"
-, testingSession ? "plasma"
+, testingDM ? "gdm" # "sddm"
+, testingDE ? "gnome" # "plasma5"
+, testingSession ? "gnome" # "plasma"
 }:
 
 import "${nixpkgs}/nixos/tests/make-test-python.nix" ({ pkgs, ... }: {
@@ -16,15 +16,12 @@ import "${nixpkgs}/nixos/tests/make-test-python.nix" ({ pkgs, ... }: {
     ];
     chaotic.mesa-git.enable = true;
 
-    virtualisation = {
-      resolution = { x = 800; y = 1280; };
-      qemu.options = [
-        "-m 16G"
-        "-vga none"
-        "-device virtio-vga-gl,xres=800,yres=1280"
-        "-display gtk,gl=on"
-      ];
-    };
+    virtualisation.qemu.options = [
+      "-m 16G"
+      "-vga none"
+      "-device virtio-vga-gl"
+      "-display gtk,gl=on"
+    ];
 
     environment.systemPackages = with pkgs; [
       vulkan-tools

--- a/pkgs/mesa-git/test.nix
+++ b/pkgs/mesa-git/test.nix
@@ -1,0 +1,54 @@
+{ nixpkgs
+, chaotic
+, testingDM ? "sddm"
+, testingDE ? "plasma5"
+, testingSession ? "plasma"
+}:
+
+import "${nixpkgs}/nixos/tests/make-test-python.nix" ({ pkgs, ... }: {
+  name = "mesa-git";
+  meta.maintainers = with pkgs.lib.maintainers; [ pedrohlc ];
+
+  nodes.machine = { pkgs, ... }: {
+    imports = [
+      chaotic.nixosModules.default
+      "${nixpkgs}/nixos/tests/common/user-account.nix"
+    ];
+    chaotic.mesa-git.enable = true;
+
+    virtualisation = {
+      resolution = { x = 800; y = 1280; };
+      qemu.options = [
+        "-m 16G"
+        "-vga none"
+        "-device virtio-vga-gl,xres=800,yres=1280"
+        "-display gtk,gl=on"
+      ];
+    };
+
+    environment.systemPackages = with pkgs; [
+      vulkan-tools mesa-demos alacritty
+    ];
+
+    services.xserver = {
+      enable = true;
+      displayManager = {
+        "${testingDM}".enable = true;
+        autoLogin = {
+          enable = true;
+          user = "alice";
+        };
+        defaultSession = testingSession;
+      };
+      desktopManager.${testingDE}.enable = true;
+    };
+  };
+
+  testScript = { nodes, ... }:
+    let
+      user = nodes.machine.users.users.alice;
+    in
+    ''
+      start_all()
+    '';
+})

--- a/pkgs/mesa-git/test.nix
+++ b/pkgs/mesa-git/test.nix
@@ -27,7 +27,9 @@ import "${nixpkgs}/nixos/tests/make-test-python.nix" ({ pkgs, ... }: {
     };
 
     environment.systemPackages = with pkgs; [
-      vulkan-tools mesa-demos alacritty
+      vulkan-tools
+      mesa-demos
+      alacritty
     ];
 
     services.xserver = {

--- a/pkgs/mesa-git/test.nix
+++ b/pkgs/mesa-git/test.nix
@@ -43,10 +43,8 @@ import "${nixpkgs}/nixos/tests/make-test-python.nix" ({ pkgs, ... }: {
     };
   };
 
-  testScript = { nodes, ... }:
-    let
-      user = nodes.machine.users.users.alice;
-    in
+  # TODO: TODO
+  testScript = _:
     ''
       start_all()
     '';


### PR DESCRIPTION
### :fish: What?

1. add DM env to mesa-git module;
2. add half-baked virgl-based VM nixosTest to mesa-git;
3. remove upstreamed `"-Dandroid-libbacktrace=disabled"`.

### :fishing_pole_and_fish: Why?

- (1) Related to #260;
- (2) What I used to test (1);
- (3) upstreamed - no longer necessary.