### PR TITLE
Update README docs: sched-ext merged with cachyos kernel

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,11 +165,13 @@ We do this automatically, so we can gracefully update the cache's address and ke
 
 <h3 id="using-linux-cachyos-with-sched-ext">Using linux-cachyos with sched-ext</h3>
 
+<p> Since sched-ext packages have been added to `linux-chachyos`, you can just use that kernel. </p>
+
 <p>First, add this to your configuration:</p>
 
 <pre lang="nix"><code class="language-nix">
 {
-  boot.kernelPackages = pkgs.linuxPackages_cachyos-sched-ext;
+  boot.kernelPackages = pkgs.linuxPackages_cachyos;
   environment.systemPackages =  [ pkgs.scx ];
 }
 </code></pre>

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ We do this automatically, so we can gracefully update the cache's address and ke
 
 <h3 id="using-linux-cachyos-with-sched-ext">Using linux-cachyos with sched-ext</h3>
 
-<p> Since sched-ext packages have been added to `linux-chachyos`, you can just use that kernel. </p>
+<p> Since sched-ext patches have been added to `linux-chachyos`, you can just use that kernel. </p>
 
 <p>First, add this to your configuration:</p>
 


### PR DESCRIPTION
I was trying out the cachyos-sched-ext kernel and rebuild script gave me an error that sched-ext patches are now merged with linux-cachyos.
So...
Updated docs to state that `pkgs.linuxPackages_cachyos-sched-ext` is deprecated and `pkgs.linuxPackages_cachyos` should be used instead.