### PR TITLE
qtile: add module, instructions and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,13 @@
     </ul>
   </li>
   <li><a href="#lists-of-options-and-packages">Lists of options and packages</a></li>
+  <li>
+    <a href="#harder-stuff">Harder stuff</a><br/>
+    <ul>
+      <li><a href="#using-linux-cachyos-with-sched-ext">Using linux-cachyos with sched-ext</a><br/></li>
+      <li><a href="#using-qtile-from-git">Using qtile from git</a><br/></li>
+    </ul>
+  </li>
   <li><a href="#notes">Notes</a></li>
   <li><a href="#maintainence">Maintainence</a></li>
 </ul>
@@ -150,6 +157,54 @@ We do this automatically, so we can gracefully update the cache's address and ke
 
 <!-- cut here --><p>An always up-to-date list of all our options and packages is available at: <a href="https://www.nyx.chaotic.cx/#lists">List page</a>.</p><!-- cut here -->
 
+<h2 id="harder-stuff">Harder stuff</h2>
+
+<p>Some packages are harder to use, I'll go into details in the following paragraphs.</p>
+
+<h3 id="using-linux-cachyos-with-sched-ext">Using linux-cachyos with sched-ext</h3>
+
+<p>First, add this to your configuration:</p>
+
+<pre lang="nix"><code class="language-nix">
+{
+  boot.kernelPackages = pkgs.linuxPackages_cachyos-sched-ext;
+  environment.systemPackages =  [ pkgs.scx ];
+}
+</code></pre>
+
+<p>Then, with the new kernel booted, check if the correct kernel booted:</p>
+
+<pre lang="text"><code class="language-text">
+╰─λ zgrep 'SCHED_CLASS' /proc/config.gz
+CONFIG_SCHED_CLASS_EXT=y
+</code></pre>
+
+<p>The last step is to start a scheduler:</p>
+
+<pre lang="text"><code class="language-text">
+╰─λ sudo scx_rusty
+21:38:53 [INFO] CPUs: online/possible = 24/32
+21:38:53 [INFO] DOM[00] cpumask 00000000FF03F03F (20 cpus)
+21:38:53 [INFO] DOM[01] cpumask 0000000000FC0FC0 (12 cpus)
+21:38:53 [INFO] Rusty Scheduler Attached
+</code></pre>
+
+<p>There are other scx_* binaries for you to play with, or head to <a href="https://github.com/sched-ext/scx" target="_blank">github.com/sched-ext/scx</a> for instructions on how to write one of your own.</p>
+
+<h3 id="using-qtile-from-git">Using qtile from git</h3>
+
+<pre lang="nix"><code class="language-nix">
+{
+  services.xserver.windowManager.qtile = {
+    enable = true;
+    backend = "wayland";
+    package = pkgs.qtile-module_git;
+    extraPackages = _pythonPackages: [ pkgs.qtile-extras_git ];
+  };
+  # if you want a proper wayland+qtile session, and/or a "start-qtile" executable in PATH:
+  chaotic.qtile.enable = true;
+}
+</code></pre>
 <h2 id="notes">Notes</h2>
 
 <h3>Our branches</h3>

--- a/maintenance/tools/document/default.nix
+++ b/maintenance/tools/document/default.nix
@@ -221,10 +221,12 @@ writeText "chaotic-documented.html" ''
       import hljs from 'https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/es/highlight.min.js';
       import nix from 'https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/es/languages/nix.min.js';
       import bash from 'https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/es/languages/bash.min.js';
+      import plaintext from 'https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/es/languages/plaintext.min.js';
 
       hljs.registerLanguage('nix', nix);
       hljs.registerLanguage('bash', bash);
       hljs.registerLanguage('sh', bash);
+      hljs.registerLanguage('text', plaintext);
       hljs.highlightAll();
     </script>
   </div></body></html>

--- a/modules/nixos/default.nix
+++ b/modules/nixos/default.nix
@@ -9,6 +9,7 @@ let
     nyx-cache = import ./nyx-cache.nix fromFlakes;
     nyx-overlay = import ../common/nyx-overlay.nix fromFlakes;
     steam-compat-tools = import ./steam-compat-tools.nix;
+    qtile = import ./qtile.nix;
     zfs-impermanence-on-shutdown = import ./zfs-impermanence-on-shutdown.nix;
   };
 

--- a/modules/nixos/qtile.nix
+++ b/modules/nixos/qtile.nix
@@ -3,7 +3,7 @@ let
   cfg = config.chaotic.qtile;
 
   mainCfg = config.services.xserver.windowManager.qtile;
-  pyEnv = pkgs.python3.withPackages (p: [ (mainCfg.package.unwrapped or mainCfg.package) ] ++ (mainCfg.extraPackages p));
+  pyEnv = pkgs.python3.withPackages (pypkgs: [ (mainCfg.package.unwrapped or mainCfg.package) ] ++ (mainCfg.extraPackages pypkgs));
 
   runner = backend: pkgs.writeShellScriptBin "start-qtile" ''
     exec ${pyEnv}/bin/qtile start -b ${backend} \

--- a/modules/nixos/qtile.nix
+++ b/modules/nixos/qtile.nix
@@ -1,0 +1,53 @@
+{ config, lib, pkgs, ... }:
+let
+  cfg = config.chaotic.qtile;
+
+  mainCfg = config.services.xserver.windowManager.qtile;
+  pyEnv = pkgs.python3.withPackages (p: [ (mainCfg.package.unwrapped or mainCfg.package) ] ++ (mainCfg.extraPackages p));
+
+  runner = backend: pkgs.writeShellScriptBin "start-qtile" ''
+    exec ${pyEnv}/bin/qtile start -b ${backend} \
+      ${lib.optionalString (mainCfg.configFile != null)
+      "--config \"${mainCfg.configFile}\""} "$@"
+  '';
+
+  defaultRunner = runner mainCfg.backend;
+
+  session = pkgs.stdenvNoCC.mkDerivation {
+    name = "qtile-wayland-session";
+    src = pkgs.writeTextDir "entry" ''
+      [Desktop Entry]
+      Name=QTile
+      Comment=QTile Wayland compositor
+      Exec=${runner "wayland"}/bin/start-qtile
+      Type=Application
+    '';
+    dontBuild = true;
+    installPhase = ''
+      mkdir -p $out/share/wayland-sessions
+      cp entry $out/share/wayland-sessions/wayland+qtile.desktop
+    '';
+    passthru.providedSessions = [ "wayland+qtile" ];
+  };
+in
+{
+  options = with lib; {
+    chaotic.qtile.enable =
+      mkOption {
+        default = true;
+        example = false;
+        type = types.bool;
+        description = ''
+          Adds a wayland-session package and a `start-qtile` binary for using with `services.xserver.windowManager.qtile` options.
+        '';
+      };
+  };
+
+  config = lib.mkIf cfg.enable {
+    services.xserver.windowManager.qtile.enable = true;
+
+    services.xserver.displayManager.sessionPackages = [ session ];
+
+    environment.systemPackages = [ defaultRunner ];
+  };
+}

--- a/pkgs/qtile-git/default.nix
+++ b/pkgs/qtile-git/default.nix
@@ -1,5 +1,7 @@
-{ gitOverride
+{ final
+, gitOverride
 , prev
+, flakes
 , ...
 }:
 
@@ -14,4 +16,15 @@ gitOverride {
     repo = "qtile";
   };
   ref = "master";
+
+  postOverride = prevAttrs: {
+    passthru = prevAttrs.passthru // {
+      tests.smoke-test = import ./test.nix
+        {
+          inherit (flakes) nixpkgs;
+          chaotic = flakes.self;
+        }
+        final;
+    };
+  };
 }

--- a/pkgs/qtile-git/test.nix
+++ b/pkgs/qtile-git/test.nix
@@ -33,10 +33,10 @@ import "${nixpkgs}/nixos/tests/make-test-python.nix" ({ pkgs, ... }: {
           enable = testingWithAutoLogin;
           user = "alice";
         };
-        defaultSession = "wayland+qtile";
+        defaultSession = "${if testingBackend == "wayland" then "wayland" else "none"}+qtile";
       };
       windowManager.qtile = {
-        backend = "wayland";
+        backend = testingBackend;
         package = pkgs.qtile-module_git;
         extraPackages = _pythonPackages: [ pkgs.qtile-extras_git ];
         configFile = pkgs.writeTextFile {

--- a/pkgs/qtile-git/test.nix
+++ b/pkgs/qtile-git/test.nix
@@ -1,0 +1,60 @@
+{ nixpkgs
+, chaotic
+, testingBackend ? "wayland"
+, testingWithAutoLogin ? true
+}:
+
+import "${nixpkgs}/nixos/tests/make-test-python.nix" ({ pkgs, ... }: {
+  name = "qtile_git";
+  meta.maintainers = with pkgs.lib.maintainers; [ pedrohlc ];
+
+  nodes.machine = { pkgs, ... }: {
+    imports = [
+      chaotic.nixosModules.default
+      "${nixpkgs}/nixos/tests/common/user-account.nix"
+    ];
+
+    virtualisation.qemu.options = [
+      "-m 16G"
+      "-vga none"
+      "-device virtio-vga-gl"
+      "-display gtk,gl=on"
+    ];
+
+    environment.systemPackages = with pkgs; [
+      alacritty
+    ];
+
+    services.xserver = {
+      enable = true;
+      displayManager = {
+        lightdm.enable = true;
+        autoLogin = {
+          enable = testingWithAutoLogin;
+          user = "alice";
+        };
+        defaultSession = "wayland+qtile";
+      };
+      windowManager.qtile = {
+        backend = "wayland";
+        package = pkgs.qtile-module_git;
+        extraPackages = _pythonPackages: [ pkgs.qtile-extras_git ];
+        configFile = pkgs.writeTextFile {
+          name = "qtile-config.py";
+          text = ''
+            from libqtile.log_utils import logger
+            import qtile_extras
+            logger.warning("This is after importing qtile_extras")
+          '';
+        };
+      };
+    };
+    chaotic.qtile.enable = true;
+  };
+
+  # TODO: TODO
+  testScript =
+    ''
+      start_all()
+    '';
+})


### PR DESCRIPTION
…ns for sched-ext too

### :fish: What?

1. Add a module for expanding qtile;
2. Add instructions on how to use `qtile_git`;
3. Add tests to try `qtile_git`;
4. Add instructions for sched-ext.

### :fishing_pole_and_fish: Why?

- (1), (2) and (3) to help Drishal;
- (4) It's something harder too.