### PR TITLE
nixos/scx: add assertions

### DIFF
--- a/modules/nixos/scx.nix
+++ b/modules/nixos/scx.nix
@@ -48,5 +48,36 @@ in
         Restart = "on-failure";
       };
     };
+
+    assertions = [
+      {
+        assertion = config.boot.kernelPackages.kernel.passthru.config.CONFIG_BPF == "y";
+        message = "SCX needs a kernel with CONFIG_BPF";
+      }
+      {
+        assertion = config.boot.kernelPackages.kernel.passthru.config.CONFIG_BPF_EVENTS == "y";
+        message = "SCX needs a kernel with CONFIG_BPF_EVENTS";
+      }
+      {
+        assertion = config.boot.kernelPackages.kernel.passthru.config.CONFIG_BPF_JIT == "y";
+        message = "SCX needs a kernel with CONFIG_BPF_JIT";
+      }
+      {
+        assertion = config.boot.kernelPackages.kernel.passthru.config.CONFIG_BPF_SYSCALL == "y";
+        message = "SCX needs a kernel with CONFIG_BPF_SYSCALL";
+      }
+      {
+        assertion = config.boot.kernelPackages.kernel.passthru.config.CONFIG_DEBUG_INFO_BTF == "y";
+        message = "SCX needs a kernel with CONFIG_DEBUG_INFO_BTF";
+      }
+      {
+        assertion = config.boot.kernelPackages.kernel.passthru.config.CONFIG_FTRACE == "y";
+        message = "SCX needs a kernel with CONFIG_FTRACE";
+      }
+      {
+        assertion = config.boot.kernelPackages.kernel.passthru.config.CONFIG_SCHED_CLASS_EXT == "y";
+        message = "SCX needs a kernel with CONFIG_SCHED_CLASS_EXT";
+      }
+    ];
   };
 }

--- a/modules/nixos/scx.nix
+++ b/modules/nixos/scx.nix
@@ -5,13 +5,12 @@ let
 in
 {
   options.chaotic.scx = {
-    enable = lib.mkEnableOption ''scx service, a 
-    scheduler daemon with wide variety of
+    enable = lib.mkEnableOption ''scx service,
+    a scheduler daemon with wide variety of
     scheduling algorithms, that can be used to
     improve system performance. Requires a kernel
     with the SCX patchset applied. Currently
-    all cachyos kernels have this patchset applied.
-    '';
+    all cachyos kernels have this patchset applied'';
     package = lib.mkPackageOptionMD pkgs "scx" { };
     scheduler = lib.mkOption {
       type = lib.types.enum [


### PR DESCRIPTION
### :fish: What?

It's better to add assertions.

### :fishing_pole_and_fish: Why?

This would help detecting whether the current kernel is suitable to run scx service on.

### :fish_cake: Pending

- [ ] Complain with linter;
- [ ] Remove some temporary fix;
- [ ] Publishing to news' channel.

### :whale: Extras

- I like chocolate cake.
