### PR TITLE
makeMicroarch: propagate pkgs.config

### DIFF
--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -9,7 +9,7 @@
 # NOTE:
 # - `*_next` packages will be removed once merged into nixpkgs-unstable.
 
-{ flakes, nixpkgs ? flakes.nixpkgs, self ? flakes.self, selfOverlay ? self.overlays.default, nixpkgsExtraConfig ? {} }:
+{ flakes, nixpkgs ? flakes.nixpkgs, self ? flakes.self, selfOverlay ? self.overlays.default, nixpkgsExtraConfig ? { } }:
 final: prev:
 let
   # Required to load version files and warning.

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -9,7 +9,7 @@
 # NOTE:
 # - `*_next` packages will be removed once merged into nixpkgs-unstable.
 
-{ flakes, nixpkgs ? flakes.nixpkgs, self ? flakes.self, selfOverlay ? self.overlays.default }:
+{ flakes, nixpkgs ? flakes.nixpkgs, self ? flakes.self, selfOverlay ? self.overlays.default, nixpkgsExtraConfig ? {} }:
 final: prev:
 let
   # Required to load version files and warning.
@@ -45,6 +45,7 @@ let
   makeMicroarch = lvl: with final;
     if stdenv.hostPlatform.isx86 then import "${nixpkgs}"
       {
+        config = final.config // nixpkgsExtraConfig;
         overlays = [
           selfOverlay
           (_final': prev': {


### PR DESCRIPTION
### :fish: What?

Propagate `pkgs.config` when re-importing Nixpkgs inside `makeMicroarch`

### :fishing_pole_and_fish: Why?

- Fixes #514;
- Also includes other `allow*`.

### :whale: Extras

Tested:

- FAILS (as expected): `nix build .#packages.x86_64-linux.pkgsx86_64_v3.discord-krisp`
- SUCCEED: `NIXPKGS_ALLOW_UNFREE=1 nix build --impure .#packages.x86_64-linux.pkgsx86_64_v3.discord-krisp`
- FAILS (as expected): `sudo nixos-rebuild dry-build` with `nixpkgs.config.allowUnfree = false`
- SUCCEED: `sudo nixos-rebuild dry-build` with `nixpkgs.config.allowUnfree = true`

I've added a `nixpkgsExtraConfig` that is not being used, but that can be helpful for debugging issues.