### PR TITLE
modules: separate nyx-cache

### DIFF
--- a/modules/home-manager/default.nix
+++ b/modules/home-manager/default.nix
@@ -1,7 +1,7 @@
 fromFlakes:
 let
   modulesPerFile = {
-    nyx-cache = import ../common/nyx-cache.nix fromFlakes;
+    nyx-cache = import ./nyx-cache.nix fromFlakes;
     nyx-overlay = import ../common/nyx-overlay.nix fromFlakes;
   };
 

--- a/modules/home-manager/nyx-cache.nix
+++ b/modules/home-manager/nyx-cache.nix
@@ -1,0 +1,25 @@
+{ flakes }: { config, lib, ... }:
+let
+  cfg = config.chaotic.nyx.cache;
+in
+{
+  options = with lib; {
+    chaotic.nyx.cache.enable =
+      mkOption {
+        default = true;
+        example = false;
+        type = types.bool;
+        description = ''
+          Whether to add Chaotic-Nyx's binary cache to settings.
+        '';
+      };
+  };
+  config = {
+    nix.settings = lib.mkIf cfg.enable
+      {
+        inherit (flakes.self._dev.nixConfig)
+          extra-substituters
+          extra-trusted-public-keys;
+      };
+  };
+}

--- a/modules/nixos/default.nix
+++ b/modules/nixos/default.nix
@@ -6,7 +6,7 @@ let
     hdr = import ./hdr.nix;
     mesa-git = import ./mesa-git.nix;
     nordvpn = import ./nordvpn.nix;
-    nyx-cache = import ../common/nyx-cache.nix fromFlakes;
+    nyx-cache = import ./nyx-cache.nix fromFlakes;
     nyx-overlay = import ../common/nyx-overlay.nix fromFlakes;
     steam-compat-tools = import ./steam-compat-tools.nix;
     zfs-impermanence-on-shutdown = import ./zfs-impermanence-on-shutdown.nix;

--- a/modules/nixos/nyx-cache.nix
+++ b/modules/nixos/nyx-cache.nix
@@ -16,14 +16,10 @@ in
   };
   config = {
     nix.settings = lib.mkIf cfg.enable
-      rec {
-        # For Non-NixOS
-        inherit (flakes.self._dev.nixConfig)
-          extra-substituters
-          extra-trusted-public-keys;
-        # For NixOS
+      # On NixOS (and not Home-Manager, flakes, or shells) we want them without the "extra-" prefix.
+      (with flakes.self._dev.nixConfig; {
         substituters = extra-substituters;
         trusted-public-keys = extra-trusted-public-keys;
-      };
+      });
   };
 }


### PR DESCRIPTION
### :fish: What?

Strict the non-extra settings to NixOS only.

### :fishing_pole_and_fish: Why?

Closes #440.