### PR TITLE
Added "scx_bpfland" to the scx module.

### DIFF
--- a/modules/nixos/scx.nix
+++ b/modules/nixos/scx.nix
@@ -14,6 +14,7 @@ in
     package = lib.mkPackageOption pkgs "scx" { };
     scheduler = lib.mkOption {
       type = lib.types.enum [
+        "scx_bpfland"
         "scx_central"
         "scx_flatcg"
         "scx_lavd"


### PR DESCRIPTION
### :fish: What?

Added an "scx_bpfland" type to the scx module.

### :fishing_pole_and_fish: Why?

(3) Fixes error:

A definition for option chaotic.scx.scheduler' is not of type one of "scx_central", "scx_flatcg", "scx_lavd", "scx_layered", "scx_nest", "scx_pair", "scx_qmap", "scx_rlfifo", "scx_rustland", "scx_rusty", "scx_simple", "scx_userland"'.

- I like chocolate cake.
