### PR TITLE
FIX: xone build error with cachyos-lto

### DIFF
--- a/pkgs/linux-cachyos/default.nix
+++ b/pkgs/linux-cachyos/default.nix
@@ -47,7 +47,7 @@ in
     description = "Linux EEVDF-BORE scheduler Kernel by CachyOS built with LLVM and Thin LTO";
 
     packagesExtend = kernel: _finalModules: builtins.mapAttrs (k: v:
-      if builtins.elem k [ "zenpower" "v4l2loopback" "zfs_cachyos" "virtualbox" ]
+      if builtins.elem k [ "zenpower" "v4l2loopback" "zfs_cachyos" "virtualbox" "xone" ]
       then llvmModuleOverlay kernel v
       else v
     );


### PR DESCRIPTION
### :fish: What?

When building xone with cachyos-lto throws an error and can't build nixos.

![image](https://github.com/user-attachments/assets/a1cc2fbd-a5df-45cf-b3a0-ca8cbe486885)

This PR is to fix this issue by adding xone as a LLVM Module.

### :fishing_pole_and_fish: Why?

This fix the problem with xone and cachyos-lto builds errors.

### :fish_cake: Pending

- [ ] Complain with linter;
- [ ] Remove some temporary fix;
- [ ] Publishing to news' channel.

### :whale: Extras

A fast workaround is to change `hardware.xone.enable` to:

```
boot = {
  blacklistedKernelModules = [ "xpad" "mt76x2u" ];
  extraModulePackages = [ pkgs.linuxPackages_cachyos.xone ];
};
hardware.firmware = [ pkgs.xow_dongle-firmware ];
```
