### PR TITLE
Overlays: Disable checkphase for coreutils and ltrace on v4

### DIFF
--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -64,7 +64,7 @@ let
           (_final': prev': {
             "pkgsx86_64_${lvl}" = prev';
           })
-        ] ++ lib.optionals (${lvl} == "v4") [
+        ] ++ lib.optionals (lvl == "v4") [
           (_final': prev': {
             coreutils = prev'.coreutils.overrideAttrs (_prevattrs: { doCheck = false; });
           })

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -64,6 +64,13 @@ let
           (_final': prev': {
             "pkgsx86_64_${lvl}" = prev';
           })
+        ] ++ lib.optionals (${lvl} == "v4") [
+          (_final': prev': {
+            coreutils = prev'.coreutils.overrideAttrs (_prevattrs: { doCheck = false; });
+          })
+          (_final': prev': {
+            ltrace = prev'.ltrace.overrideAttrs (_prevattrs: { doCheck = false; });
+          })
         ] ++ overlays;
         ${if stdenv.hostPlatform == stdenv.buildPlatform
         then "localSystem" else "crossSystem"} = {

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -67,8 +67,6 @@ let
         ] ++ lib.optionals (lvl == "v4") [
           (_final': prev': {
             coreutils = prev'.coreutils.overrideAttrs (_prevattrs: { doCheck = false; });
-          })
-          (_final': prev': {
             ltrace = prev'.ltrace.overrideAttrs (_prevattrs: { doCheck = false; });
           })
         ] ++ overlays;


### PR DESCRIPTION
I was trying to build the system for x86_64-v4, and it failed to build on checkphase for `coreutils` and `ltrace`.

So...
Added conditional overlays for v4 systems which disables checkphase for `coreutils` and `ltrace`.
