### PR TITLE
nixos/linux-hdr: re-add gamescope WSI files

### DIFF
--- a/modules/nixos/linux_hdr.nix
+++ b/modules/nixos/linux_hdr.nix
@@ -1,6 +1,19 @@
 { config, lib, pkgs, ... }:
 let
   cfg = config.chaotic;
+
+  gamescopeWSI =
+    pkgs.stdenvNoCC.mkDerivation {
+      pname = "VkLayer_FROG_gamescope_wsi";
+      version = config.programs.gamescope.package.version;
+      dontUnpack = true;
+      dontConfigure = true;
+      dontBuild = true;
+      installPhase = ''
+        mkdir -p $out/share
+        cp -r ${config.programs.gamescope.package}/share/vulkan $out/share/vulkan
+      '';
+    };
 in
 {
   options = {
@@ -26,6 +39,8 @@ in
           enable = true; # HDR can't be used with other WM right now...
           args = [ "--hdr-enabled" ];
         };
+        chaotic.mesa-git.extraPackages = [ gamescopeWSI ];
+        hardware.opengl.extraPackages = [ gamescopeWSI ];
       };
     };
   };

--- a/modules/nixos/linux_hdr.nix
+++ b/modules/nixos/linux_hdr.nix
@@ -5,7 +5,7 @@ let
   gamescopeWSI =
     pkgs.stdenvNoCC.mkDerivation {
       pname = "VkLayer_FROG_gamescope_wsi";
-      version = config.programs.gamescope.package.version;
+      inherit (config.programs.gamescope.package) version;
       dontUnpack = true;
       dontConfigure = true;
       dontBuild = true;


### PR DESCRIPTION
### :fish: What?

Re-add the missing `implicit_layer.d/VkLayer_FROG_gamescope_wsi.x86_64.json`.

### :fishing_pole_and_fish: Why?

I lost it when we dropped our gamescope-session module in favor of upstream's.