### PR TITLE
flake: adopt yafas

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,6 +2,7 @@
   "nodes": {
     "compare-to": {
       "locked": {
+        "lastModified": 1695341185,
         "narHash": "sha256-htO6DSbWyCgaDkxi7foPjXwJFPzGjVt3RRUbPSpNtZY=",
         "rev": "98b8e330823a3570d328720f87a1153f8a7f2224",
         "revCount": 2,
@@ -15,6 +16,7 @@
     },
     "flake-schemas": {
       "locked": {
+        "lastModified": 1693491534,
         "narHash": "sha256-ifw8Td8kD08J8DxFbYjeIx5naHcDLz7s2IFP3X42I/U=",
         "rev": "c702cbb663d6d70bbb716584a2ee3aeb35017279",
         "revCount": 21,
@@ -33,11 +35,12 @@
         ]
       },
       "locked": {
-        "narHash": "sha256-+hfjJLUMck5G92RVFDZA7LWkR3kOxs5zQ7RPW9t3eM8=",
-        "rev": "408ba13188ff9ce309fa2bdd2f81287d79773b00",
-        "revCount": 3026,
+        "lastModified": 1695738267,
+        "narHash": "sha256-LTNAbTQ96xSj17xBfsFrFS9i56U2BMLpD0BduhrsVkU=",
+        "rev": "0f4e5b4999fd6a42ece5da8a3a2439a50e48e486",
+        "revCount": 3035,
         "type": "tarball",
-        "url": "https://api.flakehub.com/f/pinned/nix-community/home-manager/0.1.3026%2Brev-408ba13188ff9ce309fa2bdd2f81287d79773b00/018ab63a-64c3-7df2-b944-409c2f99bdaf/source.tar.gz"
+        "url": "https://api.flakehub.com/f/pinned/nix-community/home-manager/0.1.3035%2Brev-0f4e5b4999fd6a42ece5da8a3a2439a50e48e486/018ad28d-7d5e-7e9c-ac9d-72ba62472e18/source.tar.gz"
       },
       "original": {
         "type": "tarball",
@@ -46,6 +49,7 @@
     },
     "nixpkgs": {
       "locked": {
+        "lastModified": 1695644571,
         "narHash": "sha256-asS9dCCdlt1lPq0DLwkVBbVoEKuEuz+Zi3DG7pR/RxA=",
         "rev": "6500b4580c2a1f3d0f980d32d285739d8e156d92",
         "revCount": 528952,
@@ -62,7 +66,46 @@
         "compare-to": "compare-to",
         "flake-schemas": "flake-schemas",
         "home-manager": "home-manager",
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "systems": "systems",
+        "yafas": "yafas"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "yafas": {
+      "inputs": {
+        "flake-schemas": [
+          "flake-schemas"
+        ],
+        "systems": [
+          "systems"
+        ]
+      },
+      "locked": {
+        "lastModified": 1695923771,
+        "narHash": "sha256-I0XKO9vk43lOAqp8N+Alo5i9TW/F2FI+zenai2Q3Vqk=",
+        "rev": "081a69e0552d1a886881f8d075cf0075222c1eb5",
+        "revCount": 3,
+        "type": "tarball",
+        "url": "https://api.flakehub.com/f/pinned/UbiqueLambda/yafas/0.1.3%2Brev-081a69e0552d1a886881f8d075cf0075222c1eb5/018adcef-6ebc-7d14-b952-2dc76d4e8d88/source.tar.gz"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://flakehub.com/f/UbiqueLambda/yafas/0.1.3.tar.gz"
       }
     }
   },

--- a/flake.lock
+++ b/flake.lock
@@ -2,7 +2,6 @@
   "nodes": {
     "compare-to": {
       "locked": {
-        "lastModified": 1695341185,
         "narHash": "sha256-htO6DSbWyCgaDkxi7foPjXwJFPzGjVt3RRUbPSpNtZY=",
         "rev": "98b8e330823a3570d328720f87a1153f8a7f2224",
         "revCount": 2,
@@ -16,7 +15,6 @@
     },
     "flake-schemas": {
       "locked": {
-        "lastModified": 1693491534,
         "narHash": "sha256-ifw8Td8kD08J8DxFbYjeIx5naHcDLz7s2IFP3X42I/U=",
         "rev": "c702cbb663d6d70bbb716584a2ee3aeb35017279",
         "revCount": 21,
@@ -35,12 +33,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1695738267,
-        "narHash": "sha256-LTNAbTQ96xSj17xBfsFrFS9i56U2BMLpD0BduhrsVkU=",
-        "rev": "0f4e5b4999fd6a42ece5da8a3a2439a50e48e486",
-        "revCount": 3035,
+        "narHash": "sha256-+hfjJLUMck5G92RVFDZA7LWkR3kOxs5zQ7RPW9t3eM8=",
+        "rev": "408ba13188ff9ce309fa2bdd2f81287d79773b00",
+        "revCount": 3026,
         "type": "tarball",
-        "url": "https://api.flakehub.com/f/pinned/nix-community/home-manager/0.1.3035%2Brev-0f4e5b4999fd6a42ece5da8a3a2439a50e48e486/018ad28d-7d5e-7e9c-ac9d-72ba62472e18/source.tar.gz"
+        "url": "https://api.flakehub.com/f/pinned/nix-community/home-manager/0.1.3026%2Brev-408ba13188ff9ce309fa2bdd2f81287d79773b00/018ab63a-64c3-7df2-b944-409c2f99bdaf/source.tar.gz"
       },
       "original": {
         "type": "tarball",
@@ -49,7 +46,6 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1695644571,
         "narHash": "sha256-asS9dCCdlt1lPq0DLwkVBbVoEKuEuz+Zi3DG7pR/RxA=",
         "rev": "6500b4580c2a1f3d0f980d32d285739d8e156d92",
         "revCount": 528952,

--- a/flake.lock
+++ b/flake.lock
@@ -69,7 +69,6 @@
     },
     "systems": {
       "locked": {
-        "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
         "owner": "nix-systems",
         "repo": "default",
@@ -92,7 +91,6 @@
         ]
       },
       "locked": {
-        "lastModified": 1695923771,
         "narHash": "sha256-I0XKO9vk43lOAqp8N+Alo5i9TW/F2FI+zenai2Q3Vqk=",
         "rev": "081a69e0552d1a886881f8d075cf0075222c1eb5",
         "revCount": 3,


### PR DESCRIPTION
### :fish: What?

1. Adopt `UbiqueLambda/yafas`;
2. Adopt `nix-systems/default`.

### :fishing_pole_and_fish: Why?

1. To enhance flake's output's readability;
2. To allow overriding supported systems.