### PR TITLE
nix-flake-schemas_git: fix source repository URL

### DIFF
--- a/pkgs/nix-flake-schemas-git/default.nix
+++ b/pkgs/nix-flake-schemas-git/default.nix
@@ -8,7 +8,7 @@ gitOverride {
   fetcher = "fetchFromGitHub";
   fetcherData = {
     owner = "DeterminateSystems";
-    repo = "nix";
+    repo = "nix-src";
   };
   ref = "flake-schemas";
 


### PR DESCRIPTION
### :fish: What?

This fixes nix-flake-schemas_git package by renaming the source repository.

### :fishing_pole_and_fish: Why?

Why not?