### PR TITLE
Fix module building for linux-cachyos-lto kernel

### DIFF
--- a/maintenance/failures.x86_64-linux.nix
+++ b/maintenance/failures.x86_64-linux.nix
@@ -125,12 +125,10 @@
   "linuxPackages_cachyos-lto.trelay" = "/nix/store/qmpjz5hrmz44qls4ax4vzlk332yyykjk-trelay-22.03.5-6.8.1";
   "linuxPackages_cachyos-lto.turbostat" = "/nix/store/2r29lcdpb5vsra42mjlgpk08kz29xw64-turbostat-6.8.1";
   "linuxPackages_cachyos-lto.tuxedo-keyboard" = "/nix/store/cms3w5ijlqcghz74jp9x466awmkky16s-tuxedo-keyboard-6.8.1-3.2.14";
-  "linuxPackages_cachyos-lto.v4l2loopback" = "/nix/store/77kf0i1jx2ak5a42ppsilbmi4r5cfgyk-v4l2loopback-0.12.7-unstable-2024-02-12-6.8.1";
   "linuxPackages_cachyos-lto.veikk-linux-driver" = "/nix/store/2m0shf1qzmjjj4zkqq9xm2za52pdgc2f-veikk-linux-driver-2.0";
   "linuxPackages_cachyos-lto.vendor-reset" = "/nix/store/sdilha6cbsj3d72yps9ncq41v17xmcjw-vendor-reset-unstable-2021-02-16-6.8.1";
   "linuxPackages_cachyos-lto.vhba" = "/nix/store/62da0rqmf4fs4ijsrl483g8ybmbpa2i1-vhba-20240202";
   "linuxPackages_cachyos-lto.virtio_vmmci" = "/nix/store/9267j9317378j78xw3p892h9jhxmvrar-virtio_vmmci";
-  "linuxPackages_cachyos-lto.virtualbox" = "/nix/store/0szp43d7ppgmvip7xah98hrc733pigpl-virtualbox-modules-7.0.14-6.8.1";
   "linuxPackages_cachyos-lto.virtualboxGuestAdditions" = "/nix/store/wkgpgb354xx8ckf05f3rsmyniqyyrs4n-VirtualBox-GuestAdditions-7.0.14-6.8.1";
   "linuxPackages_cachyos-lto.vm-tools" = "/nix/store/19xlcd8y5dkbyysjipanfv7vj3jlrr8k-vm-tools-6.6.22";
   "linuxPackages_cachyos-lto.vmm_clock" = "/nix/store/rda8qa7h8l1ds5hgpxiw56vfqdaf1nbk-vmm_clock-0.2.0";
@@ -138,8 +136,7 @@
   "linuxPackages_cachyos-lto.x86_energy_perf_policy" = "/nix/store/bfrfhh8fbjw2kbrib0ccywc0pvawpg97-x86_energy_perf_policy-6.8.1";
   "linuxPackages_cachyos-lto.xone" = "/nix/store/kcik8ykj9kl7hhrbdxgmyng26nwj8hqn-xone-0.3-unstable-2024-03-16";
   "linuxPackages_cachyos-lto.xpadneo" = "/nix/store/fvqnn3bangml6fn778smxwaphkifna0s-xpadneo-0.9.6";
-  "linuxPackages_cachyos-lto.zenpower" = "/nix/store/7pf13r0bv355dljbgbcy21laasjynq07-zenpower-unstable-2022-11-04";
-  "linuxPackages_cachyos-lto.zfs_cachyos" = "/nix/store/y9kj9ajpzqasfw63b5jmq13asbb8infa-zfs-kernel-2.2.3-unstable-2024-03-21-6.8.1";
+  "linuxPackages_cachyos-lto.zfs_cachyos" = "/nix/store/jjrnpr1dsgmhq38qwk20vr3y5ycpnxlr-zfs-kernel-2.2.3-unstable-2024-03-21-6.8.1";
   "linuxPackages_cachyos-server.cryptodev" = "/nix/store/vnggadhndwfzq0d7rww9z6vhzywdqf0a-cryptodev-linux-1.13-6.8.1";
   "linuxPackages_cachyos-server.ddcci-driver" = "/nix/store/7ym1nhrjlmkklizhy3g3ya5pkgsdkp7n-ddcci-driver-6.8.1-0.4.4";
   "linuxPackages_cachyos-server.ena" = "/nix/store/m394i59r7w29nasl82sm2695kp3bp0im-ena-2.8.9-6.8.1";

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -181,13 +181,7 @@ in
 
   linuxPackages_cachyos = cachyosPackages.cachyos;
   linuxPackages_cachyos-hardened = cachyosPackages.cachyos-hardened;
-  linuxPackages_cachyos-lto = cachyosPackages.cachyos-lto.extend (
-    _lto_final: lto_prev: {
-      virtualbox = lto_prev.virtualbox.overrideAttrs (_prevattrs: { stdenv = stdenvLLVM; });
-      zenpower = lto_prev.zenpower.overrideAttrs (_prevattrs: { stdenv = stdenvLLVM; });
-      zfs = lto_prev.zfs.overrideAttrs (_prevattrs: { stdenv = stdenvLLVM; });
-    }
-  );
+  linuxPackages_cachyos-lto = cachyosPackages.cachyos-lto;
   linuxPackages_cachyos-sched-ext = cachyosPackages.cachyos-sched-ext;
   linuxPackages_cachyos-server = cachyosPackages.cachyos-server;
 

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -50,7 +50,6 @@ let
 
   # Too much variations
   cachyosPackages = callOverride ../pkgs/linux-cachyos/all-packages.nix { };
-  stdenvLLVM = final.callPackage ./stdenv-llvm.nix { };
 
   # Microarch stuff
   makeMicroarch = lvl: with final;

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -50,6 +50,7 @@ let
 
   # Too much variations
   cachyosPackages = callOverride ../pkgs/linux-cachyos/all-packages.nix { };
+  stdenvLLVM = final.callPackage ./stdenv-llvm.nix { };
 
   # Microarch stuff
   makeMicroarch = lvl: with final;
@@ -181,10 +182,10 @@ in
   linuxPackages_cachyos = cachyosPackages.cachyos;
   linuxPackages_cachyos-hardened = cachyosPackages.cachyos-hardened;
   linuxPackages_cachyos-lto = cachyosPackages.cachyos-lto.extend (
-    lto_final: lto_prev: with linuxKernel.packages.linux_cachyos-lto; {
-      virtualbox = lto_prev.virtualbox.overrideAttrs (_prevattrs: { stdenv = pkgs.clangStdenv; });
-      zenpower = lto_prev.zenpower.overrideAttrs (_prevattrs: { stdenv = pkgs.clangStdenv; });
-      zfs = lto_prev.zfs.overrideAttrs (_prevattrs: { stdenv = pkgs.clangStdenv; });
+    _lto_final: lto_prev: {
+      virtualbox = lto_prev.virtualbox.overrideAttrs (_prevattrs: { stdenv = stdenvLLVM; });
+      zenpower = lto_prev.zenpower.overrideAttrs (_prevattrs: { stdenv = stdenvLLVM; });
+      zfs = lto_prev.zfs.overrideAttrs (_prevattrs: { stdenv = stdenvLLVM; });
     }
   );
   linuxPackages_cachyos-sched-ext = cachyosPackages.cachyos-sched-ext;

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -180,7 +180,13 @@ in
 
   linuxPackages_cachyos = cachyosPackages.cachyos;
   linuxPackages_cachyos-hardened = cachyosPackages.cachyos-hardened;
-  linuxPackages_cachyos-lto = cachyosPackages.cachyos-lto;
+  linuxPackages_cachyos-lto = cachyosPackages.cachyos-lto.extend (
+    lto_final: lto_prev: with linuxKernel.packages.linux_cachyos-lto; {
+      virtualbox = lto_prev.virtualbox.overrideAttrs (_prevattrs: { stdenv = pkgs.clangStdenv; });
+      zenpower = lto_prev.zenpower.overrideAttrs (_prevattrs: { stdenv = pkgs.clangStdenv; });
+      zfs = lto_prev.zfs.overrideAttrs (_prevattrs: { stdenv = pkgs.clangStdenv; });
+    }
+  );
   linuxPackages_cachyos-sched-ext = cachyosPackages.cachyos-sched-ext;
   linuxPackages_cachyos-server = cachyosPackages.cachyos-server;
 

--- a/pkgs/linux-cachyos/all-packages.nix
+++ b/pkgs/linux-cachyos/all-packages.nix
@@ -17,7 +17,7 @@ let
     inherit (mainVersions.zfs) rev hash;
   };
 
-  llvmModule = import ./llvm-module-overlay.nix inputs;
+  llvmModule = import ./llvm-module-overlay.nix inputs stdenvLLVM;
 in
 {
   inherit mainVersions mkCachyKernel;

--- a/pkgs/linux-cachyos/llvm-module-overlay.nix
+++ b/pkgs/linux-cachyos/llvm-module-overlay.nix
@@ -1,4 +1,4 @@
-{ final, nyxUtils, ... }: kernel: prevModule:
+{ final, nyxUtils, ... }: stdenvLLVM: kernel: prevModule:
 
 nyxUtils.multiOverride prevModule { stdenv = stdenvLLVM; } (prevAttrs:
 let

--- a/pkgs/linux-cachyos/llvm-module-overlay.nix
+++ b/pkgs/linux-cachyos/llvm-module-overlay.nix
@@ -1,0 +1,36 @@
+{ final, nyxUtils, ... }: kernel: prevModule:
+
+nyxUtils.multiOverride prevModule { stdenv = stdenvLLVM; } (prevAttrs:
+let
+  inherit (final.lib.trivial) pipe;
+
+  tmpPath = "/build/lto_kernel";
+  fixKernelBuild = builtins.replaceStrings [ "${kernel.dev}" ] [ tmpPath ];
+  mapFixKernelBuild = builtins.map fixKernelBuild;
+
+  filteredMakeFlags = mapFixKernelBuild (prevAttrs.makeFlags or [ ]);
+
+  fixAttrList = k: attrs:
+    if prevAttrs ? "${k}"
+    then attrs // { "${k}" = mapFixKernelBuild prevAttrs."${k}"; }
+    else attrs;
+
+  fixAttrString = k: attrs:
+    if prevAttrs ? "${k}"
+    then attrs // { "${k}" = fixKernelBuild prevAttrs."${k}"; }
+    else attrs;
+
+  baseFix = {
+    patchPhase = ''
+      cp -r ${kernel.dev} ${tmpPath}
+      chmod -R +w ${tmpPath}
+    '' + (prevAttrs.patchPhase or "");
+    makeFlags = filteredMakeFlags ++ [ "LLVM=1" "LLVM_IAS=1" ];
+  };
+in
+pipe baseFix
+  [
+    (fixAttrList "configureFlags")
+    (fixAttrString "KERN_DIR")
+  ]
+)

--- a/pkgs/linux-cachyos/make.nix
+++ b/pkgs/linux-cachyos/make.nix
@@ -23,6 +23,7 @@
 , description ? "Linux EEVDF-BORE scheduler Kernel by CachyOS with other patches and improvements"
 , withUpdateScript ? false
 , zfs-source
+, packagesExtend ? null
 }:
 
 let
@@ -75,8 +76,10 @@ let
     };
 
   basePackages = linuxPackagesFor kernel;
-  packagesWithZFS = removeAttrs (basePackages.extend addZFS) [ "zfs" "zfs_2_1" "zfs_2_2" "zfs_unstable" ];
-  packagesWithoutUpdateScript = nyxUtils.dropAttrsUpdateScript packagesWithZFS;
+  packagesWithZFS = basePackages.extend addZFS;
+  packagesWithExtend = if packagesExtend == null then packagesWithZFS else packagesWithZFS.extend (packagesExtend kernel);
+  packagesWithoutZFS = removeAttrs packagesWithExtend [ "zfs" "zfs_2_1" "zfs_2_2" "zfs_unstable" ];
+  packagesWithoutUpdateScript = nyxUtils.dropAttrsUpdateScript packagesWithoutZFS;
   packagesWithRightPlatforms = nyxUtils.setAttrsPlatforms supportedPlatforms packagesWithoutUpdateScript;
 
   supportedPlatforms = [ (with lib.systems.inspect.patterns; isx86_64 // isLinux) "x86_64-linux" ];


### PR DESCRIPTION
### :fish: What?

Added an overlay to make kernel modules use clangStdenv for lto kernel, when building.

### :fishing_pole_and_fish: Why?

- (1) Fixes error [log](https://pastebin.com/Aw3GjXZF);

### :fish_cake: Notes for reviewers:-

Please check the package names!
I am confused whether to use linuxKernel.packages.linux_cachyos-lto.somePackage
