### PR TITLE
jovian-chaotic: add mesa-radeonsi-jupiter

### DIFF
--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -94,7 +94,7 @@ let
   # apply Jovian overlay only on x86_64-linux
   jovian-chaotic =
     if final.stdenv.hostPlatform.isLinux && final.stdenv.hostPlatform.isx86_64 then {
-      inherit (jovian.legacyPackages.x86_64-linux) linux_jovian mesa-radv-jupiter;
+      inherit (jovian.legacyPackages.x86_64-linux) linux_jovian mesa-radv-jupiter mesa-radeonsi-jupiter;
       recurseForDerivations = true;
     } else { };
 in


### PR DESCRIPTION
### :fish: What?

1. Added a new package;

### :fishing_pole_and_fish: Why?

- (1) This new package is interesting to myself;

### :whale: Extras

- I added `mesa-radeonsi-jupiter` to `jovian-chaotic`, because my steam deck builds it using the flake.
