### PR TITLE
linux-cachyos-rc: update updateScript

### DIFF
--- a/pkgs/linux-cachyos/update.nix
+++ b/pkgs/linux-cachyos/update.nix
@@ -2,6 +2,7 @@
 , lib
 , coreutils
 , findutils
+, gawk
 , gnugrep
 , gnused
 , curl
@@ -17,6 +18,7 @@ let
     coreutils
     curl
     findutils
+    gawk
     gnugrep
     gnused
     jq
@@ -46,7 +48,11 @@ writeShellScript "update-cachyos" ''
     if [[ "$localVer" == "$latestVer" ]]; then
       exit 0
     fi
-    
+
+    localSuffix=$(echo $localVer | awk -F'-' '{print $2}')
+    latestSuffix=$(echo $latestVer | awk -F'-' '{print $2}')
+    sed -i "s/-$localSuffix/-$latestSuffix/g" pkgs/linux-cachyos/0001-Add-extra-version-CachyOS-rc.patch
+
     url="https://git.kernel.org/torvalds/t/linux-''${latestVer%.0}.tar.gz"
     latestHash=$(update_kernel $latestVer $url)
 


### PR DESCRIPTION
### :fish: What?

1. linux cachyos rc update script now updates the rc kernel version patch as well
2. linux-cachyos-rc: 6.10-rc5 -> rc6

### :fishing_pole_and_fish: Why?

- (1) No extra work needed from now on!

### :fish_cake: Pending

- [ ] Actual updating the rc kernel, keep an eye on https://github.com/CachyOS/linux-cachyos/blob/master/linux-cachyos-rc/.SRCINFO


### :whale: Extras

- I like chocolate cake.
