### PR TITLE
Fixes for bump 20231007-1

### DIFF
--- a/pkgs/telegram-desktop-git/default.nix
+++ b/pkgs/telegram-desktop-git/default.nix
@@ -26,14 +26,6 @@ gitOverride {
 
   postOverride = prevAttrs: {
     buildInputs = prevAttrs.buildInputs ++ (with final; [ kf6coreaddons_git ]);
-    postPatch = prevAttrs.postPatch + ''
-      (cd Telegram/ThirdParty/libprisma && \
-        patch -p1 < ${final.fetchpatch {
-          url = "https://github.com/desktop-app/libprisma/commit/b9a1ed1a1918b700eb3d140f5047f4f7533421c2.patch";
-          hash = "sha256-3mFQipw7ZH8Usj/38bnXtmVNaGuXrI4VRs8FQ7wbUoI=";
-        }} \
-      )
-    '';
     postFixup = ''
       qtWrapperArgs+=(
         --prefix LD_LIBRARY_PATH : "${final.glib_git.out}/lib"

--- a/pkgs/vulkan-versioned/default.nix
+++ b/pkgs/vulkan-versioned/default.nix
@@ -94,7 +94,11 @@ final.lib.makeScope final.newScope (self:
     key = "vulkanLoader";
     owner = "KhronosGroup";
     repo = "Vulkan-Loader";
-    extraAttrs = prevAttrs: { meta = prevAttrs.meta // { broken = false; }; };
+    extraAttrs = prevAttrs: {
+      meta = prevAttrs.meta // { broken = false; };
+      patches = [ ./fix-pkgconfig.patch ] ++
+        (nyxUtils.removeByBaseName "fix-pkgconfig.patch" prevAttrs.patches);
+    };
   };
 
   vulkan-tools = genericOverride {

--- a/pkgs/vulkan-versioned/fix-pkgconfig.patch
+++ b/pkgs/vulkan-versioned/fix-pkgconfig.patch
@@ -1,0 +1,11 @@
+diff --git a/loader/vulkan.pc.in b/loader/vulkan.pc.in
+index 16b0ded..6f725cc 100644
+--- a/loader/vulkan.pc.in
++++ b/loader/vulkan.pc.in
+@@ -1,4 +1,5 @@
+ Name: Vulkan-Loader
+ Description: Vulkan Loader
+ Version: @VULKAN_LOADER_VERSION@
+-Libs: -L@CMAKE_INSTALL_LIBDIR_PC@ -lvulkan@VULKAN_LIB_SUFFIX@
++Libs: -L@CMAKE_INSTALL_LIBDIR@ -lvulkan@VULKAN_LIB_SUFFIX@
++Cflags: -I@CMAKE_INSTALL_INCLUDEDIR@

--- a/pkgs/vulkan-versioned/latest.json
+++ b/pkgs/vulkan-versioned/latest.json
@@ -62,6 +62,6 @@
     "version": "1.3.261.1",
     "rev": "sdk-#{version}",
     "hash": "sha256-RuRNOJIMG1Tsm6TA2ltOkqm0E4OkeeDIH07TS/b4HGQ=",
-    "badTag": "v1.3.266"
+    "badTag": "v1.3.267"
   }
 }

--- a/pkgs/vulkan-versioned/latest.json
+++ b/pkgs/vulkan-versioned/latest.json
@@ -59,9 +59,9 @@
     "hash": "sha256-YlCf2XCL+qagrmRww87nhHIefLWC1T9HyySCc9yNYX0="
   },
   "vulkanValidationLayers": {
-    "version": "1.3.267",
-    "rev": "v#{version}",
-    "hash": "sha256-aiuTEYot/Cywq8WnGQYhiqzkL6DEMoOMuSsaDO+DwM0=",
+    "version": "1.3.261.1",
+    "rev": "sdk-#{version}",
+    "hash": "sha256-RuRNOJIMG1Tsm6TA2ltOkqm0E4OkeeDIH07TS/b4HGQ=",
     "badTag": "v1.3.266"
   }
 }


### PR DESCRIPTION
### :fish: What?

- Remove one patch;
- Update another patch;
- Skip yet another vulkan-validation-layers while we don't get a new SPIRV tag.


### :fishing_pole_and_fish: Why?

I like to have a release today too, but I'll skip tomorrow, it's Sunday.
