### PR TITLE
mesa_git: 20231017143116-b94b784 -> 20231019143500-4752b18

### DIFF
--- a/pkgs/mesa-git/version.json
+++ b/pkgs/mesa-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20231017143116-b94b784",
-  "rev": "b94b784492640519a37182c300b0872524c78d77",
-  "hash": "sha256-JddHYbDIe+hqIdv1i7OEnnfQ6dHkearEXn8EEG4nGW0="
+  "version": "unstable-20231019143500-4752b18",
+  "rev": "4752b188dc0c48e32a5662509c99b2c1cde29b27",
+  "hash": "sha256-3BPKEXmwyzJqeP9nlXAK8HqzhFo4sVJBCg9om5KIHWg="
 }


### PR DESCRIPTION
No failures here, the builder is just breaking with 32-bits stuff.