### PR TITLE
qtile: correct path

### DIFF
--- a/modules/nixos/qtile.nix
+++ b/modules/nixos/qtile.nix
@@ -36,7 +36,7 @@ in
   config = lib.mkIf cfg.enable {
     services.xserver.windowManager.qtile.enable = true;
 
-    services.xserver.displayManager.sessionPackages = [ session ];
+    services.displayManager.sessionPackages = [ session ];
 
     environment.systemPackages = [ defaultRunner ];
   };


### PR DESCRIPTION
### :fish: What?

 Correction of code.

### :fishing_pole_and_fish: Why?
- Fixes error ( `services.xserver.displayManager.sessionPackages` has been renamed to `services.displayManager.sessionPackages`)
