### PR TITLE
Rename options for nixpkgs changes upstream

### DIFF
--- a/modules/nixos/qtile.nix
+++ b/modules/nixos/qtile.nix
@@ -36,7 +36,7 @@ in
   config = lib.mkIf cfg.enable {
     services.xserver.windowManager.qtile.enable = true;
 
-    services.xserver.displayManager.sessionPackages = [ session ];
+    services.displayManager.sessionPackages = [ session ];
 
     environment.systemPackages = [ defaultRunner ];
   };


### PR DESCRIPTION
This renames some config options for `nixpkgs` changes.

Fixes the following error when running `nix flake check`:

```
error: The option `services.xserver.displayManager.sessionPackages' does not exist.
```