### PR TITLE
 nixos/mesa-git: fix and allow to disable safety specialisation 

### DIFF
--- a/devshells/default.nix
+++ b/devshells/default.nix
@@ -26,9 +26,7 @@ let
         {
           allPackages = final;
           homeManagerModule = homeManagerModules.default;
-          nixosModule = nixosModules.default;
           inherit nixpkgs nyxRecursionHelper self;
-          inherit (nixpkgs.lib) nixosSystem;
           inherit (home-manager.lib) homeManagerConfiguration;
         };
       evaluated = overlayFinal.callPackage ./eval.nix

--- a/devshells/default.nix
+++ b/devshells/default.nix
@@ -1,5 +1,4 @@
 { flakes
-, nixosModules
 , homeManagerModules
 , nixpkgs ? flakes.nixpkgs
 , home-manager ? flakes.home-manager

--- a/devshells/document.nix
+++ b/devshells/document.nix
@@ -2,8 +2,6 @@
 , homeManagerConfiguration
 , homeManagerModule
 , lib
-, nixosModule
-, nixosSystem
 , nixpkgs
 , nyxRecursionHelper
 , pkgs
@@ -47,10 +45,7 @@ let
   packagesEvalFlat =
     lib.lists.remove null (lib.lists.flatten packagesEval);
 
-  loadedNixOSModule = nixosSystem {
-    modules = [ nixosModule ];
-    system = "x86_64-linux";
-  };
+  loadedNixOSModule = self._dev.x86_64-linux;
   loadedHomeManagerModule = homeManagerConfiguration {
     modules = [
       {

--- a/devshells/document.nix
+++ b/devshells/document.nix
@@ -6,7 +6,6 @@
 , nyxRecursionHelper
 , pkgs
 , self
-, system
 , writeText
 }:
 let

--- a/flake.nix
+++ b/flake.nix
@@ -42,7 +42,7 @@ rec {
       };
 
     hydraJobs.default = packages;
-    devShells = import ./devshells { inherit packages homeManagerModules nixosModules; flakes = inputs; };
+    devShells = import ./devshells { inherit packages homeManagerModules; flakes = inputs; };
 
     _dev = {
       x86_64-linux =

--- a/modules/nixos/mesa-git.nix
+++ b/modules/nixos/mesa-git.nix
@@ -50,11 +50,6 @@ let
       };
     };
 
-  chosenMethod =
-    lib.mkIf (cfg.method == "replaceRuntimeDependencies") methodReplace
-    //
-    lib.mkIf (cfg.method == "GBM_BACKENDS_PATH") methodBackend;
-
   common = {
     specialisation.stable-mesa.configuration = {
       system.nixos.tags = [ "stable-mesa" ];
@@ -108,7 +103,7 @@ in
         '';
       };
 
-      extraPackages32 = with lib; mkOption {
+      extraPackages32 = mkOption {
         type = types.listOf types.package;
         default = [ ];
         example = literalExpression "with pkgs.pkgsi686Linux; [ pkgs.mesa32_git.opencl intel-media-driver vaapiIntel ]";
@@ -121,5 +116,9 @@ in
     };
   };
 
-  config = lib.mkIf cfg.enable (common // chosenMethod);
+  config = lib.mkIf cfg.enable (lib.mkMerge [
+    common
+    (lib.mkIf (cfg.method == "replaceRuntimeDependencies") methodReplace)
+    (lib.mkIf (cfg.method == "GBM_BACKENDS_PATH") methodBackend)
+  ]);
 }

--- a/modules/nixos/mesa-git.nix
+++ b/modules/nixos/mesa-git.nix
@@ -71,6 +71,16 @@ in
         '';
       };
 
+      fallbackSpecialisation = mkOption {
+        default = true;
+        example = false;
+        type = types.bool;
+        description = ''
+          Whether to add a specialisation with stable Mesa.
+          Recommended.
+        '';
+      };
+
       method =
         mkOption {
           type = types.enum [
@@ -117,7 +127,7 @@ in
   };
 
   config = lib.mkIf cfg.enable (lib.mkMerge [
-    common
+    (lib.mkIf cfg.fallbackSpecialisation common)
     (lib.mkIf (cfg.method == "replaceRuntimeDependencies") methodReplace)
     (lib.mkIf (cfg.method == "GBM_BACKENDS_PATH") methodBackend)
   ]);


### PR DESCRIPTION
### :fish: What?

1. Use `lib.mkMerge` in `nixos/mesa-git`;
2. Allow disabling the fallback specialisation;
3. Re-use `_dev` while making the documentation.

### :fishing_pole_and_fish: Why?

- (1) Fix the issue where the fallback specialisation was not evaluated;
- (2) One might be fearless or have another specialisation doing the same;
- (3) Code de-dup.
