### PR TITLE
firedragon: add back wrapper, without no .desktop

### DIFF
--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -145,7 +145,11 @@ in
 
   extra-cmake-modules_git = callOverride ../pkgs/extra-cmake-modules-git/latest.nix { };
 
-  firedragon = final.callPackage ../pkgs/firedragon { };
+  firedragon-unwrapped = final.callPackage ../pkgs/firedragon { };
+
+  firedragon = final.wrapFirefox final.firedragon-unwrapped {
+    libName = "firedragon";
+  };
 
   firefox-unwrapped_nightly = final.callPackage ../pkgs/firefox-nightly { };
   firefox_nightly = final.wrapFirefox final.firefox-unwrapped_nightly {


### PR DESCRIPTION
### :fish: What?

1. Added back the firefox wrapper. 

### :fishing_pole_and_fish: Why?

- App was working as expected but the .desktop is seemingly not present once installed in the system without it.

### :fish_cake: Pending

- [x] Complain with linter;