### PR TITLE
hdr: Move args/env to programs.gamescope

### DIFF
--- a/modules/nixos/hdr.nix
+++ b/modules/nixos/hdr.nix
@@ -19,8 +19,8 @@ let
 
   configuration = strength: {
     boot.kernelPackages = strength cfg.kernelPackages;
-    programs.steam.gamescopeSession = {
-      enable = true; # HDR can't be used with other WM right now...
+    programs.steam.gamescopeSession.enable = true; # HDR can only be used with headless Gamescope right now...
+    programs.gamescope = {
       args = [ "--hdr-enabled" ];
       env = {
         DXVK_HDR = "1";


### PR DESCRIPTION
### :fish: What?

The args/env required for HDR that were applied to `steam-gamescope` are now applied to simply `gamescope`.

### :fishing_pole_and_fish: Why?

In order to use HDR with Gamescope, it just needs to be launched headless, Steam isn't necessary. For instance, `gamescope --hdr-enabled -- legendary launch game` is a valid way to play a game in HDR.
