### PR TITLE
mesa_git: revert MR 24386 (again)

### DIFF
--- a/pkgs/mesa-git/default.nix
+++ b/pkgs/mesa-git/default.nix
@@ -19,6 +19,24 @@ let
     syn = { version = "2.0.39"; hash = "sha256-I+eLkPL89F0+hCAyzjLj8tFUW6ZjYnHcvyT6MG2Hvno="; };
     unicode-ident = { version = "1.0.12"; hash = "sha256-M1S5rD+uH/Z1XLbbU2g622YWNPZ1V5Qt6k+s6+wP7ks="; };
   };
+
+  revert_mr_26943 = final.fetchpatch {
+    url = "https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/26943.diff";
+    hash = "sha256-KwIG68mf+aArMlvWBtGJdOFdCn5zTZJG6geWXE7bK44=";
+    revert = true;
+  };
+
+  revert_mr_24386_1 = final.fetchpatch {
+    url = "https://github.com/chaotic-cx/mesa-mirror/commit/299f9497758ca5d7278e5aafd210aa91d20dfb4d.patch";
+    hash = "sha256-ugrkIqJ/Tndimn6YIQSanLVvQ5qZfp2m6GGStHLt8xg=";
+    revert = true;
+  };
+
+  revert_mr_24386_2 = final.fetchpatch {
+    url = "https://github.com/chaotic-cx/mesa-mirror/commit/1e5bc00715ad8acf3dc323278d0d6a24986bb4ae.patch";
+    hash = "sha256-i0+sBeU/c8Eo8WA34aJfMLJOxhd7146+t7H6llGwS+g=";
+    revert = true;
+  };
 in
 gitOverride (current: {
   newInputs =
@@ -68,6 +86,10 @@ gitOverride (current: {
         ./opencl.patch
         ./disk_cache-include-dri-driver-path-in-cache-key.patch
         ./gbm-backend.patch
+      ] ++ final.lib.optionals (!is32bit) [
+        revert_mr_26943
+        revert_mr_24386_1
+        revert_mr_24386_2
       ];
 
     # expose gbm backend and rename vendor (if necessary)


### PR DESCRIPTION
### :fish: What?

Reverts https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/24386

### :fishing_pole_and_fish: Why?

Breaks building with tons of `error: no xxxx named 'yyyy' in namespace 'std'`.