### PR TITLE
linux-cachyos: revamp update script

### DIFF
--- a/pkgs/linux-cachyos/0001-Add-extra-version-CachyOS-rc.patch
+++ b/pkgs/linux-cachyos/0001-Add-extra-version-CachyOS-rc.patch
@@ -1,5 +1,5 @@
 --- a/Makefile
 +++ b/Makefile
 @@ -6 +6 @@
--EXTRAVERSION = -rc4
-+EXTRAVERSION = -rc4-cachyos
+-EXTRAVERSION = -rc5
++EXTRAVERSION = -rc5-cachyos

--- a/pkgs/linux-cachyos/default.nix
+++ b/pkgs/linux-cachyos/default.nix
@@ -26,7 +26,7 @@ in
     taste = "linux-cachyos";
     configPath = ./config-nix/cachyos.x86_64-linux.nix;
     # since all flavors use the same versions.json, we just need the updateScript in one of them
-    withUpdateScript = true;
+    withUpdateScript = "stable";
   };
 
   cachyos-rc = mkCachyKernel {
@@ -39,6 +39,8 @@ in
         inherit (mainVersions.linuxRc) version hash;
       };
     };
+
+    withUpdateScript = "rc";
     # Prevent building kernel modules for rc kernel
     packagesExtend = _kernel: _final: prev: prev // { recurseForDerivations = false; };
   };

--- a/pkgs/linux-cachyos/default.nix
+++ b/pkgs/linux-cachyos/default.nix
@@ -33,7 +33,7 @@ in
     taste = "linux-cachyos-rc";
     configPath = ./config-nix/cachyos-rc.x86_64-linux.nix;
 
-    cpuSched = "eevdf"; # rc kernel does not have scx patches ready, usually
+    # cpuSched = "eevdf"; # rc kernel does not have scx patches ready, usually
     versions = mainVersions // {
       linux = {
         inherit (mainVersions.linuxRc) version hash;

--- a/pkgs/linux-cachyos/kernel.nix
+++ b/pkgs/linux-cachyos/kernel.nix
@@ -46,6 +46,8 @@ in
     };
     updateScript = null;
   } // nyxUtils.optionalAttr "updateScript"
-    cachyConfig.withUpdateScript
-    (callPackage ./update.nix { });
+    (cachyConfig.withUpdateScript == "stable" || cachyConfig.withUpdateScript == "rc")
+    (callPackage ./update.nix {
+      inherit (cachyConfig) withUpdateScript;
+    });
 })

--- a/pkgs/linux-cachyos/packages-for.nix
+++ b/pkgs/linux-cachyos/packages-for.nix
@@ -22,7 +22,7 @@
 , withHDR ? true
 , withoutDebug ? false
 , description ? "Linux EEVDF-BORE scheduler Kernel by CachyOS with other patches and improvements"
-, withUpdateScript ? false
+, withUpdateScript ? null
 , zfs-source
 , packagesExtend ? null
 }:

--- a/pkgs/linux-cachyos/update.nix
+++ b/pkgs/linux-cachyos/update.nix
@@ -10,6 +10,7 @@
 , nix
 , nix-prefetch-git
 , moreutils
+, withUpdateScript
 }:
 let
   path = lib.makeBinPath [
@@ -28,23 +29,68 @@ in
 writeShellScript "update-cachyos" ''
   set -euo pipefail
   PATH=${path}
-
   srcJson=pkgs/linux-cachyos/versions.json
-  localVer=$(jq -r .linux.version < $srcJson)
-  localRcVer=$(jq -r .linuxRc.version < $srcJson)
 
-  latestVer=$(curl 'https://raw.githubusercontent.com/CachyOS/linux-cachyos/master/linux-cachyos/.SRCINFO' | grep -Po '(?<=pkgver = )(.+)$')
-  latestRcVer=$(curl 'https://raw.githubusercontent.com/CachyOS/linux-cachyos/master/linux-cachyos-rc/.SRCINFO' | grep -Po '(?<=pkgver = )(.+)$' | sed 's/\.rc/-rc/')
+  update_kernel () {
+    local ver=$1
+    local url=$2
 
-  if [[ "$localVer" == "$latestVer" ]]; then
-    exit 0
+    local hash_sha256=$(nix-prefetch-url --type sha256 $url)
+    local hash_sri=$(nix-hash --to-sri --type sha256 $hash_sha256)
+    echo $hash_sri
+  }
+
+  if [[ "${withUpdateScript}" == "rc" ]]; then
+    localVer=$(jq -r .linuxRc.version < $srcJson)
+    latestVer=$(curl 'https://raw.githubusercontent.com/CachyOS/linux-cachyos/master/linux-cachyos-rc/.SRCINFO' | grep -Po '(?<=pkgver = )(.+)$' | sed 's/\.rc/-rc/')
+    if [[ "$localVer" == "$latestVer" ]]; then
+      exit 0
+    fi
+    
+    url="https://git.kernel.org/torvalds/t/linux-''${latestVer%.0}.tar.gz"
+    latestHash=$(update_kernel $latestVer $url)
+
+    cat "$(nix build '.#packages.x86_64-linux.linuxPackages_cachyos-rc.kernel.kconfigToNix' --no-link --print-out-paths)" \
+    > pkgs/linux-cachyos/config-nix/cachyos-rc.x86_64-linux.nix
+
+    jq \
+    --arg latestRcVer "$latestVer" --arg latestRcHash "$latestHash" \
+    ".linuxRc.version = \$latestRcVer | .linuxRc.hash = \$latestRcHash " \
+    "$srcJson" | sponge "$srcJson"
+
+    message="linux_cachyos-rc: $localVer -> $latestVer"
+  elif [[ "${withUpdateScript}" == "stable" ]]; then
+    localVer=$(jq -r .linux.version < $srcJson)
+    latestVer=$(curl 'https://raw.githubusercontent.com/CachyOS/linux-cachyos/master/linux-cachyos/.SRCINFO' | grep -Po '(?<=pkgver = )(.+)$')
+    if [[ "$localVer" == "$latestVer" ]]; then
+      exit 0
+    fi
+    
+    url="https://cdn.kernel.org/pub/linux/kernel/v6.x/linux-''${latestVer%.0}.tar.xz"
+    latestHash=$(update_kernel $latestVer $url)
+
+    cat "$(nix build '.#packages.x86_64-linux.linuxPackages_cachyos.kernel.kconfigToNix' --no-link --print-out-paths)" \
+      > pkgs/linux-cachyos/config-nix/cachyos.x86_64-linux.nix
+
+    cat "$(nix build '.#packages.x86_64-linux.linuxPackages_cachyos-lto.kernel.kconfigToNix' --no-link --print-out-paths)" \
+      > pkgs/linux-cachyos/config-nix/cachyos-lto.x86_64-linux.nix
+
+    cat "$(nix build '.#packages.x86_64-linux.linuxPackages_cachyos-server.kernel.kconfigToNix' --no-link --print-out-paths)" \
+      > pkgs/linux-cachyos/config-nix/cachyos-server.x86_64-linux.nix
+
+    cat "$(nix build '.#packages.x86_64-linux.linuxPackages_cachyos-hardened.kernel.kconfigToNix' --no-link --print-out-paths)" \
+      > pkgs/linux-cachyos/config-nix/cachyos-hardened.x86_64-linux.nix
+
+  jq \
+    --arg latestVer "$latestVer" --arg latestHash "$latestHash" \
+    ".linux.version = \$latestVer | .linux.hash = \$latestHash " \
+    "$srcJson" | sponge "$srcJson"
+
+    message="linux_cachyos: $localVer -> $latestVer"
+  else
+    echo "Error, wrong kernel selected, please either update linux_cachyos or linux_cachyos-rc"
+    exit 1
   fi
-
-  latestSha256=$(nix-prefetch-url --type sha256 "https://cdn.kernel.org/pub/linux/kernel/v6.x/linux-''${latestVer%.0}.tar.xz")
-  latestHash=$(nix-hash --to-sri --type sha256 $latestSha256)
-
-  latestRcSha256=$(nix-prefetch-url --type sha256 "https://git.kernel.org/torvalds/t/linux-''${latestRcVer%.0}.tar.gz")
-  latestRcHash=$(nix-hash --to-sri --type sha256 $latestRcSha256)
 
   configRepo=$(nix-prefetch-git --quiet 'https://github.com/CachyOS/linux-cachyos.git')
   configRev=$(echo "$configRepo" | jq -r .rev)
@@ -60,38 +106,14 @@ writeShellScript "update-cachyos" ''
   zfsHash=$(echo "$zfsRepo" | jq -r .hash)
 
   jq \
-    --arg latestVer "$latestVer" --arg latestHash "$latestHash" \
-    --arg latestRcVer "$latestRcVer" --arg latestRcHash "$latestRcHash" \
     --arg configRev "$configRev" --arg configHash "$configHash" \
     --arg patchesRev "$patchesRev" --arg patchesHash "$patchesHash" \
     --arg zfsRev "$zfsRev" --arg zfsHash "$zfsHash" \
-    ".linux.version = \$latestVer | .linux.hash = \$latestHash |\
-    .linuxRc.version = \$latestRcVer | .linuxRc.hash = \$latestRcHash |\
-      .config.rev = \$configRev | .config.hash = \$configHash |\
+      ".config.rev = \$configRev | .config.hash = \$configHash |\
       .patches.rev = \$patchesRev | .patches.hash = \$patchesHash |\
       .zfs.rev = \$zfsRev | .zfs.hash = \$zfsHash" \
     "$srcJson" | sponge "$srcJson"
 
-  cat "$(nix build '.#packages.x86_64-linux.linuxPackages_cachyos.kernel.kconfigToNix' --no-link --print-out-paths)" \
-    > pkgs/linux-cachyos/config-nix/cachyos.x86_64-linux.nix
-
-  cat "$(nix build '.#packages.x86_64-linux.linuxPackages_cachyos-rc.kernel.kconfigToNix' --no-link --print-out-paths)" \
-    > pkgs/linux-cachyos/config-nix/cachyos-rc.x86_64-linux.nix
-
-  cat "$(nix build '.#packages.x86_64-linux.linuxPackages_cachyos-lto.kernel.kconfigToNix' --no-link --print-out-paths)" \
-    > pkgs/linux-cachyos/config-nix/cachyos-lto.x86_64-linux.nix
-
-  cat "$(nix build '.#packages.x86_64-linux.linuxPackages_cachyos-server.kernel.kconfigToNix' --no-link --print-out-paths)" \
-    > pkgs/linux-cachyos/config-nix/cachyos-server.x86_64-linux.nix
-
-  cat "$(nix build '.#packages.x86_64-linux.linuxPackages_cachyos-hardened.kernel.kconfigToNix' --no-link --print-out-paths)" \
-    > pkgs/linux-cachyos/config-nix/cachyos-hardened.x86_64-linux.nix
-
   git add $srcJson pkgs/linux-cachyos/config-*.nix
-  if [ "$localVer" != "$latestVer" ]; then
-    git commit -m "linux_cachyos: $localVer -> $latestVer"
-  else
-    git commit -m "linux_cachyos-rc: $localRcVer -> $latestRcVer"
-  fi
+  git commit -m "$message"
 ''
-

--- a/pkgs/linux-cachyos/versions.json
+++ b/pkgs/linux-cachyos/versions.json
@@ -7,18 +7,18 @@
     "hash": "sha256-XUNm4riZmPJ0q+A1V+87x4tY5H/GLBAtUeb0nl7Za0s="
   },
   "linuxRc": {
-    "version": "6.10-rc4",
-    "hash": "sha256-PUxS9xxHFX5sh9Xny/+NZ8AFSNIYkDIvUnS+6+e9P3w="
+    "version": "6.10-rc5",
+    "hash": "sha256-VjXGm3LtHZzWim+XT01ssxHw/97kra7/pdSZIqfyHq8="
   },
   "_config": "latest commit from https://github.com/CachyOS/linux-cachyos/commits/master/linux-cachyos",
   "config": {
-    "rev": "5f0b8639b592d80f3fce63a573610ff57372562d",
-    "hash": "sha256-qwqRXQeLns3C70QwqhAmrzRgDLVipZZISHp9bxQcNGY="
+    "rev": "32d5dab368925474f71a7cff103d78a3141dab84",
+    "hash": "sha256-ixoWCHXriLfM9gan7fDvqejOGJpyFWOOFXu3CqOZOgs="
   },
   "_patches": "latest commit from https://github.com/CachyOS/kernel-patches/commits/master/x.y",
   "patches": {
-    "rev": "97d61eeeab14589187757e923f4207a6a2a932ea",
-    "hash": "sha256-DAeFknFB9u3iHCgx6THfiDvigHqBbjG1zV9KR8y9r5s="
+    "rev": "441903ed722b3d3738ab205da066ff4062f51d77",
+    "hash": "sha256-DGjvuQPEPWq/OqNORuRCa0IM2eD6Ag9pVUrve6UNAzA="
   },
   "_zfs": "search for `git+https://github.com/cachyos/zfs.git` in config's PKGBUILD",
   "zfs": {


### PR DESCRIPTION
### :fish: What?

1. Rework update script
2. Now we can run:

```
  bash $(nix build --no-link --print-out-paths **.#linuxPackages_cachyos.kernel.updateScript);
```

or

```
  bash $(nix build --no-link --print-out-paths **.#linuxPackages_cachyos-rc.kernel.updateScript);
```

to update seperately.

### :whale: Extras
- I like chocolate cake.
