### PR TITLE
linux_cachyos: add bcachefs patch

### DIFF
--- a/pkgs/linux-cachyos/default.nix
+++ b/pkgs/linux-cachyos/default.nix
@@ -140,6 +140,7 @@ in
       "${patches-src}/${major}/sched/0001-EEVDF-cachy.patch"
       "${patches-src}/${major}/sched/0001-bore-eevdf.patch"
       "${patches-src}/${major}/misc/0001-Add-extra-version-CachyOS.patch"
+      "${patches-src}/${major}/misc/0001-bcachefs.patch"
     ];
 
   extraMeta = { maintainers = with lib; [ maintainers.dr460nf1r3 ]; };


### PR DESCRIPTION
### :fish: What?

1. Add bcachefs support to `linux_cachyos`

Closes #324

Tested in https://github.com/LudovicoPiero/dotfiles/pull/54