### PR TITLE
pkgsx86_64_v3-core: init

### DIFF
--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -46,7 +46,7 @@ let
       {
         overlays = [
           selfOverlay
-          (self': super': {
+          (_self': super': {
             "pkgsx86_64_${lvl}" = super';
           })
         ] ++ overlays;

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -9,7 +9,7 @@
 # NOTE:
 # - `*_next` packages will be removed once merged into nixpkgs-unstable.
 
-{ flakes, self ? flakes.self, selfOverlay ? self.overlays.default }:
+{ flakes, nixpkgs ? flakes.nixpkgs, self ? flakes.self, selfOverlay ? self.overlays.default }:
 final: prev:
 let
   # Required to load version files and warning.
@@ -39,6 +39,28 @@ let
 
   # Too much variations
   cachyosPackages = callOverride ../pkgs/linux-cachyos/all-packages.nix { };
+
+  # Microarch stuff
+  makeMicroarch = lvl: with final;
+    if stdenv.hostPlatform.isx86 then import "${nixpkgs}"
+      {
+        overlays = [
+          selfOverlay
+          (self': super': {
+            "pkgsx86_64_${lvl}" = super';
+          })
+        ] ++ overlays;
+        ${if stdenv.hostPlatform == stdenv.buildPlatform
+        then "localSystem" else "crossSystem"} = {
+          parsed = stdenv.hostPlatform.parsed // {
+            cpu = lib.systems.parse.cpuTypes.x86_64;
+          };
+          gcc = stdenv.hostPlatform.gcc // {
+            arch = "x86-64-${lvl}";
+          };
+        };
+      } // { recurseForDerivations = false; }
+    else throw "x86_64_${lvl} package set can only be used with the x86 family.";
 in
 {
   inherit nyxUtils;
@@ -152,6 +174,12 @@ in
     openmohaaVersion = importJSON ../pkgs/openmohaa/version.json;
   };
   openmohaa_git = callOverride ../pkgs/openmohaa-git { };
+
+  pkgsx86_64_v2 = makeMicroarch "v2";
+  pkgsx86_64_v3 = makeMicroarch "v3";
+  pkgsx86_64_v4 = makeMicroarch "v4";
+
+  pkgsx86_64_v3-core = import ../shared/core-tier.nix final.pkgsx86_64_v3;
 
   proton-ge-custom = final.callPackage ../pkgs/proton-ge-custom {
     protonGeTitle = "Proton-GE";

--- a/shared/core-tier.nix
+++ b/shared/core-tier.nix
@@ -1,0 +1,19 @@
+pkgs: with pkgs; {
+  # ArchLinux's core skipping efi-related, fs-related, kernel-related, bootloaders,
+  #   text-editors, and network managers. Last synced 2023-11-21
+  inherit acl libargon2 attr audit bash binutils coreutils bison brotli bzip2 cracklib
+    cryptsetup curl dash db dbus debugedit dialog diffutils elfutils expat file findutils
+    flex gawk gcc gdbm gettext glib glibc gpm gnutls gpgme gmp gnugrep groff guile gzip
+    hwdata iana-etc icu inetutils iproute2 iptables iputils jansson jfsutils json_c kbd
+    keyutils kmod krb5 ldns lemon less libaio libarchive libcap libedit libelf libevent
+    libffi libgccjit libgcrypt libgpg-error libgssglue libidn2 inih isl libksba
+    libmicrohttpd libmnl libmpc libnetfilter_conntrack libnfnetlink libnftnl
+    libnghttp2 libnl libnsl libpcap libpipeline libpsl gsasl libseccomp
+    libsecret libssh2 libtasn1 libtirpc libtool libunistring libusb libverto;
+  inherit libxcrypt libxml2 links2 logrotate libgcc lz4 lzo m4 gnumake man-db mdadm
+    minizip mlocate mpfr ncurses nettools npth nspr nss openssl p11-kit patch pciutils
+    pcre pcre2 perl python3 readline rpcbind gnused sqlite gnutar texinfo tzdata
+    util-linux which xz zlib zstd;
+
+  recurseForDerivations = true;
+}


### PR DESCRIPTION
### :fish: What?

Adds `x86-64-v3` builds for the following packages:
```
acl, attr, audit, bash, binutils, bison, brotli, bzip2, coreutils, cracklib, cryptsetup,
curl, dash, db, dbus, debugedit, dialog, diffutils, elfutils, expat, file, findutils,
flex, gawk, gcc, gdbm, gettext, glib, glibc, gmp, gnugrep, gnumake, gnused, gnutar,
gnutls, gpgme, gpm, groff, gsasl, guile, gzip, hwdata, iana, icu, inetutils, inih,
iproute2, iptables, iputils, isl, jansson, jfsutils, json_c, kbd, keyutils, kmod, krb5,
ldns, lemon, less, libaio, libarchive, libargon2, libcap, libedit, libelf, libevent,
libffi, libgcc, libgccjit, libgcrypt, libgpg, libgssglue, libidn2, libksba, libmicrohttpd,
libmnl, libmpc, libnetfilter_conntrack, libnfnetlink, libnftnl, libnghttp2, libnl, libnsl,
libpcap, libpipeline, libpsl, libseccomp, libsecret, libssh2, libtasn1, libtirpc, libtool,
libunistring, libusb, libverto, libxcrypt, libxml2, links2, logrotate, lz4, lzo, m4, man,
mdadm, minizip, mlocate, mpfr, ncurses, nettools, npth, nspr, nss, openssl, p11, patch,
pciutils, pcre2, pcre, perl, python3, readline, rpcbind, sqlite, texinfo, tzdata, util,
which, xz, zlib, zstd
```

### :fishing_pole_and_fish: Why?

Some people are interested in building x86-64-v3 packages (mostly browsers and ffmpeg-based), this should give them the necessary to start.