### PR TITLE
linux-cachyos: fix config generation

### DIFF
--- a/pkgs/linux-cachyos/configfile-raw.nix
+++ b/pkgs/linux-cachyos/configfile-raw.nix
@@ -212,7 +212,6 @@ stdenv.mkDerivation {
 
   buildPhase = ''
     ${makeEnv} defconfig
-    cp "${config-src}/${cachyConfig.taste}/config" ".config"
     patchShebangs scripts/config
     scripts/config ${lib.concatStringsSep " " pkgbuildConfig}
   '';


### PR DESCRIPTION
### :fish: What?

Fixed linux-cachyos-lto configuration generation.

### :fishing_pole_and_fish: Why?

Should fix a few problems with out-of-tree modules.