### PR TITLE
virtualboxKvm: init cache

### DIFF
--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -280,6 +280,8 @@ in
   telegram-desktop_git = callOverride ../pkgs/telegram-desktop-git { };
   tg-owt_git = callOverride ../pkgs/tg-owt-git { };
 
+  virtualboxKvm = nixpkgs.legacyPackages.${final.system}.virtualboxKvm;
+
   vulkanPackages_latest = callOverride ../pkgs/vulkan-versioned
     { vulkanVersions = importJSON ../pkgs/vulkan-versioned/latest.json; };
 


### PR DESCRIPTION
### :fish: What?

Adds virtualboxKvm to be cached by Nyx.

### :fishing_pole_and_fish: Why?

I currently have to compile it myself everytime, which is a lengthy process.
