### PR TITLE
conduwuit_git: switch remote to github

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -73,12 +73,12 @@
         "owner": "girlbossceo",
         "repo": "conduwuit",
         "rev": "e888a0a745ac979abe6a687ff24b8c5e7b7b79ed",
-        "type": "gitlab"
+        "type": "github"
       },
       "original": {
         "owner": "girlbossceo",
         "repo": "conduwuit",
-        "type": "gitlab"
+        "type": "github"
       }
     },
     "crane": {

--- a/flake.nix
+++ b/flake.nix
@@ -18,7 +18,7 @@ rec {
 
     # thirdy-party repositories
     conduit = {
-      url = "gitlab:girlbossceo/conduwuit";
+      url = "github:girlbossceo/conduwuit";
       inputs.nixpkgs.follows = "nixpkgs";
       inputs.attic.follows = "attic";
       inputs.crane.follows = "crane";


### PR DESCRIPTION
### :fish: What?

- Switches conduwuit_git remote to [GitHub](https://github.com/girlbossceo/conduwuit) from [GitLab](https://gitlab.com/girlbossceo/conduwuit)

### :fishing_pole_and_fish: Why?

- Conduwuit development is done only on GitHub
- GitLab, git.gay, Codeberg, sr.ht, etc are only mirrors that I manually push to, and have admittedly forgotten to push to for at most a few days
- Our CI only works on GitHub until I can get a GitLab Runner setup (https://github.com/girlbossceo/conduwuit/issues/160)

### :fish_cake: Pending

- [ ] Complain with linter;
- [ ] Remove some temporary fix;
- [ ] Publishing to news' channel.
