### PR TITLE
nixos/scx: lib.mkPackageOptionMD -> lib.mkPackageOption

### DIFF
--- a/modules/nixos/scx.nix
+++ b/modules/nixos/scx.nix
@@ -11,7 +11,7 @@ in
     improve system performance. Requires a kernel
     with the SCX patchset applied. Currently
     all cachyos kernels have this patchset applied'';
-    package = lib.mkPackageOptionMD pkgs "scx" { };
+    package = lib.mkPackageOption pkgs "scx" { };
     scheduler = lib.mkOption {
       type = lib.types.enum [
         "scx_central"


### PR DESCRIPTION
from lib.mkPackageOptionMD to lib.mkPackageOption

### :fish: What?

1. Migrated from deparced `lib.mkPackageOptionMD` to `lib.mkPackageOption`

### :fishing_pole_and_fish: Why?

- (1) To get rid of deparced options. 👀 

### :fish_cake: Pending

- [x] Be updated and too bleeding edge as always! 

### :whale: Extras

- I wish this PR IS suiting your PR requirements! 