### PR TITLE
firedragon: remove conflicting patch

### DIFF
--- a/pkgs/firedragon/default.nix
+++ b/pkgs/firedragon/default.nix
@@ -1,44 +1,53 @@
 { buildMozillaMach
 , callPackage
 , lib
+, nyxUtils
+, stdenv
 }:
 let
   firedragon-src = callPackage ./firedragon.nix { };
-in
-((buildMozillaMach {
-  applicationName = "FireDragon";
-  binaryName = "firedragon";
-  pname = "firedragon";
-  branding = "browser/branding/firedragon";
-  requireSigning = false;
-  allowAddonSideload = true;
 
-  inherit (firedragon-src) extraConfigureFlags extraNativeBuildInputs extraPassthru packageVersion src version;
+  mach = ((buildMozillaMach {
+    applicationName = "FireDragon";
+    binaryName = "firedragon";
+    pname = "firedragon";
+    branding = "browser/branding/firedragon";
+    requireSigning = false;
+    allowAddonSideload = true;
 
-  updateScript = callPackage ./update.nix { };
+    inherit (firedragon-src) extraConfigureFlags extraNativeBuildInputs extraPassthru packageVersion src version;
 
-  meta = {
-    badPlatforms = lib.platforms.darwin;
-    description = "Floorp fork build using custom branding & settings";
-    homepage = "https://github.com/dr460nf1r3/firedragon-browser";
-    license = lib.licenses.mpl20;
-    maintainers = with lib; [ maintainers.dr460nf1r3 ];
-    # broken = stdenv.buildPlatform.is32bit; # since Firefox 60, build on 32-bit platforms fails with "out of memory".
-    maxSilent = 14400; # 4h, double the default of 7200s (c.f. #129212, #129115)
-    platforms = lib.platforms.unix;
-    mainProgram = "firedragon";
+    updateScript = callPackage ./update.nix { };
+
+    meta = {
+      badPlatforms = lib.platforms.darwin;
+      description = "Floorp fork build using custom branding & settings";
+      homepage = "https://firedragon.garudalinux.org";
+      license = lib.licenses.mpl20;
+      maintainers = with lib; [ maintainers.dr460nf1r3 ];
+      broken = stdenv.buildPlatform.is32bit;
+      maxSilent = 14400;
+      platforms = lib.platforms.unix;
+      mainProgram = "firedragon";
+    };
+  }).override {
+    crashreporterSupport = false;
+    enableOfficialBranding = false;
+    pgoSupport = true;
+    privacySupport = true;
+    webrtcSupport = true;
+  }).overrideAttrs {
+    MOZ_APP_REMOTINGNAME = "firedragon";
+    MOZ_CRASHREPORTER = "";
+    MOZ_DATA_REPORTING = "";
+    MOZ_TELEMETRY_REPORTING = "";
+    OPT_LEVEL = "3";
+    RUSTC_OPT_LEVEL = "3";
   };
-}).override {
-  crashreporterSupport = false;
-  enableOfficialBranding = false;
-  pgoSupport = true;
-  privacySupport = true;
-  webrtcSupport = true;
-}).overrideAttrs {
-  MOZ_APP_REMOTINGNAME = "firedragon";
-  MOZ_CRASHREPORTER = "";
-  MOZ_DATA_REPORTING = "";
-  MOZ_TELEMETRY_REPORTING = "";
-  OPT_LEVEL = "3";
-  RUSTC_OPT_LEVEL = "3";
-}
+
+  postOverride = prevAttrs: {
+    patches = nyxUtils.removeByName "cbindgen-0.27.0-compat.patch" prevAttrs.patches;
+  };
+in
+
+nyxUtils.multiOverride mach { } postOverride

--- a/pkgs/firedragon/version.json
+++ b/pkgs/firedragon/version.json
@@ -1,8 +1,8 @@
 {
   "firefoxVersion": "128.2.0",
   "firedragonSource": {
-    "version": "11.17.4-3",
-    "hash": "sha256-fgK9mMjQ9kkixmGQ+cOUTKRIgBGCgwPuKW/A8yvIBX8="
+    "version": "11.17.5-1",
+    "hash": "sha256-Fg81UamtvEv1wC3Bbwa9GH8BTpl/WBILa2JG7yx7YQ8="
   },
   "firedragonSettings": {
     "rev": "d4337abd013bcf3128ea9cbeee161f2355a8ee36",


### PR DESCRIPTION
### :fish: What?

Removed conflicting patch from the list of patches - FireDragon has it already patched in.

### :fishing_pole_and_fish: Why?

Fixes building.
