### PR TITLE
nixos/hdr: remove hdr.kernelPackages option and assert AMD_PRIVATE_COLOR

### DIFF
--- a/maintenance/tools/linter/default.nix
+++ b/maintenance/tools/linter/default.nix
@@ -19,7 +19,7 @@ writeShellScriptBin "chaotic-nyx-lint" ''
   ${Statix} check .
   ${Deadnix} --fail .
 
-  _SHORT_FILES=$(${Find} . -type f -name '*.nix' | (xargs ${Rg} -P '[^\w"\/\{](?!_?xs|_?id|_?[kvx]:)(_?[a-zA-Z_][a-zA-Z_-]?:)(?!\w)' || true))
+  _SHORT_FILES=$(${Find} . -type f -name '*.nix' | (xargs ${Rg} -P '[^\w"-\/\{](?!_?xs|_?id|_?[kvx]:)(_?[a-zA-Z_][a-zA-Z_-]?:)(?!\w)' || true))
   if [[ -n "$_SHORT_FILES" ]]; then
     echo "Lambda parameters can't have two letters or less (except: x, xs, id, k, v):"
     echo "$_SHORT_FILES"

--- a/modules/nixos/hdr.nix
+++ b/modules/nixos/hdr.nix
@@ -24,36 +24,36 @@ let
   };
 in
 {
-  options.chaotic.hdr = with lib; {
+  options.chaotic.hdr = {
     enable =
-      mkEnableOption ''AMD-HDR as seen in
+      lib.mkEnableOption ''AMD-HDR as seen in
         https://lore.kernel.org/amd-gfx/20230810160314.48225-1-mwen@igalia.com/
       '';
     specialisation.enable =
-      mkOption {
+      lib.mkOption {
         default = true;
         example = false;
-        type = types.bool;
+        type = lib.types.bool;
         description = ''
           Isolates the changes in a specialisation.
         '';
       };
     kernelPackages =
-      mkOption {
+      lib.mkOption {
         default = pkgs.linuxPackages_cachyos;
-        defaultText = literalExpression "pkgs.linuxPackages_cachyos";
-        example = literalExpression "pkgs.linuxKernel.packages.linux_hdr";
-        type = types.raw;
+        defaultText = lib.literalExpression "pkgs.linuxPackages_cachyos";
+        example = lib.literalExpression "pkgs.linuxKernel.packages.linux_hdr";
+        type = lib.types.raw;
         description = ''
           Kernel+packages with "AMD Color Management" patches applied.
         '';
       };
     wsiPackage =
-      mkOption {
+      lib.mkOption {
         default = pkgs.gamescope-wsi;
-        defaultText = literalExpression "pkgs.gamescope-wsi";
-        example = literalExpression "pkgs.gamescope-wsi_git";
-        type = types.package;
+        defaultText = lib.literalExpression "pkgs.gamescope-wsi";
+        example = lib.literalExpression "pkgs.gamescope-wsi_git";
+        type = lib.types.package;
         description = ''
           Gamescope WSI package to use
         '';

--- a/modules/nixos/hdr.nix
+++ b/modules/nixos/hdr.nix
@@ -23,10 +23,10 @@ let
     environment.systemPackages = [ cfg.wsiPackage ];
   };
 
-  sysConfig = lib.mkIf (!cfg.specialisation.enable) (configuration (x: x));
+  sysConfig = lib.mkIf (!cfg.specialisation.enable) configuration;
 
   specConfig = lib.mkIf cfg.specialisation.enable {
-    specialisation.hdr.configuration = configuration lib.mkForce // {
+    specialisation.hdr.configuration = configuration // {
       system.nixos.tags = [ "hdr" ];
     };
   };

--- a/modules/nixos/hdr.nix
+++ b/modules/nixos/hdr.nix
@@ -3,7 +3,6 @@ let
   cfg = config.chaotic.hdr;
 
   configuration = strength: {
-    boot.kernelPackages = strength cfg.kernelPackages;
     programs.steam.gamescopeSession.enable = true; # HDR can only be used with headless Gamescope right now...
     programs.gamescope = {
       args = [ "--hdr-enabled" ];
@@ -38,16 +37,6 @@ in
           Isolates the changes in a specialisation.
         '';
       };
-    kernelPackages =
-      lib.mkOption {
-        default = pkgs.linuxPackages_cachyos;
-        defaultText = lib.literalExpression "pkgs.linuxPackages_cachyos";
-        example = lib.literalExpression "pkgs.linuxKernel.packages.linux_hdr";
-        type = lib.types.raw;
-        description = ''
-          Kernel+packages with "AMD Color Management" patches applied.
-        '';
-      };
     wsiPackage =
       lib.mkOption {
         default = pkgs.gamescope-wsi;
@@ -60,4 +49,11 @@ in
       };
   };
   config = lib.mkIf cfg.enable (lib.mkMerge [ sysConfig specConfig ]);
+
+  imports = [
+    (lib.mkRemovedOptionModule
+      [ "chaotic" "hdr" "kernelPackages" ]
+      "kernelPackages option is deprecated. Please use a kernel built with the `AMD_PRIVATE_COLOR` flag."
+    )
+  ];
 }

--- a/modules/nixos/hdr.nix
+++ b/modules/nixos/hdr.nix
@@ -2,7 +2,16 @@
 let
   cfg = config.chaotic.hdr;
 
-  configuration = strength: {
+  assertConfig = {
+    assertions = [
+      {
+        assertion = (config.boot.kernelPackages.kernel.passthru.config.CONFIG_AMD_PRIVATE_COLOR or null) == "y";
+        message = "HDR needs a kernel compiled with CONFIG_AMD_PRIVATE_COLOR";
+      }
+    ];
+  };
+
+  configuration = {
     programs.steam.gamescopeSession.enable = true; # HDR can only be used with headless Gamescope right now...
     programs.gamescope = {
       args = [ "--hdr-enabled" ];
@@ -48,7 +57,7 @@ in
         '';
       };
   };
-  config = lib.mkIf cfg.enable (lib.mkMerge [ sysConfig specConfig ]);
+  config = lib.mkIf cfg.enable (lib.mkMerge [ sysConfig specConfig assertConfig ]);
 
   imports = [
     (lib.mkRemovedOptionModule

--- a/modules/nixos/scx.nix
+++ b/modules/nixos/scx.nix
@@ -52,31 +52,31 @@ in
     assertions = [
       {
         assertion = (config.boot.kernelPackages.kernel.passthru.config.CONFIG_BPF or null) == "y";
-        message = "SCX needs a kernel with CONFIG_BPF";
+        message = "SCX needs a kernel compiled with CONFIG_BPF";
       }
       {
         assertion = (config.boot.kernelPackages.kernel.passthru.config.CONFIG_BPF_EVENTS or null) == "y";
-        message = "SCX needs a kernel with CONFIG_BPF_EVENTS";
+        message = "SCX needs a kernel compiled with CONFIG_BPF_EVENTS";
       }
       {
         assertion = (config.boot.kernelPackages.kernel.passthru.config.CONFIG_BPF_JIT or null) == "y";
-        message = "SCX needs a kernel with CONFIG_BPF_JIT";
+        message = "SCX needs a kernel compiled with CONFIG_BPF_JIT";
       }
       {
         assertion = (config.boot.kernelPackages.kernel.passthru.config.CONFIG_BPF_SYSCALL or null) == "y";
-        message = "SCX needs a kernel with CONFIG_BPF_SYSCALL";
+        message = "SCX needs a kernel compiled with CONFIG_BPF_SYSCALL";
       }
       {
         assertion = (config.boot.kernelPackages.kernel.passthru.config.CONFIG_DEBUG_INFO_BTF or null) == "y";
-        message = "SCX needs a kernel with CONFIG_DEBUG_INFO_BTF";
+        message = "SCX needs a kernel compiled with CONFIG_DEBUG_INFO_BTF";
       }
       {
         assertion = (config.boot.kernelPackages.kernel.passthru.config.CONFIG_FTRACE or null) == "y";
-        message = "SCX needs a kernel with CONFIG_FTRACE";
+        message = "SCX needs a kernel compiled with CONFIG_FTRACE";
       }
       {
         assertion = (config.boot.kernelPackages.kernel.passthru.config.CONFIG_SCHED_CLASS_EXT or null) == "y";
-        message = "SCX needs a kernel with CONFIG_SCHED_CLASS_EXT";
+        message = "SCX needs a kernel compiled with CONFIG_SCHED_CLASS_EXT";
       }
     ];
   };


### PR DESCRIPTION
### :fish: What?

1. This deprecates and removes `chaotic.hdr.kernelPackages` option.
2. In additon, adds assertion that for HDR feature to work, kernel has to be built with proper support, ie, with AMD_PRIVATE_COLOR.

### :fishing_pole_and_fish: Why?

- (1) Closes https://github.com/chaotic-cx/nyx/issues/630

### :fish_cake: Pending

- [x] Complain with linter;
- [ ] Publishing to news' channel.

### :whale: Extras

- Perhaps this change needs to be notified in the news channel.