### PR TITLE
blurredwallpaper: 2.0 -> 3.0.0

### DIFF
--- a/pkgs/blurredwallpaper/default.nix
+++ b/pkgs/blurredwallpaper/default.nix
@@ -4,13 +4,13 @@
 }:
 stdenvNoCC.mkDerivation rec {
   pname = "blurredwallpaper";
-  version = "2.2";
+  version = "3.0.0";
 
   src = fetchFromGitHub {
     owner = "bouteillerAlan";
     repo = pname;
     rev = "v${version}";
-    hash = "sha256-FgEyKVNTSJklYo/B4p0BqK9eYoc/3DU4nDxYdElDyCw=";
+    hash = "sha256-mCqf03cXlTl4vuJIzVEiYhHQsAPG3i6yHQ3Xdt06HfA=";
   };
 
   propagatedBuildInputs = [ ];
@@ -24,7 +24,7 @@ stdenvNoCC.mkDerivation rec {
   '';
 
   meta = with lib; {
-    description = "Plasma 5 wallpaper plugin that blurs the wallpaper when a window is active";
+    description = "Plasma 6 wallpaper plugin that blurs the wallpaper when a window is active";
     homepage = "https://github.com/bouteillerAlan/blurredwallpaper";
     license = licenses.gpl3;
     maintainers = [ maintainers.dr460nf1r3 ];


### PR DESCRIPTION
Includes KDE 6 compatibility.

### :fish: What?

Updated a package.

### :fishing_pole_and_fish: Why?

KDE 6 release.