### PR TITLE
firedragon: fix update script (again)

### DIFF
--- a/pkgs/firedragon/update.nix
+++ b/pkgs/firedragon/update.nix
@@ -29,7 +29,7 @@ writeShellScript "update-firedragon" ''
   PATH=${path}
 
   srcJson=pkgs/firedragon/version.json
-  localVer=$(jq -r .versison <$srcJson)
+  localVer=$(jq -r .version <$srcJson)
 
   latestVer=$(curl -s https://gitlab.com/api/v4/projects/55893651/releases/ | jq '.[0].tag_name' -r | sed 's/v//g')
 
@@ -37,7 +37,7 @@ writeShellScript "update-firedragon" ''
     exit 0
   fi
 
-  latestSha256=$(nix-prefetch-url --type sha256 "https://gitlab.com/api/v4/projects/55893651/packages/generic/firedragon/${latestVer}/firedragon-v${latestVer}.source.tar.zst")
+  latestSha256=$(nix-prefetch-url --type sha256 "https://gitlab.com/api/v4/projects/55893651/packages/generic/firedragon/$latestVer/firedragon-v$latestVer.source.tar.zst")
   latestHash=$(nix-hash --to-sri --type sha256 "$latestSha256")
 
   jq \


### PR DESCRIPTION
### :fish: What?

1. Fixed the update script

### :fishing_pole_and_fish: Why?

- Curly braces made the bash variable a Nix variable and broke the update process therefore.

### :fish_cake: Pending

- [x] Complain with linter;
