### PR TITLE
linux-cachyos: disable tomoyo

### DIFF
--- a/pkgs/linux-cachyos/prepare.nix
+++ b/pkgs/linux-cachyos/prepare.nix
@@ -76,6 +76,8 @@ let
       "-d DEFAULT_FQ_CODEL"
       "-e DEFAULT_FQ"
       "--set-str DEFAULT_NET_SCH fq"
+      # TOMOYO not packaged in nixpkgs
+      "-d SECURITY_TOMOYO"
     ]
     ++ ltoConfig
     ++ ticksHzConfig


### PR DESCRIPTION
### :fish: What?

We don't package TOMOYO in nixpkgs, nor we have a module. So no need to enable this feature.
