### PR TITLE
nixos/duckdns: IPv6 and timers.target

### DIFF
--- a/modules/nixos/duckdns.nix
+++ b/modules/nixos/duckdns.nix
@@ -104,6 +104,8 @@ in
     };
 
     systemd.timers.duckdns-updater = {
+      description = "DuckDNS updater timer";
+      wantedBy = [ "timers.target" ];
       timerConfig = {
         OnCalendar = cfg.onCalendar;
         Persistent = true;

--- a/modules/nixos/duckdns.nix
+++ b/modules/nixos/duckdns.nix
@@ -94,7 +94,7 @@ in
         ProtectProc = "invisible";
         ProtectSystem = "strict";
         RestrictAddressFamilies = [ "AF_UNIX" "AF_INET" "AF_INET6" ]
-          ++ lib.optionals (cfg.ipv6.enable) [ "AF_NETLINK" ];
+          ++ lib.optionals cfg.ipv6.enable [ "AF_NETLINK" ];
         RestrictNamespaces = true;
         RestrictRealtime = true;
         SystemCallArchitectures = "native";


### PR DESCRIPTION
### :fish: What?

1. support IPv6;
2. add `timers.target`.

### :fishing_pole_and_fish: Why?

Just pulling Kokada's work.