### PR TITLE
cachix: only keep two revisions

### DIFF
--- a/maintenance/tools/builder/lib.sh
+++ b/maintenance/tools/builder/lib.sh
@@ -136,7 +136,7 @@ function deploy() {
     # Pin packages
     if [ -e to-pin.txt ]; then
       cat to-pin.txt | xargs -n 2 \
-        cachix -v pin chaotic-nyx
+        cachix -v pin chaotic-nyx --keep-revisions 2
     fi
   else
     echo_error "Nothing to push."


### PR DESCRIPTION
We already abused too much from these unsupervised pins:

![image](https://github.com/chaotic-cx/nyx/assets/1368952/7567d045-bfe9-424f-87de-471956cf2d4b)
