### PR TITLE
mesa_git: add NVK, all drivers, and all codecs

### DIFF
--- a/pkgs/mesa-git/default.nix
+++ b/pkgs/mesa-git/default.nix
@@ -72,7 +72,7 @@ gitOverride (current: {
       let
         cargoFetch = who: final.fetchurl {
           url = "https://crates.io/api/v1/crates/${who}/${cargoDeps.${who}.version}/download";
-          hash = cargoDeps.${who}.hash;
+          inherit (cargoDeps.${who}) hash;
         };
 
         cargoSubproject = who: ''

--- a/pkgs/mesa-git/default.nix
+++ b/pkgs/mesa-git/default.nix
@@ -11,10 +11,23 @@
 
 let
   inherit (final.stdenv) is32bit;
+
+  cargoDeps = {
+    proc-macro2 = { version = "1.0.56"; hash = "sha256-K2O9sM0G8fTe32myVHNPm0WvZuSgMeQqdIAlfZiYtDU="; };
+    quote = { version = "1.0.25"; hash = "sha256-UwjoIIcpw+FQSmz60NXarMRhTJouZdHqMSo0tcsA/oQ="; };
+    syn = { version = "2.0.15"; hash = "sha256-o0/PPotg9X5qFDAaLpFtMjr5iw6mPFmUQe7IVYZgyCI="; };
+    unicode-ident = { version = "1.0.6"; hash = "sha256-hKIrnyGLQGFK3LP0/wi3A3c61E+pQj5ODTRtXbhuTrw="; };
+  };
 in
 gitOverride (current: {
-  newInputs = with final; {
-    meson = if is32bit then meson else meson_1_3;
+  newInputs = if is32bit then { } else with final; {
+    meson = meson_1_3;
+    # We need to mention those besides "all", because of the usage of nix's `lib.elem` in
+    # the original derivation.
+    galliumDrivers = [ "all" "zink" "d3d12" ];
+    vulkanDrivers = [ "all" "microsoft-experimental" ];
+    # Instead, we enable the new option in `mesonFlags`
+    enablePatentEncumberedCodecs = false;
   };
 
   nyxKey = if is32bit then "mesa32_git" else "mesa_git";
@@ -33,7 +46,9 @@ gitOverride (current: {
     mesonFlags =
       builtins.map
         (builtins.replaceStrings [ "virtio-experimental" ] [ "virtio" ])
-        prevAttrs.mesonFlags;
+        prevAttrs.mesonFlags
+      ++ final.lib.optional (!is32bit) "-D video-codecs=all";
+
     patches =
       (nyxUtils.removeByBaseName
         "disk_cache-include-dri-driver-path-in-cache-key.patch"
@@ -46,22 +61,47 @@ gitOverride (current: {
         ./disk_cache-include-dri-driver-path-in-cache-key.patch
         ./gbm-backend.patch
       ];
+
     # expose gbm backend and rename vendor (if necessary)
     outputs =
       if gbmDriver
       then prevAttrs.outputs ++ [ "gbm" ]
       else prevAttrs.outputs;
-    # allow renaming the new backend name
+
     postPatch =
-      if gbmBackend != "dri_git" then prevAttrs.postPatch + ''
-        sed -i"" 's/"dri_git"/"${gbmBackend}"/' src/gbm/backends/dri/gbm_dri.c src/gbm/main/backend.c
-      '' else prevAttrs.postPatch;
+      let
+        cargoFetch = who: final.fetchurl {
+          url = "https://crates.io/api/v1/crates/${who}/${cargoDeps.${who}.version}/download";
+          hash = cargoDeps.${who}.hash;
+        };
+
+        cargoSubproject = who: ''
+          ln -s ${cargoFetch who} subprojects/packagecache/${who}-${cargoDeps.${who}.version}.tar.gz
+        '';
+
+        # allow renaming the new backend name
+        backendRename =
+          if gbmBackend != "dri_git" then ''
+            sed -i"" 's/"dri_git"/"${gbmBackend}"/' src/gbm/backends/dri/gbm_dri.c src/gbm/main/backend.c
+          '' else "";
+      in
+      prevAttrs.postPatch
+      + backendRename
+      + ''
+        mkdir subprojects/packagecache
+      ''
+      + (cargoSubproject "proc-macro2")
+      + (cargoSubproject "quote")
+      + (cargoSubproject "syn")
+      + (cargoSubproject "unicode-ident");
+
     # move new backend to its own output (if necessary)
     postInstall =
       if gbmDriver then prevAttrs.postInstall + ''
         mkdir -p $gbm/lib/gbm
         ln -s $out/lib/libgbm.so $gbm/lib/gbm/${gbmBackend}_gbm.so
       '' else prevAttrs.postInstall;
+
     # test and accessible information
     passthru = prevAttrs.passthru // {
       inherit gbmBackend;

--- a/pkgs/mesa-git/version.json
+++ b/pkgs/mesa-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20231213111907-40c6e54",
-  "rev": "40c6e54ce7382007ba3ffa28c9d3d7362799274b",
-  "hash": "sha256-V2bmNpZYPDJ1nS6Ft4LKgK8aXhhU4Ku33uXvr/O48Z4="
+  "version": "unstable-20231214140506-14267d9",
+  "rev": "14267d973936240d321cb7e6e47e8cee642d35cd",
+  "hash": "sha256-LO0vxGh9efmqFBisXCDGz2VeiIXK4H0b25TuJ69VKro="
 }


### PR DESCRIPTION
### :fish: What?

1. Add `all` to `galliumDrivers` *;
2. Add `all` to `vulkanDrivers` *;
3. Replace `enablePatentEncumberedCodecs` with `-D video-codecs=all` *;
4. Add `NVK` rust deps to `packagecache`;
5. Bump to latest commit.

[*]: Only applies to 64-bit right now.

### :fishing_pole_and_fish: Why?

Shining newer stuff.
