### PR TITLE
mangohud_git: `glxinfo` -> `mesa-demos`

### DIFF
--- a/pkgs/mangohud-git/default.nix
+++ b/pkgs/mangohud-git/default.nix
@@ -26,9 +26,9 @@ gitOverride {
           path = lib.makeBinPath [
             coreutils
             curl
-            glxinfo
             gnugrep
             gnused
+            mesa-demos
             xdg-utils
           ];
 


### PR DESCRIPTION
### :fish: What?

Fixed a package that doesn't build with aliases off.
https://github.com/NixOS/nixpkgs/pull/324562

### :fishing_pole_and_fish: Why?

I have aliases off.

### :fish_cake: Pending

I didn't test, I'm assuming it should work now.
