### PR TITLE
flake: allow unfreeRedistributable builds

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -18,39 +18,29 @@ rec {
     };
   };
 
-  outputs = { nixpkgs, yafas, ... }@inputs:
-    let
-      overlays.default = import ./overlays { flakes = inputs; };
-      getPackages = pkgs:
-        let
-          overlayFinal = pkgs // ourPackages // { callPackage = pkgs.newScope overlayFinal; };
-          ourPackages = overlays.default overlayFinal pkgs;
-        in
-        ourPackages;
+  outputs = { self, nixpkgs, yafas, ... }@inputs: yafas.withAllSystems nixpkgs
+    (universals: { pkgs, ... }: with universals; {
+      # Exposes the packages created by the overlay.
+      packages = utils.applyOverlay { inherit pkgs; };
 
-    in
-    yafas.withAllSystems nixpkgs
-      (universals: { pkgs, ... }: with universals; {
-        # Just exposes the packages created by the overlay.
-        packages = getPackages pkgs;
+      # I would prefer if we had something stricter, with attribute alphabetical
+      # sorting, and optimized for git's diffing. But this is the closer we have.
+      formatter = pkgs.nixpkgs-fmt;
+    })
+    rec {
+      # To fix `nix show` and FlakeHub
+      schemas = import ./maintenance/schemas { flakes = inputs; };
 
-        # I would prefer if we had something stricter, with attribute alphabetical
-        # sorting, and optimized for git's diffing. But this is the closer we have.
-        formatter = pkgs.nixpkgs-fmt;
-      })
-      rec {
-        # To fix `nix show` and FlakeHub
-        schemas = import ./maintenance/schemas { flakes = inputs; };
+      # The stars: our overlay and our modules.
+      overlays.default = import ./overlays { flakes = inputs; selfOverlay = overlays.default; };
+      nixosModules = import ./modules/nixos { flakes = inputs; };
+      homeManagerModules = import ./modules/home-manager { flakes = inputs; };
 
-        # The stars: our overlay and our modules.
-        inherit overlays;
-        nixosModules = import ./modules/nixos { flakes = inputs; };
-        homeManagerModules = import ./modules/home-manager { flakes = inputs; };
-
-        # Dev stuff.
-        devShells = import ./maintenance/dev-shells { flakes = inputs; };
-        _dev = import ./maintenance/dev { flakes = inputs; inherit nixConfig getPackages; };
-      };
+      # Dev stuff.
+      utils = import ./shared/utils.nix { lib = nixpkgs.lib; nyxOverlay = overlays.default; };
+      devShells = import ./maintenance/dev-shells { flakes = inputs; };
+      _dev = import ./maintenance/dev { flakes = inputs; inherit nixConfig utils; };
+    };
 
   # Allows the user to use our cache when using `nix run <thisFlake>`.
   nixConfig = {

--- a/flake.nix
+++ b/flake.nix
@@ -18,7 +18,7 @@ rec {
     };
   };
 
-  outputs = { self, nixpkgs, yafas, ... }@inputs: yafas.withAllSystems nixpkgs
+  outputs = { nixpkgs, yafas, ... }@inputs: yafas.withAllSystems nixpkgs
     (universals: { pkgs, ... }: with universals; {
       # Exposes the packages created by the overlay.
       packages = utils.applyOverlay { inherit pkgs; };
@@ -37,7 +37,7 @@ rec {
       homeManagerModules = import ./modules/home-manager { flakes = inputs; };
 
       # Dev stuff.
-      utils = import ./shared/utils.nix { lib = nixpkgs.lib; nyxOverlay = overlays.default; };
+      utils = import ./shared/utils.nix { nyxOverlay = overlays.default; inherit (nixpkgs) lib; };
       devShells = import ./maintenance/dev-shells { flakes = inputs; };
       _dev = import ./maintenance/dev { flakes = inputs; inherit nixConfig utils; };
     };

--- a/maintenance/dev-shells/default.nix
+++ b/maintenance/dev-shells/default.nix
@@ -2,9 +2,9 @@
 , homeManagerModules ? self.homeManagerModules
 , nixpkgs ? flakes.nixpkgs
 , home-manager ? flakes.home-manager
-, packages ? self.packages
+, packages ? self._dev.packages
 , self ? flakes.self
-, nyxosConfiguration ? self._dev.x86_64-linux
+, nyxosConfiguration ? self._dev.system.x86_64-linux
 }:
 
 # The following shells are used to help our maintainers and CI/CDs.

--- a/maintenance/dev/default.nix
+++ b/maintenance/dev/default.nix
@@ -1,4 +1,4 @@
-{ flakes, nixConfig, getPackages, self ? flakes.self }: flakes.yafas.withAllSystems { }
+{ flakes, nixConfig, utils, self ? flakes.self }: flakes.yafas.withAllSystems { }
   (universals: { system, ... }:
   let
     pkgs = import flakes.nixpkgs {
@@ -10,7 +10,7 @@
     };
   in
   with universals; {
-    packages = getPackages pkgs;
+    packages = utils.applyOverlay { inherit pkgs; };
     nixpkgs = pkgs;
     system = flakes.nixpkgs.lib.nixosSystem {
       modules = [ self.nixosModules.default ];

--- a/maintenance/dev/default.nix
+++ b/maintenance/dev/default.nix
@@ -1,0 +1,22 @@
+{ flakes, nixConfig, getPackages, self ? flakes.self }: flakes.yafas.withAllSystems { }
+  (universals: { system, ... }:
+  let
+    pkgs = import flakes.nixpkgs {
+      inherit system;
+      config = {
+        allowlistedLicenses = [ flakes.nixpkgs.lib.licenses.unfreeRedistributable ];
+        nvidia.acceptLicense = true;
+      };
+    };
+  in
+  with universals; {
+    packages = getPackages pkgs;
+    nixpkgs = pkgs;
+    system = flakes.nixpkgs.lib.nixosSystem {
+      modules = [ self.nixosModules.default ];
+      system = "x86_64-linux";
+    };
+  })
+{
+  inherit nixConfig;
+}

--- a/maintenance/failures.nix
+++ b/maintenance/failures.nix
@@ -5,6 +5,7 @@
   "linuxPackages_cachyos.kvdo" = "/nix/store/vnjzilphpk8pv4djpbh6wbmfszsvg8k0-kvdo-8.2.1.6";
   "linuxPackages_cachyos.mba6x_bl" = "/nix/store/cqjz4brifzvgprmzb132wbajawr35zrj-mba6x_bl-unstable-2017-12-30";
   "linuxPackages_cachyos.mbp2018-bridge-drv" = "/nix/store/cwb0nqz972knv6fr38mps4bir0bfhw2d-mbp2018-bridge-drv-2020-01-31";
+  "linuxPackages_cachyos.nvidia_dc" = "/nix/store/rdmaclk48m7p3r6ysgd1gvkg940p9i3x-nvidia-dc-520.61.05-6.5.5";
   "linuxPackages_cachyos.openafs" = "/nix/store/6l1pnbi5q5bjfb1k73qjvi0c6w4d713l-openafs-1.8.10-6.5.5-cachyos";
   "linuxPackages_cachyos.system76-acpi" = "/nix/store/pcsc4pf7ghj7zxkclq4gncl46imckvv7-system76-acpi-module-1.0.2-6.5.5";
   "linuxPackages_cachyos.virtio_vmmci" = "/nix/store/8d0lajiirnra6i4n9msz2sxrzp7n42b9-virtio_vmmci";

--- a/maintenance/schemas/default.nix
+++ b/maintenance/schemas/default.nix
@@ -66,4 +66,18 @@
     '';
     inventory = import ./packages/inventory.nix { inherit nixpkgs; };
   };
+  utils = {
+    version = 1;
+    doc = ''
+      Pack of functions that are useful for Chaotic-Nyx and might become useful for you too.
+    '';
+    inventory = output: {
+      children = builtins.mapAttrs
+        (name: value: {
+          what = "lamdda";
+          evalChecks.isDerivation = false;
+        })
+        (builtins.removeAttrs output [ "_description" ]);
+    };
+  };
 }

--- a/maintenance/schemas/default.nix
+++ b/maintenance/schemas/default.nix
@@ -55,7 +55,7 @@
       The `nixosModules` flake output contains the modules and options we support for NixOS setups.
     '';
     inventory = import ./nixos-modules/inventory.nix {
-      nyxosConfiguration = self._dev.${baseSystem};
+      nyxosConfiguration = self._dev.system.${baseSystem};
       pkgs = nixpkgs.legacyPackages.${baseSystem};
     };
   };

--- a/maintenance/schemas/default.nix
+++ b/maintenance/schemas/default.nix
@@ -73,7 +73,7 @@
     '';
     inventory = output: {
       children = builtins.mapAttrs
-        (name: value: {
+        (_name: _value: {
           what = "lamdda";
           evalChecks.isDerivation = false;
         })

--- a/maintenance/schemas/packages/inventory.nix
+++ b/maintenance/schemas/packages/inventory.nix
@@ -1,12 +1,10 @@
 { nixpkgs }: output:
 let
-  mkPackages = final: prev:
+  mkPackages = nyxPkgs:
     let
-      inherit (prev) lib;
+      inherit (nixpkgs) lib;
 
-      overlayFinal = prev // final // { callPackage = prev.newScope final; };
-
-      nyxRecursionHelper = overlayFinal.callPackage ../../../shared/recursion-helper.nix { };
+      nyxRecursionHelper = import ../../../shared/recursion-helper.nix { inherit lib; };
 
       derivationMap = k: v:
         {
@@ -32,7 +30,7 @@ let
           };
         };
 
-      packagesEval = nyxRecursionHelper.derivationsLimited "explicit" derivationWarn derivationMap final;
+      packagesEval = nyxRecursionHelper.derivationsLimited "explicit" derivationWarn derivationMap nyxPkgs;
 
       packagesEvalFlat =
         lib.lists.remove null (lib.lists.flatten packagesEval);
@@ -44,8 +42,7 @@ in
   children = {
     x86_64-linux.forSystems = [ "x86_64-linux" ];
     x86_64-linux.children =
-      mkPackages output.x86_64-linux
-        nixpkgs.legacyPackages.x86_64-linux;
+      mkPackages output.x86_64-linux;
     aarch64-linux = {
       forSystems = [ "aarch64-linux" ];
       what = "broken";

--- a/maintenance/tools/builder/default.nix
+++ b/maintenance/tools/builder/default.nix
@@ -12,6 +12,7 @@
 , nix
 , nyxUtils
 , writeShellScriptBin
+, hostPlatform
 }:
 let
   Jq = "${jq}/bin/jq";
@@ -166,7 +167,7 @@ writeShellScriptBin "chaotic-nyx-build" ''
   function build() {
     _WHAT="''${1:- アンノーン}"
     _MAIN_OUT_PATH="''${2:-/dev/null}"
-    _FULL_TARGETS=("''${_ALL_OUT_KEYS[@]/#/$NYX_SOURCE\#}")
+    _FULL_TARGETS=("''${_ALL_OUT_KEYS[@]/#/$NYX_SOURCE\#_dev.packages.${hostPlatform.system}.}")
     echo -n "* $_WHAT..."
     # If NYX_CHANGED_ONLY is set, only build changed derivations
     if [ -f filter.txt ] && ! ${Grep} -Pq "^$_WHAT\$" filter.txt; then

--- a/modules/common/nyx-overlay.nix
+++ b/modules/common/nyx-overlay.nix
@@ -22,13 +22,8 @@ let
             inherit (cfg.flakeNixpkgs) config;
             localSystem = stdenv.hostPlatform;
           };
-
-      # NOTE: "prev" overrides "ourPackages", since we don't want to
-      # replace anything in nixpkgs, but only add new packages to it.
-      overlayFinal = ourPackages // prev // { callPackage = prev.newScope overlayFinal; };
-      ourPackages = flakes.self.overlays.default overlayFinal prev;
     in
-    ourPackages;
+    flakes.self.utils.applyOverlay { pkgs = prev; };
 
   onTopOfUserPkgs =
     flakes.self.overlays.default;

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -9,13 +9,13 @@
 # NOTE:
 # - `*_next` packages will be removed once merged into nixpkgs-unstable.
 
-{ flakes }: final: prev:
+{ flakes, selfOverlay }: final: prev:
 let
   # Required to load version files.
   inherit (final.lib.trivial) importJSON;
 
   # Our utilities/helpers.
-  nyxUtils = import ../shared/utils.nix { inherit (final) lib; };
+  nyxUtils = import ../shared/utils.nix { inherit (final) lib; nyxOverlay = selfOverlay; };
   inherit (nyxUtils) dropAttrsUpdateScript dropUpdateScript multiOverride multiOverrides overrideDescription;
 
   # Helps when calling .nix that will override packages.

--- a/shared/recursion-helper.nix
+++ b/shared/recursion-helper.nix
@@ -21,7 +21,9 @@ rec {
           (if lib.attrsets.isDerivation v then
             (if (v.meta.broken or true) then
               warnFn fullKey v "marked broken"
-            else if (v.meta.unfree or true) then
+            # In case we get issues with custom licenses at a later date or we need to remove nvidia.acceptLicense
+            # else if (v.meta.unfree or true && !(v.meta.license == lib.licenses.unfreeRedistributable && (!(v ? src) || (builtins.tryEval v.src).success))) then
+            else if (v.meta.unfree or true && !(v.meta.nyx.bypassLicense or false) && v.meta.license != lib.licenses.unfreeRedistributable) then
               warnFn fullKey v "unfree"
             else
               mapFn fullKey v

--- a/shared/recursion-helper.nix
+++ b/shared/recursion-helper.nix
@@ -21,9 +21,7 @@ rec {
           (if lib.attrsets.isDerivation v then
             (if (v.meta.broken or true) then
               warnFn fullKey v "marked broken"
-            # In case we get issues with custom licenses at a later date or we need to remove nvidia.acceptLicense
-            # else if (v.meta.unfree or true && !(v.meta.license == lib.licenses.unfreeRedistributable && (!(v ? src) || (builtins.tryEval v.src).success))) then
-            else if (v.meta.unfree or true && !(v.meta.nyx.bypassLicense or false) && v.meta.license != lib.licenses.unfreeRedistributable) then
+            else if (v.meta.unfree or true && v.meta.license != lib.licenses.unfreeRedistributable) then
               warnFn fullKey v "unfree"
             else
               mapFn fullKey v

--- a/shared/utils.nix
+++ b/shared/utils.nix
@@ -4,11 +4,11 @@ rec {
   _description = "Pack of functions that are useful for Chaotic-Nyx and might become useful for you too";
 
   # All the ways I found to overlay in nixpkgs
-  applyOverlay = { replace ? false, merge ? false, overlay ? nyxOverlay, pkgs }:
+  applyOverlay = { replace ? false, merge ? false, overlay ? nyxOverlay, nyxPkgs ? null, pkgs }:
     let
-      fullPacakges = if replace then ourPackages // pkgs else pkgs // ourPackages;
-      overlayFinal = pkgs // ourPackages // { callPackage = pkgs.newScope overlayFinal; };
-      ourPackages = overlay overlayFinal pkgs;
+      fullPackages = if replace then pkgs // ourPackages else ourPackages // pkgs;
+      overlayFinal = fullPackages // { callPackage = pkgs.newScope overlayFinal; };
+      ourPackages = if nyxPkgs != null then nyxPkgs else overlay overlayFinal pkgs;
     in
     if merge then overlayFinal else ourPackages;
 

--- a/shared/utils.nix
+++ b/shared/utils.nix
@@ -1,7 +1,16 @@
-{ lib }:
+{ lib, nyxOverlay }:
 rec {
   # For viewing in our documentation page.
   _description = "Pack of functions that are useful for Chaotic-Nyx and might become useful for you too";
+
+  # All the ways I found to overlay in nixpkgs
+  applyOverlay = { replace ? false, merge ? false, overlay ? nyxOverlay, pkgs }:
+    let
+      fullPacakges = if replace then ourPackages // pkgs else pkgs // ourPackages;
+      overlayFinal = pkgs // ourPackages // { callPackage = pkgs.newScope overlayFinal; };
+      ourPackages = overlay overlayFinal pkgs;
+    in
+    if merge then overlayFinal else ourPackages;
 
   # When `removeByBaseName` and `removeByURL` can't help, use this to drop patches.
   dropN = qty: list: lib.lists.take (builtins.length list - qty) list;


### PR DESCRIPTION
### :fish: What?

1. Allowed unfreeRedistributable packages to be built on nyx
2. Refactor _dev

### :fishing_pole_and_fish: Why?

Many things are marked as do not build because they have an unfree license. However, in many cases, these unfree licenses still allow us to redistribute built versions of the package.

### :fish_cake: Pending

- [x] Nothing

### :whale: Extras

- Added meta.nyx.bypassLicense
