### PR TITLE
nixos/scx: improve description, add stricter type checking

### DIFF
--- a/modules/nixos/scx.nix
+++ b/modules/nixos/scx.nix
@@ -1,15 +1,27 @@
 { lib, pkgs, config, ... }:
 # Originally from https://github.com/nix-community/nur-combined/blob/1b7e474178abfdeb6f89142d37fcc4854a16a5a1/repos/oluceps/modules/scx.nix
-with lib;
 let
   cfg = config.chaotic.scx;
 in
 {
   options.chaotic.scx = {
-    enable = mkEnableOption "scx service";
-    package = mkPackageOptionMD pkgs "scx" { };
-    scheduler = mkOption {
-      type = types.str;
+    enable = lib.mkEnableOption "scx service";
+    package = lib.mkPackageOptionMD pkgs "scx" { };
+    scheduler = lib.mkOption {
+      type = lib.types.enum [
+        "scx_central"
+        "scx_flatcg"
+        "scx_lavd"
+        "scx_layered"
+        "scx_nest"
+        "scx_pair"
+        "scx_qmap"
+        "scx_rlfifo"
+        "scx_rustland"
+        "scx_rusty"
+        "scx_simple"
+        "scx_userland"
+      ];
       default = "scx_rustland";
       example = "scx_rusty";
       description = ''
@@ -18,7 +30,7 @@ in
     };
   };
 
-  config = mkIf cfg.enable {
+  config = lib.mkIf cfg.enable {
     environment.systemPackages = [ cfg.package ];
 
     systemd.services.scx = {

--- a/modules/nixos/scx.nix
+++ b/modules/nixos/scx.nix
@@ -5,7 +5,13 @@ let
 in
 {
   options.chaotic.scx = {
-    enable = lib.mkEnableOption "scx service";
+    enable = lib.mkEnableOption ''scx service, a 
+    scheduler daemon with wide variety of
+    scheduling algorithms, that can be used to
+    improve system performance. Requires a kernel
+    with the SCX patchset applied. Currently
+    all cachyos kernels have this patchset applied.
+    '';
     package = lib.mkPackageOptionMD pkgs "scx" { };
     scheduler = lib.mkOption {
       type = lib.types.enum [


### PR DESCRIPTION
### :fish: What?

1. Add stricter type checking for `chaotic.scx.scheduler` option 
2. Improved description of `chaotic.scx.enable` option.
3. Cleanup `with lib;` by using `lib.` explicitly

### :fishing_pole_and_fish: Why?

I don't see a reason to not :)

### :fish_cake: Pending

- [ ] Complain with linter;
- [ ] Remove some temporary fix;
- [ ] Publishing to news' channel.
