### PR TITLE
libdrm_git: match drvName with the original

### DIFF
--- a/pkgs/libdrm-git/default.nix
+++ b/pkgs/libdrm-git/default.nix
@@ -3,9 +3,12 @@
 , ...
 }:
 
-gitOverride {
+gitOverride (current: {
   nyxKey = "libdrm_git";
   prev = prev.libdrm;
+
+  # Matching the drvName length to use with replaceRuntime
+  version = builtins.substring 0 (builtins.stringLength prev.libdrm.version) current.rev;
 
   versionNyxPath = "pkgs/libdrm-git/version.json";
   fetcher = "fetchFromGitLab";
@@ -14,4 +17,4 @@ gitOverride {
     owner = "mesa";
     repo = "drm";
   };
-}
+})

--- a/pkgs/libdrm-git/default.nix
+++ b/pkgs/libdrm-git/default.nix
@@ -7,7 +7,7 @@ gitOverride (current: {
   nyxKey = "libdrm_git";
   prev = prev.libdrm;
 
-  # Matching the drvName length to use with replaceRuntime
+  # Matching the drvName length to use with replaceRuntimeDependencies
   version = builtins.substring 0 (builtins.stringLength prev.libdrm.version) current.rev;
 
   versionNyxPath = "pkgs/libdrm-git/version.json";

--- a/pkgs/mesa-git/default.nix
+++ b/pkgs/mesa-git/default.nix
@@ -66,6 +66,8 @@ gitOverride (current: {
     repo = "mesa-mirror";
   };
   withUpdateScript = !is32bit;
+
+  # Matching the drvName length to use with replaceRuntime
   version = builtins.substring 0 (builtins.stringLength prev.mesa.version) current.rev;
 
   postOverride = prevAttrs: {


### PR DESCRIPTION
### :fish: What?

Matches libdrm_git's drvName's length to the OG one.

### :fishing_pole_and_fish: Why?

So I can use it with replaceRuntimeDependencies.