### PR TITLE
bumper: fix exit-code mess

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -33,11 +33,11 @@
         ]
       },
       "locked": {
-        "narHash": "sha256-Tn5feZ5SoYHQM9BTjw5e06DuNu8wc21gC9+bq/kXA8Y=",
-        "rev": "3b67ae3f665379c06999641f99d94dba75b53876",
-        "revCount": 3062,
+        "narHash": "sha256-jCs/ffIP3tUPN7HWWuae4BB8+haAw2NI02z5BQvWMGM=",
+        "rev": "78125bc681d12364cb65524eaa887354134053d0",
+        "revCount": 3064,
         "type": "tarball",
-        "url": "https://api.flakehub.com/f/pinned/nix-community/home-manager/0.1.3062%2Brev-3b67ae3f665379c06999641f99d94dba75b53876/018b3339-224e-7757-9456-aff78b2a0a67/source.tar.gz"
+        "url": "https://api.flakehub.com/f/pinned/nix-community/home-manager/0.1.3064%2Brev-78125bc681d12364cb65524eaa887354134053d0/018b359c-7750-7456-b1a6-df0aaed8259c/source.tar.gz"
       },
       "original": {
         "type": "tarball",

--- a/maintenance/tools/bumper/default.nix
+++ b/maintenance/tools/bumper/default.nix
@@ -57,7 +57,7 @@ writeShellScriptBin "chaotic-nyx-bumper" ''
   NYX_BRANCH=''${NYX_BRANCH:-bump/$NYX_NAME}
 
   function bump-packages() {
-    ${concatStringsSep "\n  " packagesEvalSorted}
+    bump-package 'glib_git' '/nix/store/dbc0hvsq26yk9nza05xb4kwlg6ca0rl1-update-glib-git'
   }
 
   function default-phases () {
@@ -65,8 +65,8 @@ writeShellScriptBin "chaotic-nyx-bumper" ''
     bump-packages
     bump-flake
     push
-    create-pr
-    deploy-cache
+    #create-pr
+    #deploy-cache
   }
 
   PHASES=''${PHASES:-default-phases};

--- a/maintenance/tools/bumper/default.nix
+++ b/maintenance/tools/bumper/default.nix
@@ -53,7 +53,7 @@ writeShellScriptBin "chaotic-nyx-bumper" ''
   NYX_BRANCH=''${NYX_BRANCH:-bump/$NYX_NAME}
 
   function bump-packages() {
-    bump-package 'glib_git' '/nix/store/dbc0hvsq26yk9nza05xb4kwlg6ca0rl1-update-glib-git'
+    ${concatStringsSep "\n  " packagesEvalSorted}
   }
 
   function default-phases () {
@@ -61,8 +61,8 @@ writeShellScriptBin "chaotic-nyx-bumper" ''
     bump-packages
     bump-flake
     push
-    #create-pr
-    #deploy-cache
+    create-pr
+    deploy-cache
   }
 
   PHASES=''${PHASES:-default-phases};

--- a/maintenance/tools/bumper/default.nix
+++ b/maintenance/tools/bumper/default.nix
@@ -4,6 +4,7 @@
 , git
 , gnused
 , nix
+, openssh
 , ripgrep
 , writeShellScriptBin
 , allPackages
@@ -20,6 +21,7 @@ let
     ripgrep
     gnused
     gh
+    openssh
   ];
 
   evalResult = k: v:

--- a/maintenance/tools/bumper/default.nix
+++ b/maintenance/tools/bumper/default.nix
@@ -2,10 +2,8 @@
 , coreutils
 , gh
 , git
-, gnused
 , nix
 , openssh
-, ripgrep
 , writeShellScriptBin
 , allPackages
 , nyxRecursionHelper
@@ -18,8 +16,6 @@ let
     coreutils
     git
     nix
-    ripgrep
-    gnused
     gh
     openssh
   ];

--- a/maintenance/tools/bumper/lib.sh
+++ b/maintenance/tools/bumper/lib.sh
@@ -38,7 +38,7 @@ function bump-package() {
       git revert --no-commit "${_PREV}..${_CURR}"
       git commit -m "Bumping \"$1\" failed"
     else
-      echo "## Exited with $nixReturn"
+      echo "## Exited with $?"
     fi
   fi
 

--- a/maintenance/tools/bumper/lib.sh
+++ b/maintenance/tools/bumper/lib.sh
@@ -1,7 +1,7 @@
 function checkout() {
   git checkout -b "$NYX_BRANCH"
-  #git fetch origin
-  #git reset --hard origin/main
+  git fetch origin
+  git reset --hard origin/main
   return 0
 }
 

--- a/maintenance/tools/bumper/lib.sh
+++ b/maintenance/tools/bumper/lib.sh
@@ -18,7 +18,7 @@ function bump-flake() {
   readarray -t CHANGED < <(git diff | rg -Po '(?<=^     ")([^"]+)(?=": {$)' | sed 's/-src$//;s/-git$//')
   [[ "${#CHANGED[@]}" -lt 1 ]] && return 0
   CHANGED_CSV=$(join_by ', ' "${CHANGED[@]}")
-  git add -u
+  git add flake.lock
   git commit -m "flake-${NYX_NAME}: $CHANGED_CSV"
   return 0
 }

--- a/maintenance/tools/bumper/lib.sh
+++ b/maintenance/tools/bumper/lib.sh
@@ -7,8 +7,8 @@ function join_by { # https://stackoverflow.com/a/17841619
 
 function checkout() {
   git checkout -b "$NYX_BRANCH"
-  git fetch origin
-  git reset --hard origin/main
+  #git fetch origin
+  #git reset --hard origin/main
   return 0
 }
 

--- a/maintenance/tools/bumper/lib.sh
+++ b/maintenance/tools/bumper/lib.sh
@@ -37,9 +37,11 @@ function bump-package() {
     if ! (NYX_CHANGED_ONLY="git+file:$PWD?rev=$_PREV" \
         PHASES='prepare build-jobs no-fail' \
         nix develop --impure -c 'chaotic-nyx-build') \
-        && [ $? -eq 43 ]; then
+        && nixReturn=$? && [ $nixReturn -eq 43 ]; then
       git revert --no-commit "${_PREV}..HEAD"
       git commit -m "Bumping \"$1\" failed"
+    else
+      echo "Exited with $nixReturn"
     fi
   fi
 


### PR DESCRIPTION
### :fish: What?

1. No longer try to list what inputs' bumped;
2. Properly recognize exit codes.

### :fishing_pole_and_fish: Why?

- (1) It was broken;
- (2) It was broken too.