### PR TITLE
discord-krisp: init

### DIFF
--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -81,6 +81,8 @@ in
 
   bytecode-viewer_git = final.callPackage ../pkgs/bytecode-viewer-git { };
 
+  discord-krisp = callOverride ../pkgs/discord-krisp { };
+
   dr460nized-kde-theme = final.callPackage ../pkgs/dr460nized-kde-theme { };
 
   droid-sans-mono-nerdfont = multiOverrides

--- a/pkgs/discord-krisp/default.nix
+++ b/pkgs/discord-krisp/default.nix
@@ -1,0 +1,21 @@
+{ prev, ... }:
+let
+  patch-krisp = prev.writeScript "patch-krisp" ''
+    discord_version="${prev.discord.version}"
+    file="$HOME/.config/discord/$discord_version/modules/discord_krisp/discord_krisp.node"
+    if [ -f "$file" ]; then
+    addr=$("${prev.rizin}/bin/rz-find" -x '4881ec00010000' "$file" | head -n1)
+    "${prev.rizin}/bin/rizin" -q -w -c "s $addr + 0x30 ; wao nop" "$file"
+    fi
+  '';
+  binaryName = "Discord";
+in
+prev.discord.overrideAttrs (_: previousAttrs: {
+  postInstall = previousAttrs.postInstall + ''
+    wrapProgramShell $out/opt/${binaryName}/${binaryName} \
+    --run "${patch-krisp}"
+  '';
+  meta = {
+    nyx.bypassLicense = true;
+  };
+})

--- a/pkgs/discord-krisp/default.nix
+++ b/pkgs/discord-krisp/default.nix
@@ -10,7 +10,7 @@ let
   '';
   binaryName = "Discord";
 in
-prev.discord.overrideAttrs (_: previousAttrs: {
+prev.discord.overrideAttrs (previousAttrs: {
   postInstall = previousAttrs.postInstall + ''
     wrapProgramShell $out/opt/${binaryName}/${binaryName} \
     --run "${patch-krisp}"

--- a/shared/recursion-helper.nix
+++ b/shared/recursion-helper.nix
@@ -21,7 +21,7 @@ rec {
           (if lib.attrsets.isDerivation v then
             (if (v.meta.broken or true) then
               warnFn fullKey v "marked broken"
-            else if (v.meta.unfree or true && v.meta.license != lib.licenses.unfreeRedistributable) then
+            else if (v.meta.unfree or true && !(v.meta.nyx.bypassLicense or false) && v.meta.license != lib.licenses.unfreeRedistributable) then
               warnFn fullKey v "unfree"
             else
               mapFn fullKey v


### PR DESCRIPTION
### :fish: What?

1. Added discord-krisp as a new package

### :fishing_pole_and_fish: Why?

- (1) Default nixpkgs discord is not compatible with discord's included krisp, because nix changes the hash of the discord executable, breaking a signature check. This can be solved with a binary byte-patch.
- (2) The binary byte-patch needs to happen during the launch, because the library is downloaded by the discord updater, not retrieved from the binaries that we have direct control over.

### :fish_cake: Pending

- [ ] Wait for PR #361 to get merged.
