### PR TITLE
scx package in environment should respect settings

### DIFF
--- a/modules/nixos/scx.nix
+++ b/modules/nixos/scx.nix
@@ -19,7 +19,7 @@ in
   };
 
   config = mkIf cfg.enable {
-    environment.systemPackages = [ pkgs.scx ];
+    environment.systemPackages = [ cfg.package ];
 
     systemd.services.scx = {
       wantedBy = [ "multi-user.target" ];


### PR DESCRIPTION
### :fish: What?

Fixed an error in nixos module.

### :fishing_pole_and_fish: Why?

I want to use modified scx packages (`services.scx.package` option), both in systemd service and in `environment.systemPackages`.
