### PR TITLE
LLVM xone with cachyos-lto

### DIFF
--- a/pkgs/linux-cachyos/default.nix
+++ b/pkgs/linux-cachyos/default.nix
@@ -47,7 +47,7 @@ in
     description = "Linux EEVDF-BORE scheduler Kernel by CachyOS built with LLVM and Thin LTO";
 
     packagesExtend = kernel: _finalModules: builtins.mapAttrs (k: v:
-      if builtins.elem k [ "zenpower" "v4l2loopback" "zfs_cachyos" "virtualbox" ]
+      if builtins.elem k [ "zenpower" "v4l2loopback" "zfs_cachyos" "virtualbox" "xone" ]
       then llvmModuleOverlay kernel v
       else v
     );


### PR DESCRIPTION
### :fish: What?

When building xone with cachyos-lto throws an error and can't build nixos.

![image](https://github.com/user-attachments/assets/7847593f-2809-4a98-8873-f1b6cb71c296)

### :fishing_pole_and_fish: Why?

This fix the problem with xone and cachyos-lto making nixos buildable again.

### :fish_cake: Pending

- [x] Complain with linter;
- [x] Remove some temporary fix;
- [ ] Publishing to news' channel.

### :whale: Extras

A fast workaround is to change hardware.xone.enable to:


```
boot = {
  blacklistedKernelModules = [ "xpad" "mt76x2u" ];
  extraModulePackages = [ pkgs.linuxPackages_cachyos.xone ];
};
hardware.firmware = [ pkgs.xow_dongle-firmware ];
```


