### PR TITLE
conduit_git: migrate to conduwuit (renames package)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -68,17 +68,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1708220210,
-        "narHash": "sha256-qsiApRdQEk9Sd3u/iiFt7idUEdsccHc3TcxmsHy3CJ4=",
-        "owner": "famedly",
-        "repo": "conduit",
-        "rev": "be1e2e93073d88ef1972a3c99014a7d14d731b85",
+        "lastModified": 1707957373,
+        "narHash": "sha256-UmySXmi6tZsXSCROUKgV3UM7W05uGhH9lslw8h6EUd0=",
+        "owner": "girlbossceo",
+        "repo": "conduwuit",
+        "rev": "cf9d77d04ec8f7e118cbc8d4400e273778ee47a2",
         "type": "gitlab"
       },
       "original": {
-        "owner": "famedly",
-        "ref": "next",
-        "repo": "conduit",
+        "owner": "girlbossceo",
+        "repo": "conduwuit",
         "type": "gitlab"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -18,7 +18,7 @@ rec {
 
     # thirdy-party repositories
     conduit = {
-      url = "gitlab:famedly/conduit/next";
+      url = "gitlab:girlbossceo/conduwuit";
       inputs.nixpkgs.follows = "nixpkgs";
       inputs.attic.follows = "attic";
       inputs.crane.follows = "crane";

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -119,7 +119,7 @@ in
 
   bytecode-viewer_git = final.callPackage ../pkgs/bytecode-viewer-git { };
 
-  conduit_git = conduit.packages.${final.system}.default;
+  conduwuit_git = conduit.packages.${final.system}.default;
 
   discord-krisp = callOverride ../pkgs/discord-krisp { };
 


### PR DESCRIPTION
### :fish: What?

- Removes `conduit_git`
- Adds `conduwuit_git` from https://github.com/girlbossceo/conduwuit

### :fishing_pole_and_fish: Why?

It's a fork with fixes and “early-access” to upstream's MRs:
https://github.com/girlbossceo/conduwuit/blob/0593dce8a66788c67e52ecb521c878ef2c53e0c4/DIFFERENCES.md