### PR TITLE
flake(conduwuit): unpin crane as the toml bug has been fixed

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -106,16 +106,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1706473297,
-        "narHash": "sha256-FbxuYIrHaXpsYCLtI1gCNJhd+qvERjPibXL3ctmVaCs=",
-        "rev": "fe812ef0dad5bb93a56c599d318be176d080281d",
-        "revCount": 493,
+        "lastModified": 1712513517,
+        "narHash": "sha256-VuLm5tTMqfS82NZAsNfsW7U+pTZ1+GcOU7gYR/Fb1Z4=",
+        "rev": "9caad1eb0c69a13ee6467035353b71a76c85ea53",
+        "revCount": 540,
         "type": "tarball",
-        "url": "https://api.flakehub.com/f/pinned/ipetkov/crane/0.16.1/018d51be-1c17-765e-babc-c9e3bc8a5a14/source.tar.gz"
+        "url": "https://api.flakehub.com/f/pinned/ipetkov/crane/0.16.4/018eb9c4-47d3-7d6b-9a55-1e0f89eabf96/source.tar.gz"
       },
       "original": {
         "type": "tarball",
-        "url": "https://flakehub.com/f/ipetkov/crane/%3D0.16.1.tar.gz"
+        "url": "https://flakehub.com/f/ipetkov/crane/%2A.tar.gz"
       }
     },
     "fenix": {

--- a/flake.nix
+++ b/flake.nix
@@ -55,7 +55,7 @@ rec {
       inputs.flake-utils.follows = "flake-utils";
     };
     crane = {
-      url = "https://flakehub.com/f/ipetkov/crane/=0.16.1.tar.gz"; # This is the last commit that does not break conduwuit
+      url = "https://flakehub.com/f/ipetkov/crane/*.tar.gz";
       inputs.nixpkgs.follows = "nixpkgs";
     };
     flake-compat = {


### PR DESCRIPTION
### :fish: What?

Unpins `crane` from flake.nix for conduwuit builds

### :fishing_pole_and_fish: Why?

The TOML mangle bug has been fixed:

https://github.com/girlbossceo/conduwuit/pull/298
https://github.com/ipetkov/crane/issues/527#issuecomment-2067882206
