### PR TITLE
Generalize makeMicroarch and add pkgsznver4

### DIFF
--- a/maintenance/schemas/packages/inventory.nix
+++ b/maintenance/schemas/packages/inventory.nix
@@ -60,6 +60,7 @@ in
               "pkgsx86_64_v3"
               "pkgsx86_64_v3-core"
               "pkgsx86_64_v4"
+              "pkgsznver4"
               "libdrm32_git"
               "mangohud32_git"
               "mesa32_git"


### PR DESCRIPTION
### :fish: What?

This PR generalizes the `makeMicroarch` function and also adds a `pkgsznver4` package set.

### :fishing_pole_and_fish: Why?

`-march=znver4` enables several additional features that are not exposed by `-march=x86_64_v4`. These are listed below. Additionally, `-march=znver4` enables cost-specific tunings for zen4.

```
gcc -march=x86-64-v4 -Q --help=target > v4.flags
gcc -march=znver4 -Q --help=target > znver4.flags
diff -u v4.flags znver4.flags
```

<details>
<pre>
--- v4.flags	2024-04-05 19:25:56.343759165 -0600
+++ znver4.flags	2024-04-05 19:26:05.471907237 -0600
@@ -9,11 +9,11 @@
   -m8bit-idiv                 		[disabled]
   -m96bit-long-double         		[disabled]
   -mabi=                      		sysv
-  -mabm                       		[disabled]
+  -mabm                       		[enabled]
   -maccumulate-outgoing-args  		[disabled]
   -maddress-mode=             		long
-  -madx                       		[disabled]
-  -maes                       		[disabled]
+  -madx                       		[enabled]
+  -maes                       		[enabled]
   -malign-data=               		compat
   -malign-double              		[disabled]
   -malign-functions=          		0
@@ -26,7 +26,7 @@
   -mamx-int8                  		[disabled]
   -mamx-tile                  		[disabled]
   -mandroid                   		[disabled]
-  -march=                     		x86-64-v4
+  -march=                     		znver4
   -masm=                      		att
   -mavx                       		[enabled]
   -mavx2                      		[enabled]
@@ -34,22 +34,22 @@
   -mavx256-split-unaligned-store 	[disabled]
   -mavx5124fmaps              		[disabled]
   -mavx5124vnniw              		[disabled]
-  -mavx512bf16                		[disabled]
-  -mavx512bitalg              		[disabled]
+  -mavx512bf16                		[enabled]
+  -mavx512bitalg              		[enabled]
   -mavx512bw                  		[enabled]
   -mavx512cd                  		[enabled]
   -mavx512dq                  		[enabled]
   -mavx512er                  		[disabled]
   -mavx512f                   		[enabled]
   -mavx512fp16                		[disabled]
-  -mavx512ifma                		[disabled]
+  -mavx512ifma                		[enabled]
   -mavx512pf                  		[disabled]
-  -mavx512vbmi                		[disabled]
-  -mavx512vbmi2               		[disabled]
+  -mavx512vbmi                		[enabled]
+  -mavx512vbmi2               		[enabled]
   -mavx512vl                  		[enabled]
-  -mavx512vnni                		[disabled]
+  -mavx512vnni                		[enabled]
   -mavx512vp2intersect        		[disabled]
-  -mavx512vpopcntdq           		[disabled]
+  -mavx512vpopcntdq           		[enabled]
   -mavxifma                   		[disabled]
   -mavxneconvert              		[disabled]
   -mavxvnni                   		[disabled]
@@ -62,9 +62,9 @@
   -mcet-switch                		[disabled]
   -mcld                       		[disabled]
   -mcldemote                  		[disabled]
-  -mclflushopt                		[disabled]
-  -mclwb                      		[disabled]
-  -mclzero                    		[disabled]
+  -mclflushopt                		[enabled]
+  -mclwb                      		[enabled]
+  -mclzero                    		[enabled]
   -mcmodel=                   		small
   -mcmpccxadd                 		[disabled]
   -mcpu=                      		
@@ -86,12 +86,12 @@
   -mforce-indirect-call       		[disabled]
   -mfp-ret-in-387             		[enabled]
   -mfpmath=                   		sse
-  -mfsgsbase                  		[disabled]
+  -mfsgsbase                  		[enabled]
   -mfunction-return=          		keep
   -mfused-madd                		-ffp-contract=fast
   -mfxsr                      		[enabled]
   -mgeneral-regs-only         		[disabled]
-  -mgfni                      		[disabled]
+  -mgfni                      		[enabled]
   -mglibc                     		[enabled]
   -mhard-float                		[enabled]
   -mharden-sls=               		none
@@ -128,7 +128,7 @@
   -mms-bitfields              		[disabled]
   -mmusl                      		[disabled]
   -mmwait                     		[enabled]
-  -mmwaitx                    		[disabled]
+  -mmwaitx                    		[enabled]
   -mneeded                    		[disabled]
   -mno-align-stringops        		[disabled]
   -mno-default                		[disabled]
@@ -141,23 +141,23 @@
   -mpc32                      		[disabled]
   -mpc64                      		[disabled]
   -mpc80                      		[disabled]
-  -mpclmul                    		[disabled]
+  -mpclmul                    		[enabled]
   -mpcommit                   		[disabled]
   -mpconfig                   		[disabled]
-  -mpku                       		[disabled]
+  -mpku                       		[enabled]
   -mpopcnt                    		[enabled]
   -mprefer-avx128             		-mprefer-vector-width=128
   -mprefer-vector-width=      		none
   -mpreferred-stack-boundary= 		0
   -mprefetchi                 		[disabled]
   -mprefetchwt1               		[disabled]
-  -mprfchw                    		[disabled]
+  -mprfchw                    		[enabled]
   -mptwrite                   		[disabled]
   -mpush-args                 		[enabled]
   -mraoint                    		[disabled]
-  -mrdpid                     		[disabled]
-  -mrdrnd                     		[disabled]
-  -mrdseed                    		[disabled]
+  -mrdpid                     		[enabled]
+  -mrdrnd                     		[enabled]
+  -mrdseed                    		[enabled]
   -mrecip                     		[disabled]
   -mrecip=                    		
   -mrecord-mcount             		[disabled]
@@ -170,7 +170,7 @@
   -msahf                      		[enabled]
   -mserialize                 		[disabled]
   -msgx                       		[disabled]
-  -msha                       		[disabled]
+  -msha                       		[enabled]
   -mshstk                     		[disabled]
   -mskip-rax-setup            		[disabled]
   -msoft-float                		[disabled]
@@ -181,7 +181,7 @@
   -msse4                      		[enabled]
   -msse4.1                    		[enabled]
   -msse4.2                    		[enabled]
-  -msse4a                     		[disabled]
+  -msse4a                     		[enabled]
   -msse5                      		-mavx
   -msseregparm                		[disabled]
   -mssse3                     		[enabled]
@@ -199,24 +199,24 @@
   -mtls-direct-seg-refs       		[enabled]
   -mtsxldtrk                  		[disabled]
   -mtune-ctrl=                		
-  -mtune=                     		generic
+  -mtune=                     		znver4
   -muclibc                    		[disabled]
   -muintr                     		[disabled]
   -munroll-only-small-loops   		[disabled]
-  -mvaes                      		[disabled]
+  -mvaes                      		[enabled]
   -mveclibabi=                		[default]
   -mvect8-ret-in-mem          		[disabled]
-  -mvpclmulqdq                		[disabled]
+  -mvpclmulqdq                		[enabled]
   -mvzeroupper                		[disabled]
   -mwaitpkg                   		[disabled]
-  -mwbnoinvd                  		[disabled]
+  -mwbnoinvd                  		[enabled]
   -mwidekl                    		[disabled]
   -mx32                       		[disabled]
   -mxop                       		[disabled]
   -mxsave                     		[enabled]
-  -mxsavec                    		[disabled]
-  -mxsaveopt                  		[disabled]
-  -mxsaves                    		[disabled]
+  -mxsavec                    		[enabled]
+  -mxsaveopt                  		[enabled]
+  -mxsaves                    		[enabled]
 
   Known assembler dialects (for use with the -masm= option):
     att intel
</pre>
</details>
