### PR TITLE
godot4-mono: init at 4.3-stable

### DIFF
--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -173,6 +173,8 @@ in
   gamescope_git = callOverride ../pkgs/gamescope-git { };
   gamescope-wsi_git = callOverride ../pkgs/gamescope-git { isWSI = true; };
 
+  godot_4-mono = final.callPackage ../pkgs/godot_4-mono { };
+
   jujutsu_git = callOverride ../pkgs/jujutsu-git { };
 
   kf6coreaddons_git = callOverride ../pkgs/kf6coreaddons-git/latest.nix { };

--- a/pkgs/godot_4-mono/default.nix
+++ b/pkgs/godot_4-mono/default.nix
@@ -1,0 +1,198 @@
+# Taken from https://github.com/NixOS/nixpkgs/pull/285941 and updated to latest stable
+# Thanks to ilikefrogs101 for the original PR!
+{ lib
+, stdenv
+, fetchFromGitHub
+, pkg-config
+, autoPatchelfHook
+, installShellFiles
+, scons
+, python3
+, mkNugetDeps
+, vulkan-loader
+, libGL
+, libX11
+, libXcursor
+, libXinerama
+, libXext
+, libXrandr
+, libXrender
+, libXi
+, libXfixes
+, libxkbcommon
+, alsa-lib
+, libpulseaudio
+, dbus
+, speechd
+, fontconfig
+, udev
+, wayland-scanner
+, withPlatform ? "linuxbsd"
+, withTarget ? "editor"
+, withPrecision ? "single"
+, withPulseaudio ? true
+, withDbus ? true
+, withSpeechd ? true
+, withFontconfig ? true
+, withUdev ? true
+, deps ? ./deps.nix
+, mono
+, callPackage
+, dotnet-sdk_8
+, dotnet-runtime_8
+, makeWrapper
+, msbuild
+,
+}:
+assert lib.asserts.assertOneOf "withPrecision" withPrecision [ "single" "double" ];
+stdenv.mkDerivation rec {
+  pname = "godot_4-mono";
+  version = "4.3-stable";
+  commitHash = "77dcf97d82cbfe4e4615475fa52ca03da645dbd8";
+  sourceHash = "sha256-v2lBD3GEL8CoIwBl3UoLam0dJxkLGX0oneH6DiWkEsM=";
+
+  src = fetchFromGitHub {
+    owner = "godotengine";
+    repo = "godot";
+    rev = commitHash;
+    hash = sourceHash;
+  };
+
+  keepNugetConfig = deps == null;
+
+  nativeBuildInputs = [
+    pkg-config
+    autoPatchelfHook
+    installShellFiles
+    python3
+    speechd
+    wayland-scanner
+    makeWrapper
+    mono
+    dotnet-sdk_8
+    dotnet-runtime_8
+  ];
+
+  buildInputs = [
+    scons
+  ] ++ lib.optional (deps != null)
+    (mkNugetDeps { name = "deps"; nugetDeps = import deps; });
+
+  runtimeDependencies =
+    [
+      vulkan-loader
+      libGL
+      libX11
+      libXcursor
+      libXinerama
+      speechd
+      libXext
+      libXrandr
+      libXrender
+      libXi
+      libXfixes
+      libxkbcommon
+      alsa-lib
+      mono
+      wayland-scanner
+      dotnet-sdk_8
+      dotnet-runtime_8
+    ]
+    ++ lib.optional withPulseaudio libpulseaudio
+    ++ lib.optional withDbus dbus
+    ++ lib.optional withDbus dbus.lib
+    ++ lib.optional withSpeechd speechd
+    ++ lib.optional withFontconfig fontconfig
+    ++ lib.optional withFontconfig fontconfig.lib
+    ++ lib.optional withUdev udev;
+
+  enableParallelBuilding = true;
+
+  # Set the build name which is part of the version. In official downloads, this
+  # is set to 'official'. When not specified explicitly, it is set to
+  # 'custom_build'. Other platforms packaging Godot (Gentoo, Arch, Flatpack
+  # etc.) usually set this to their name as well.
+  #
+  # See also 'methods.py' in the Godot repo and 'build' in
+  # https://docs.godotengine.org/en/stable/classes/class_engine.html#class-engine-method-get-version-info
+  BUILD_NAME = "chaotic-nyx";
+
+  # Required for the commit hash to be included in the version number.
+  #
+  # `methods.py` reads the commit hash from `.git/HEAD` and manually follows
+  # refs. Since we just write the hash directly, there is no need to emulate any
+  # other parts of the .git directory.
+  #
+  # See also 'hash' in
+  # https://docs.godotengine.org/en/stable/classes/class_engine.html#class-engine-method-get-version-info
+  preConfigure = ''
+    mkdir -p .git
+    echo ${commitHash} > .git/HEAD
+  '';
+
+  outputs = [ "out" "man" ];
+
+  postConfigure = ''
+    echo "Setting up buildhome."
+    mkdir buildhome
+    export HOME="$PWD"/buildhome
+  '';
+
+  buildPhase = ''
+    echo "Starting Build"
+    scons p=${withPlatform} target=${withTarget} precision=${withPrecision} module_mono_enabled=yes mono_glue=no
+
+    echo "Generating Glue"
+    if [[ ${withPrecision} == *double* ]]; then
+        bin/godot.${withPlatform}.${withTarget}.${withPrecision}.x86_64.mono --headless --generate-mono-glue modules/mono/glue
+    else
+        bin/godot.${withPlatform}.${withTarget}.x86_64.mono --headless --generate-mono-glue modules/mono/glue
+    fi
+
+    echo "Building Assemblies"
+    scons p=${withPlatform} target=${withTarget} precision=${withPrecision} module_mono_enabled=yes mono_glue=yes
+
+    echo "Building C#/.NET Assemblies"
+    python modules/mono/build_scripts/build_assemblies.py --godot-output-dir bin --precision=${withPrecision}
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p "$out/bin"
+    cp bin/godot.* $out/bin/godot4-mono
+    cp -r bin/GodotSharp/ $out/bin/
+
+    installManPage misc/dist/linux/godot.6
+
+    mkdir -p "$out"/share/{applications,icons/hicolor/scalable/apps}
+    cp misc/dist/linux/org.godotengine.Godot.desktop "$out/share/applications/org.godotengine.Godot4-Mono.desktop"
+    substituteInPlace "$out/share/applications/org.godotengine.Godot4-Mono.desktop" \
+      --replace-quiet "Exec=godot" "Exec=$out/bin/godot4-mono" \
+      --replace-quiet "Godot Engine" "Godot Engine ${version} (Mono, $(echo "${withPrecision}" | sed 's/.*/\u&/') Precision)"
+    cp icon.svg "$out/share/icons/hicolor/scalable/apps/godot.svg"
+    cp icon.png "$out/share/icons/godot.png"
+
+    wrapProgram $out/bin/godot4-mono \
+      --set DOTNET_ROOT ${dotnet-sdk_8} \
+      --prefix PATH : "${lib.makeBinPath [
+      dotnet-sdk_8
+      dotnet-runtime_8
+      mono
+      msbuild
+    ]}"
+    runHook postInstall
+  '';
+
+  meta = {
+    homepage = "https://godotengine.org";
+    description = "Free and Open Source 2D and 3D game engine";
+    license = lib.licenses.mit;
+    platforms = [ "i686-linux" "x86_64-linux" "aarch64-linux" ];
+    maintainers = with lib.maintainers; [ dr460nf1r3 ];
+    mainProgram = "godot4-mono";
+  };
+
+  passthru = {
+    make-deps = callPackage ./make-deps.nix { };
+  };
+}

--- a/pkgs/godot_4-mono/deps.nix
+++ b/pkgs/godot_4-mono/deps.nix
@@ -1,0 +1,1322 @@
+{ fetchNuGet }: [
+  (fetchNuGet {
+    pname = "coverlet.collector";
+    version = "3.2.0";
+    hash = "sha256-2aM3pKX5toQQRLKpH5ArzND2Rgq1fSpMsLxcEDbat+M=";
+  })
+  (fetchNuGet {
+    pname = "DiffPlex";
+    version = "1.5.0";
+    hash = "sha256-6HwA6ZyCn++NAXy6ep9ywSF/Ss+e/nmMhjyeIft9fQw=";
+  })
+  (fetchNuGet {
+    pname = "envdte";
+    version = "17.8.37221";
+    hash = "sha256-jKSZceeB+/IwrOqZ3USX6HeSQtxKCPs9VzA733NHEEU=";
+  })
+  (fetchNuGet {
+    pname = "Humanizer.Core";
+    version = "2.14.1";
+    hash = "sha256-EXvojddPu+9JKgOG9NSQgUTfWq1RpOYw7adxDPKDJ6o=";
+  })
+  (fetchNuGet {
+    pname = "Humanizer.Core";
+    version = "2.2.0";
+    hash = "sha256-5Q6oRaV8wHPONHreKvB74VjV2FW36mwC3n+05It5vyI=";
+  })
+  (fetchNuGet {
+    pname = "JetBrains.Annotations";
+    version = "2019.1.3";
+    hash = "sha256-gn2Z7yANT+2tnK+qbOA2PviRf1M1VtvamABGajgGC6E=";
+  })
+  (fetchNuGet {
+    pname = "JetBrains.Rider.PathLocator";
+    version = "1.0.9";
+    hash = "sha256-7c5TRZ594tr1Fj5fNiXtPI0pcBuyX/3eU4x+it6Yzew=";
+  })
+  (fetchNuGet {
+    pname = "Microsoft.AspNetCore.App.Ref";
+    version = "6.0.33";
+    hash = "sha256-GcPiO+iI0JsHYlqURAmzWjOnDX2jDCUY4jYaIwr8ojs=";
+  })
+  (fetchNuGet {
+    pname = "Microsoft.Bcl.AsyncInterfaces";
+    version = "1.1.1";
+    hash = "sha256-fAcX4sxE0veWM1CZBtXR/Unky+6sE33yrV7ohrWGKig=";
+  })
+  (fetchNuGet {
+    pname = "Microsoft.Bcl.AsyncInterfaces";
+    version = "5.0.0";
+    hash = "sha256-bpJjcJSUSZH0GeOXoZI12xUQOf2SRtxG7sZV0dWS5TI=";
+  })
+  (fetchNuGet {
+    pname = "Microsoft.Bcl.AsyncInterfaces";
+    version = "7.0.0";
+    hash = "sha256-1e031E26iraIqun84ad0fCIR4MJZ1hcQo4yFN+B7UfE=";
+  })
+  (fetchNuGet {
+    pname = "Microsoft.Build";
+    version = "15.1.548";
+    hash = "sha256-v6rTGfytT6QwXkp97T6vQurVi8oDzZmIOn3/cHYuC6s=";
+  })
+  (fetchNuGet {
+    pname = "Microsoft.Build.Framework";
+    version = "15.1.548";
+    hash = "sha256-0U6XANGftKOS9Owx1x8hOe5GOdqx2uwQwuAsVHw297g=";
+  })
+  (fetchNuGet {
+    pname = "Microsoft.Build.Locator";
+    version = "1.2.6";
+    hash = "sha256-Z5wzSnsGbbJe3nvj6kAAv6KhYMK1H3Mktn4ugflpzuY=";
+  })
+  (fetchNuGet {
+    pname = "Microsoft.Build.NoTargets";
+    version = "2.0.1";
+    hash = "sha256-5Gqi/OQayuQiQNEcoaFue0glNvcF4nmGneW07Hs9prg=";
+  })
+  (fetchNuGet {
+    pname = "Microsoft.CodeAnalysis.Analyzer.Testing";
+    version = "1.1.1";
+    hash = "sha256-3w7g0KhG16ZH8rYK9FxP15qbd+hTgwRDpDJEKpDMHu8=";
+  })
+  (fetchNuGet {
+    pname = "Microsoft.CodeAnalysis.Analyzers";
+    version = "2.6.1";
+    hash = "sha256-1+FV3KvwerZsknecHZhdDACsPKaWrbQQeN27BAcZk94=";
+  })
+  (fetchNuGet {
+    pname = "Microsoft.CodeAnalysis.Analyzers";
+    version = "3.3.2";
+    hash = "sha256-pDeaMqX7a01Hp1Qd9P/y/B2rEGAv2eIY0Ld/klBZW5g=";
+  })
+  (fetchNuGet {
+    pname = "Microsoft.CodeAnalysis.Analyzers";
+    version = "3.3.3";
+    hash = "sha256-pkZiggwLw8k+CVSXKTzsVGsT+K49LxXUS3VH5PNlpCY=";
+  })
+  (fetchNuGet {
+    pname = "Microsoft.CodeAnalysis.Analyzers";
+    version = "3.3.4";
+    hash = "sha256-qDzTfZBSCvAUu9gzq2k+LOvh6/eRvJ9++VCNck/ZpnE=";
+  })
+  (fetchNuGet {
+    pname = "Microsoft.CodeAnalysis.CodeFix.Testing";
+    version = "1.1.1";
+    hash = "sha256-NXEGr/+rzt4ENdTWPlgW7upyjofPP841xzwU78lReio=";
+  })
+  (fetchNuGet {
+    pname = "Microsoft.CodeAnalysis.Common";
+    version = "1.0.1";
+    hash = "sha256-jjWtdrHSISgBF1m94P0DsVbQa4YxKnf2CWRWYHQLTG8=";
+  })
+  (fetchNuGet {
+    pname = "Microsoft.CodeAnalysis.Common";
+    version = "3.10.0";
+    hash = "sha256-AXmLVmjWuDXmV/P0aeeioA5NzthnCWepT4hHWgjmR4k=";
+  })
+  (fetchNuGet {
+    pname = "Microsoft.CodeAnalysis.Common";
+    version = "3.11.0";
+    hash = "sha256-lOW5q1kAAk+Wpweb9TaZ1LztWzAODt9yZKe6SN5rkV8=";
+  })
+  (fetchNuGet {
+    pname = "Microsoft.CodeAnalysis.Common";
+    version = "3.8.0";
+    hash = "sha256-3G9vSc/gHH7FWgOySLTut1+eEaf3H66qcPOvNPLOx4o=";
+  })
+  (fetchNuGet {
+    pname = "Microsoft.CodeAnalysis.Common";
+    version = "4.8.0";
+    hash = "sha256-3IEinVTZq6/aajMVA8XTRO3LTIEt0PuhGyITGJLtqz4=";
+  })
+  (fetchNuGet {
+    pname = "Microsoft.CodeAnalysis.CSharp";
+    version = "3.10.0";
+    hash = "sha256-09QIyQUkYBg8ltgWtDrCg8f6wnN/sLhduDG3BGvcl14=";
+  })
+  (fetchNuGet {
+    pname = "Microsoft.CodeAnalysis.CSharp";
+    version = "3.11.0";
+    hash = "sha256-AVFv1c6eMi5Jc6GXyL2P3WSs9YTOs3hPO7iGq9tZJsA=";
+  })
+  (fetchNuGet {
+    pname = "Microsoft.CodeAnalysis.CSharp";
+    version = "4.8.0";
+    hash = "sha256-MmOnXJvd/ezs5UPcqyGLnbZz5m+VedpRfB+kFZeeqkU=";
+  })
+  (fetchNuGet {
+    pname = "Microsoft.CodeAnalysis.CSharp.Analyzer.Testing";
+    version = "1.1.1";
+    hash = "sha256-uZf99S701CcUoR8XHn+PusRXdDeeWylFiqdMjR9R6TY=";
+  })
+  (fetchNuGet {
+    pname = "Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.XUnit";
+    version = "1.1.1";
+    hash = "sha256-Fs+ygXsCxoJGcaatBc1v8ZXTVSsid+Y60O4/JLiMD18=";
+  })
+  (fetchNuGet {
+    pname = "Microsoft.CodeAnalysis.CSharp.CodeFix.Testing";
+    version = "1.1.1";
+    hash = "sha256-g1AkqFBndpl4ySk1w5IMAN+EibO9OsLiWCLjMggImDo=";
+  })
+  (fetchNuGet {
+    pname = "Microsoft.CodeAnalysis.CSharp.CodeFix.Testing.XUnit";
+    version = "1.1.1";
+    hash = "sha256-3z6ELEBETjKlCyGQ5PzyQWS6Ud982BQMNvLdJnOdlWw=";
+  })
+  (fetchNuGet {
+    pname = "Microsoft.CodeAnalysis.CSharp.SourceGenerators.Testing";
+    version = "1.1.1";
+    hash = "sha256-nX4GSfovb8K4cD9xFEKXcRXVDNmXyWOaAAVQ/XfvAFk=";
+  })
+  (fetchNuGet {
+    pname = "Microsoft.CodeAnalysis.CSharp.SourceGenerators.Testing.XUnit";
+    version = "1.1.1";
+    hash = "sha256-QAQ87pM9sr+8uqwDSXR39x3wtx82jVGcdTJPmwDSB2Y=";
+  })
+  (fetchNuGet {
+    pname = "Microsoft.CodeAnalysis.CSharp.Workspaces";
+    version = "3.11.0";
+    hash = "sha256-4WQgwOdmKbCMfT2c4K+5ZkErU3zkRboJO0ORHhnUvpo=";
+  })
+  (fetchNuGet {
+    pname = "Microsoft.CodeAnalysis.CSharp.Workspaces";
+    version = "4.8.0";
+    hash = "sha256-WNzc+6mKqzPviOI0WMdhKyrWs8u32bfGj2XwmfL7bwE=";
+  })
+  (fetchNuGet {
+    pname = "Microsoft.CodeAnalysis.SourceGenerators.Testing";
+    version = "1.1.1";
+    hash = "sha256-d4zoBTjX9DAwIZfGAa9as5vE/BIshKIov4GepT9l1vg=";
+  })
+  (fetchNuGet {
+    pname = "Microsoft.CodeAnalysis.Testing.Verifiers.XUnit";
+    version = "1.1.1";
+    hash = "sha256-WOo0pITkG6CZwJ9MiLaCMSbjbBOxn7+tlpjJGn//gnc=";
+  })
+  (fetchNuGet {
+    pname = "Microsoft.CodeAnalysis.Workspaces.Common";
+    version = "1.0.1";
+    hash = "sha256-/SYPkq5LhOoEWi+rcBZDyQL2U0cQk2YrykNJODrRLVs=";
+  })
+  (fetchNuGet {
+    pname = "Microsoft.CodeAnalysis.Workspaces.Common";
+    version = "3.11.0";
+    hash = "sha256-mkJ/pkf7x7kQ2NngYl8yOlEwJIEjphL84KyUC5vEKh4=";
+  })
+  (fetchNuGet {
+    pname = "Microsoft.CodeAnalysis.Workspaces.Common";
+    version = "3.8.0";
+    hash = "sha256-3D7xV3V1WsUU9OMMEOj+z9GouCDKXSBC4Z/Szs/OcWE=";
+  })
+  (fetchNuGet {
+    pname = "Microsoft.CodeAnalysis.Workspaces.Common";
+    version = "4.8.0";
+    hash = "sha256-X8R4SpWVO/gpip5erVZf5jCCx8EX3VzIRtNrQiLDIoM=";
+  })
+  (fetchNuGet {
+    pname = "Microsoft.CodeCoverage";
+    version = "17.7.1";
+    hash = "sha256-MePYLGy7Y4DuPZccxIbRTjq4GB554jBwT4noLiAZJKs=";
+  })
+  (fetchNuGet {
+    pname = "Microsoft.Composition";
+    version = "1.0.27";
+    hash = "sha256-G/3p3zxOWC8HqLt7Ll5cqN7507F6N/G6G/HzKazQRdE=";
+  })
+  (fetchNuGet {
+    pname = "Microsoft.CSharp";
+    version = "4.0.1";
+    hash = "sha256-0huoqR2CJ3Z9Q2peaKD09TV3E6saYSqDGZ290K8CrH8=";
+  })
+  (fetchNuGet {
+    pname = "Microsoft.NET.Test.Sdk";
+    version = "17.7.1";
+    hash = "sha256-ySyNpRodd6R6qKnGrgwLYaiHZga2GL0fQARrYGIFa6k=";
+  })
+  (fetchNuGet {
+    pname = "Microsoft.NETCore.App.Host.win-x86";
+    version = "6.0.33";
+    hash = "sha256-OybB5ATvnnPEsKAdn5a/UdjSPcT78wlf38YNmuRWBZg=";
+  })
+  (fetchNuGet {
+    pname = "Microsoft.NETCore.App.Ref";
+    version = "6.0.33";
+    hash = "sha256-BiGUcXo1FQTlZdR6ndhUQ8lrYG3KaGXNXRVF+Fc3L28=";
+  })
+  (fetchNuGet {
+    pname = "Microsoft.NETCore.Platforms";
+    version = "1.0.1";
+    hash = "sha256-mZotlGZqtrqDSoBrZhsxFe6fuOv5/BIo0w2Z2x0zVAU=";
+  })
+  (fetchNuGet {
+    pname = "Microsoft.NETCore.Platforms";
+    version = "1.1.0";
+    hash = "sha256-FeM40ktcObQJk4nMYShB61H/E8B7tIKfl9ObJ0IOcCM=";
+  })
+  (fetchNuGet {
+    pname = "Microsoft.NETCore.Platforms";
+    version = "2.0.0";
+    hash = "sha256-IEvBk6wUXSdyCnkj6tHahOJv290tVVT8tyemYcR0Yro=";
+  })
+  (fetchNuGet {
+    pname = "Microsoft.NETCore.Platforms";
+    version = "2.1.2";
+    hash = "sha256-gYQQO7zsqG+OtN4ywYQyfsiggS2zmxw4+cPXlK+FB5Q=";
+  })
+  (fetchNuGet {
+    pname = "Microsoft.NETCore.Platforms";
+    version = "5.0.0";
+    hash = "sha256-LIcg1StDcQLPOABp4JRXIs837d7z0ia6+++3SF3jl1c=";
+  })
+  (fetchNuGet {
+    pname = "Microsoft.NETCore.Targets";
+    version = "1.0.1";
+    hash = "sha256-lxxw/Gy32xHi0fLgFWNj4YTFBSBkjx5l6ucmbTyf7V4=";
+  })
+  (fetchNuGet {
+    pname = "Microsoft.NETCore.Targets";
+    version = "1.1.0";
+    hash = "sha256-0AqQ2gMS8iNlYkrD+BxtIg7cXMnr9xZHtKAuN4bjfaQ=";
+  })
+  (fetchNuGet {
+    pname = "Microsoft.NETFramework.ReferenceAssemblies";
+    version = "1.0.0";
+    hash = "sha256-6faPQ4jaFY3OGGVk3lZKW+DEZaIOBZ/wHqbiDTsRR1k=";
+  })
+  (fetchNuGet {
+    pname = "Microsoft.NETFramework.ReferenceAssemblies.net461";
+    version = "1.0.0";
+    hash = "sha256-oS7sUMzKBkLmhggqbI6eBqb1OPAipH0TDTaDaBixcwM=";
+  })
+  (fetchNuGet {
+    pname = "Microsoft.TestPlatform.ObjectModel";
+    version = "17.7.1";
+    hash = "sha256-KfqM1E0jhAg07QfpjfEcjQ+HX13XZfdvveT5qxm89Sk=";
+  })
+  (fetchNuGet {
+    pname = "Microsoft.TestPlatform.TestHost";
+    version = "17.7.1";
+    hash = "sha256-MMrdBDByByYDpO/xaRCl9Cb27zIfcjPJqld/649e8Mw=";
+  })
+  (fetchNuGet {
+    pname = "Microsoft.VisualBasic";
+    version = "10.0.1";
+    hash = "sha256-7HHzZcWLVTTQ1K1rCIyoB+UxLHMvOIz+O5av6XDa22A=";
+  })
+  (fetchNuGet {
+    pname = "Microsoft.VisualStudio.Composition";
+    version = "16.1.8";
+    hash = "sha256-yFT4t3Uk31R5EPdAxxsTAmRuiv58MlYoYL4JT1ywlHQ=";
+  })
+  (fetchNuGet {
+    pname = "Microsoft.VisualStudio.Composition.NetFxAttributes";
+    version = "16.1.8";
+    hash = "sha256-FFemIG+m8RWUPo5W+kCHPh5Yn4fGS+tpjGiQTcT0sAE=";
+  })
+  (fetchNuGet {
+    pname = "Microsoft.VisualStudio.Interop";
+    version = "17.8.37221";
+    hash = "sha256-n4gHogs2T+RxO7OCuFiITu90KTychqZycQMqPbukNuE=";
+  })
+  (fetchNuGet {
+    pname = "Microsoft.VisualStudio.Validation";
+    version = "15.0.82";
+    hash = "sha256-7JFaA/HZHVjsEtTh/iHDRLi5RcuA39KKvvCkuI4JQFc=";
+  })
+  (fetchNuGet {
+    pname = "Microsoft.Win32.Primitives";
+    version = "4.0.1";
+    hash = "sha256-B4t5El/ViBdxALMcpZulewc4j/3SIXf71HhJWhm4Ctk=";
+  })
+  (fetchNuGet {
+    pname = "Microsoft.Win32.Primitives";
+    version = "4.3.0";
+    hash = "sha256-mBNDmPXNTW54XLnPAUwBRvkIORFM7/j0D0I2SyQPDEg=";
+  })
+  (fetchNuGet {
+    pname = "Microsoft.Win32.Registry";
+    version = "4.0.0";
+    hash = "sha256-M/06F/Z2wTHCh4pZOgtCjUGLD1FJXEJKCmzOeFMl7uo=";
+  })
+  (fetchNuGet {
+    pname = "Microsoft.Win32.Registry";
+    version = "4.3.0";
+    hash = "sha256-50XwFbyRfZkTD/bBn76WV/NIpOy/mzXD3MMEVFX/vr8=";
+  })
+  (fetchNuGet {
+    pname = "Microsoft.Win32.Registry";
+    version = "5.0.0";
+    hash = "sha256-9kylPGfKZc58yFqNKa77stomcoNnMeERXozWJzDcUIA=";
+  })
+  (fetchNuGet {
+    pname = "NETStandard.Library";
+    version = "1.6.1";
+    hash = "sha256-iNan1ix7RtncGWC9AjAZ2sk70DoxOsmEOgQ10fXm4Pw=";
+  })
+  (fetchNuGet {
+    pname = "NETStandard.Library";
+    version = "2.0.3";
+    hash = "sha256-Prh2RPebz/s8AzHb2sPHg3Jl8s31inv9k+Qxd293ybo=";
+  })
+  (fetchNuGet {
+    pname = "Newtonsoft.Json";
+    version = "13.0.1";
+    hash = "sha256-K2tSVW4n4beRPzPu3rlVaBEMdGvWSv/3Q1fxaDh4Mjo=";
+  })
+  (fetchNuGet {
+    pname = "Newtonsoft.Json";
+    version = "9.0.1";
+    hash = "sha256-mYCBrgUhIJFzRuLLV9SIiIFHovzfR8Uuqfg6e08EnlU=";
+  })
+  (fetchNuGet {
+    pname = "NuGet.Common";
+    version = "5.6.0";
+    hash = "sha256-uc/gCpcfugMjulqDVpS0ryfcaVBtmKyho07g3M8o//g=";
+  })
+  (fetchNuGet {
+    pname = "NuGet.Configuration";
+    version = "5.6.0";
+    hash = "sha256-K5A66u9WPz8PZYIl+DDyCAodYGUJfLdNNix6f5F7adI=";
+  })
+  (fetchNuGet {
+    pname = "NuGet.Frameworks";
+    version = "5.6.0";
+    hash = "sha256-iMacMTcuvemRQ4p3gv/3MioC/OEDOju8rnmZioWq9bc=";
+  })
+  (fetchNuGet {
+    pname = "NuGet.Frameworks";
+    version = "6.5.0";
+    hash = "sha256-ElqfN4CcKxT3hP2qvxxObb4mnBlYG89IMxO0Sm5oZ2g=";
+  })
+  (fetchNuGet {
+    pname = "NuGet.Packaging";
+    version = "5.6.0";
+    hash = "sha256-bl/A1QbIJAu/GpzKOKjGwe7NrTXlYH5s3ppJ6mYAoQk=";
+  })
+  (fetchNuGet {
+    pname = "NuGet.Protocol";
+    version = "5.6.0";
+    hash = "sha256-faY3xEk4g9xQFRT7DspGmlVLRGH1r4Vvr5VLT9sLUf8=";
+  })
+  (fetchNuGet {
+    pname = "NuGet.Resolver";
+    version = "5.6.0";
+    hash = "sha256-wAiARlBJtCjP482a0jnZKpZBbHRl3voXYMTz3WEox04=";
+  })
+  (fetchNuGet {
+    pname = "NuGet.Versioning";
+    version = "5.6.0";
+    hash = "sha256-3HKwW3hhTuwkZM5n02VFe8yDZbCLgqNE8gI+pqFTToI=";
+  })
+  (fetchNuGet {
+    pname = "ReflectionAnalyzers";
+    version = "0.1.22-dev";
+    hash = "sha256-NA/pyCCzzIewVr6IfZtFQjR5lOBnBdSzYj5SzgsBFvw=";
+  })
+  (fetchNuGet {
+    pname = "runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl";
+    version = "4.3.0";
+    hash = "sha256-LXUPLX3DJxsU1Pd3UwjO1PO9NM2elNEDXeu2Mu/vNps=";
+  })
+  (fetchNuGet {
+    pname = "runtime.fedora.23-x64.runtime.native.System.Security.Cryptography.OpenSsl";
+    version = "4.3.0";
+    hash = "sha256-qeSqaUI80+lqw5MK4vMpmO0CZaqrmYktwp6L+vQAb0I=";
+  })
+  (fetchNuGet {
+    pname = "runtime.fedora.24-x64.runtime.native.System.Security.Cryptography.OpenSsl";
+    version = "4.3.0";
+    hash = "sha256-SrHqT9wrCBsxILWtaJgGKd6Odmxm8/Mh7Kh0CUkZVzA=";
+  })
+  (fetchNuGet {
+    pname = "runtime.native.System";
+    version = "4.0.0";
+    hash = "sha256-bmaM0ovT4X4aqDJOR255Yda/u3fmHZskU++lMnsy894=";
+  })
+  (fetchNuGet {
+    pname = "runtime.native.System";
+    version = "4.3.0";
+    hash = "sha256-ZBZaodnjvLXATWpXXakFgcy6P+gjhshFXmglrL5xD5Y=";
+  })
+  (fetchNuGet {
+    pname = "runtime.native.System.IO.Compression";
+    version = "4.1.0";
+    hash = "sha256-085JrZxNEwIHdBWKKKFsh1JzpF0AblvrUsz5T8kH4jQ=";
+  })
+  (fetchNuGet {
+    pname = "runtime.native.System.IO.Compression";
+    version = "4.3.0";
+    hash = "sha256-DWnXs4vlKoU6WxxvCArTJupV6sX3iBbZh8SbqfHace8=";
+  })
+  (fetchNuGet {
+    pname = "runtime.native.System.Net.Http";
+    version = "4.3.0";
+    hash = "sha256-c556PyheRwpYhweBjSfIwEyZHnAUB8jWioyKEcp/2dg=";
+  })
+  (fetchNuGet {
+    pname = "runtime.native.System.Security.Cryptography.Apple";
+    version = "4.3.0";
+    hash = "sha256-2IhBv0i6pTcOyr8FFIyfPEaaCHUmJZ8DYwLUwJ+5waw=";
+  })
+  (fetchNuGet {
+    pname = "runtime.native.System.Security.Cryptography.OpenSsl";
+    version = "4.3.0";
+    hash = "sha256-Jy01KhtcCl2wjMpZWH+X3fhHcVn+SyllWFY8zWlz/6I=";
+  })
+  (fetchNuGet {
+    pname = "runtime.opensuse.13.2-x64.runtime.native.System.Security.Cryptography.OpenSsl";
+    version = "4.3.0";
+    hash = "sha256-wyv00gdlqf8ckxEdV7E+Ql9hJIoPcmYEuyeWb5Oz3mM=";
+  })
+  (fetchNuGet {
+    pname = "runtime.opensuse.42.1-x64.runtime.native.System.Security.Cryptography.OpenSsl";
+    version = "4.3.0";
+    hash = "sha256-zi+b4sCFrA9QBiSGDD7xPV27r3iHGlV99gpyVUjRmc4=";
+  })
+  (fetchNuGet {
+    pname = "runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.Apple";
+    version = "4.3.0";
+    hash = "sha256-serkd4A7F6eciPiPJtUyJyxzdAtupEcWIZQ9nptEzIM=";
+  })
+  (fetchNuGet {
+    pname = "runtime.osx.10.10-x64.runtime.native.System.Security.Cryptography.OpenSsl";
+    version = "4.3.0";
+    hash = "sha256-gybQU6mPgaWV3rBG2dbH6tT3tBq8mgze3PROdsuWnX0=";
+  })
+  (fetchNuGet {
+    pname = "runtime.rhel.7-x64.runtime.native.System.Security.Cryptography.OpenSsl";
+    version = "4.3.0";
+    hash = "sha256-VsP72GVveWnGUvS/vjOQLv1U80H2K8nZ4fDAmI61Hm4=";
+  })
+  (fetchNuGet {
+    pname = "runtime.ubuntu.14.04-x64.runtime.native.System.Security.Cryptography.OpenSsl";
+    version = "4.3.0";
+    hash = "sha256-4yKGa/IrNCKuQ3zaDzILdNPD32bNdy6xr5gdJigyF5g=";
+  })
+  (fetchNuGet {
+    pname = "runtime.ubuntu.16.04-x64.runtime.native.System.Security.Cryptography.OpenSsl";
+    version = "4.3.0";
+    hash = "sha256-HmdJhhRsiVoOOCcUvAwdjpMRiyuSwdcgEv2j9hxi+Zc=";
+  })
+  (fetchNuGet {
+    pname = "runtime.ubuntu.16.10-x64.runtime.native.System.Security.Cryptography.OpenSsl";
+    version = "4.3.0";
+    hash = "sha256-pVFUKuPPIx0edQKjzRon3zKq8zhzHEzko/lc01V/jdw=";
+  })
+  (fetchNuGet {
+    pname = "System.AppContext";
+    version = "4.1.0";
+    hash = "sha256-v6YfyfrKmhww+EYHUq6cwYUMj00MQ6SOfJtcGVRlYzs=";
+  })
+  (fetchNuGet {
+    pname = "System.AppContext";
+    version = "4.3.0";
+    hash = "sha256-yg95LNQOwFlA1tWxXdQkVyJqT4AnoDc+ACmrNvzGiZg=";
+  })
+  (fetchNuGet {
+    pname = "System.Buffers";
+    version = "4.3.0";
+    hash = "sha256-XqZWb4Kd04960h4U9seivjKseGA/YEIpdplfHYHQ9jk=";
+  })
+  (fetchNuGet {
+    pname = "System.Buffers";
+    version = "4.5.1";
+    hash = "sha256-wws90sfi9M7kuCPWkv1CEYMJtCqx9QB/kj0ymlsNaxI=";
+  })
+  (fetchNuGet {
+    pname = "System.Collections";
+    version = "4.0.11";
+    hash = "sha256-puoFMkx4Z55C1XPxNw3np8nzNGjH+G24j43yTIsDRL0=";
+  })
+  (fetchNuGet {
+    pname = "System.Collections";
+    version = "4.3.0";
+    hash = "sha256-afY7VUtD6w/5mYqrce8kQrvDIfS2GXDINDh73IjxJKc=";
+  })
+  (fetchNuGet {
+    pname = "System.Collections.Concurrent";
+    version = "4.0.12";
+    hash = "sha256-zIEM7AB4SyE9u6G8+o+gCLLwkgi6+3rHQVPdn/dEwB8=";
+  })
+  (fetchNuGet {
+    pname = "System.Collections.Concurrent";
+    version = "4.3.0";
+    hash = "sha256-KMY5DfJnDeIsa13DpqvyN8NkReZEMAFnlmNglVoFIXI=";
+  })
+  (fetchNuGet {
+    pname = "System.Collections.Immutable";
+    version = "1.1.36";
+    hash = "sha256-x/UyLEyveCYI+JAWo9xallSPbl78dIVuW2pGqgTY/C0=";
+  })
+  (fetchNuGet {
+    pname = "System.Collections.Immutable";
+    version = "1.2.0";
+    hash = "sha256-FQ3l+ulbLSPhQ0JcQCC4D4SzjTnHsRqcOj56Ywy7pMo=";
+  })
+  (fetchNuGet {
+    pname = "System.Collections.Immutable";
+    version = "5.0.0";
+    hash = "sha256-GdwSIjLMM0uVfE56VUSLVNgpW0B//oCeSFj8/hSlbM8=";
+  })
+  (fetchNuGet {
+    pname = "System.Collections.Immutable";
+    version = "7.0.0";
+    hash = "sha256-9an2wbxue2qrtugYES9awshQg+KfJqajhnhs45kQIdk=";
+  })
+  (fetchNuGet {
+    pname = "System.Collections.NonGeneric";
+    version = "4.0.1";
+    hash = "sha256-jdCVXmGOsJ+2F0xAagCkiMZ91SGAm9iOhO2u4ksmKaU=";
+  })
+  (fetchNuGet {
+    pname = "System.ComponentModel.Composition";
+    version = "4.5.0";
+    hash = "sha256-xxeZs1zIkhl2ZXU8CaOtCkMX1N290IK7bbHYeEKD0aQ=";
+  })
+  (fetchNuGet {
+    pname = "System.Composition";
+    version = "1.0.31";
+    hash = "sha256-wcQEG6MCRa1S03s3Yb3E3tfsIBZid99M7WDhcb48Qik=";
+  })
+  (fetchNuGet {
+    pname = "System.Composition";
+    version = "7.0.0";
+    hash = "sha256-YjhxuzuVdAzRBHNQy9y/1ES+ll3QtLcd2o+o8wIyMao=";
+  })
+  (fetchNuGet {
+    pname = "System.Composition.AttributedModel";
+    version = "1.0.31";
+    hash = "sha256-u+XnXfj6LQ3OXwrb9KqHRW4a/a9yHzLrJOXwDQ1a/sY=";
+  })
+  (fetchNuGet {
+    pname = "System.Composition.AttributedModel";
+    version = "7.0.0";
+    hash = "sha256-3s52Dyk2J66v/B4LLYFBMyXl0I8DFDshjE+sMjW4ubM=";
+  })
+  (fetchNuGet {
+    pname = "System.Composition.Convention";
+    version = "1.0.31";
+    hash = "sha256-GQWo1YDyQ3r2OMcKW+GbR3BbZNIAdwK79XAfinNj+AE=";
+  })
+  (fetchNuGet {
+    pname = "System.Composition.Convention";
+    version = "7.0.0";
+    hash = "sha256-N4MkkBXSQkcFKsEdcSe6zmyFyMmFOHmI2BNo3wWxftk=";
+  })
+  (fetchNuGet {
+    pname = "System.Composition.Hosting";
+    version = "1.0.31";
+    hash = "sha256-fg9BIY+zWtiEBIJefYP2lKHDYa4r/vtPTr3ZI8e0K7g=";
+  })
+  (fetchNuGet {
+    pname = "System.Composition.Hosting";
+    version = "7.0.0";
+    hash = "sha256-7liQGMaVKNZU1iWTIXvqf0SG8zPobRoLsW7q916XC3M=";
+  })
+  (fetchNuGet {
+    pname = "System.Composition.Runtime";
+    version = "1.0.31";
+    hash = "sha256-mqfxjAnVyE1YCgXMOcV34IWhYFnvXVKjMo9Y/d3yDuo=";
+  })
+  (fetchNuGet {
+    pname = "System.Composition.Runtime";
+    version = "7.0.0";
+    hash = "sha256-Oo1BxSGLETmdNcYvnkGdgm7JYAnQmv1jY0gL0j++Pd0=";
+  })
+  (fetchNuGet {
+    pname = "System.Composition.TypedParts";
+    version = "1.0.31";
+    hash = "sha256-w9ApcUJr7jYP4Vf5+efIIqoWmr5v9R56W4uC0n8KktQ=";
+  })
+  (fetchNuGet {
+    pname = "System.Composition.TypedParts";
+    version = "7.0.0";
+    hash = "sha256-6ZzNdk35qQG3ttiAi4OXrihla7LVP+y2fL3bx40/32s=";
+  })
+  (fetchNuGet {
+    pname = "System.Console";
+    version = "4.0.0";
+    hash = "sha256-jtZfT/TpJtLisV/y5Mk3IfCpE79zwhBYXtyGP9jC3Xo=";
+  })
+  (fetchNuGet {
+    pname = "System.Console";
+    version = "4.3.0";
+    hash = "sha256-Xh3PPBZr0pDbDaK8AEHbdGz7ePK6Yi1ZyRWI1JM6mbo=";
+  })
+  (fetchNuGet {
+    pname = "System.Diagnostics.Contracts";
+    version = "4.0.1";
+    hash = "sha256-Mq2MU+80m+zqhe92JazEIDi4rsgk8MHg3yjNYlObzXg=";
+  })
+  (fetchNuGet {
+    pname = "System.Diagnostics.Debug";
+    version = "4.0.11";
+    hash = "sha256-P+rSQJVoN6M56jQbs76kZ9G3mAWFdtF27P/RijN8sj4=";
+  })
+  (fetchNuGet {
+    pname = "System.Diagnostics.Debug";
+    version = "4.3.0";
+    hash = "sha256-fkA79SjPbSeiEcrbbUsb70u9B7wqbsdM9s1LnoKj0gM=";
+  })
+  (fetchNuGet {
+    pname = "System.Diagnostics.DiagnosticSource";
+    version = "4.3.0";
+    hash = "sha256-OFJRb0ygep0Z3yDBLwAgM/Tkfs4JCDtsNhwDH9cd1Xw=";
+  })
+  (fetchNuGet {
+    pname = "System.Diagnostics.FileVersionInfo";
+    version = "4.0.0";
+    hash = "sha256-Yy94jPhDXF2QHOF7qTmqKkn1048K9xkKryuBeDzsu+g=";
+  })
+  (fetchNuGet {
+    pname = "System.Diagnostics.Process";
+    version = "4.1.0";
+    hash = "sha256-OgW6ogQ+oYADYS0PHmwXdhrOKQJpqXlwzSvmfjTLNBg=";
+  })
+  (fetchNuGet {
+    pname = "System.Diagnostics.Process";
+    version = "4.3.0";
+    hash = "sha256-Rzo24qXhuJDDgrGNHr2eQRHhwLmsYmWDqAg/P5fOlzw=";
+  })
+  (fetchNuGet {
+    pname = "System.Diagnostics.Tools";
+    version = "4.0.1";
+    hash = "sha256-vSBqTbmWXylvRa37aWyktym+gOpsvH43mwr6A962k6U=";
+  })
+  (fetchNuGet {
+    pname = "System.Diagnostics.Tools";
+    version = "4.3.0";
+    hash = "sha256-gVOv1SK6Ape0FQhCVlNOd9cvQKBvMxRX9K0JPVi8w0Y=";
+  })
+  (fetchNuGet {
+    pname = "System.Diagnostics.TraceSource";
+    version = "4.0.0";
+    hash = "sha256-cCjdPU7ow91HGf1hBIOLJMQGO6pNmF+N+5/Z38XJh9U=";
+  })
+  (fetchNuGet {
+    pname = "System.Diagnostics.Tracing";
+    version = "4.1.0";
+    hash = "sha256-JA0jJcLbU3zh52ub3zweob2EVHvxOqiC6SCYHrY5WbQ=";
+  })
+  (fetchNuGet {
+    pname = "System.Diagnostics.Tracing";
+    version = "4.3.0";
+    hash = "sha256-hCETZpHHGVhPYvb4C0fh4zs+8zv4GPoixagkLZjpa9Q=";
+  })
+  (fetchNuGet {
+    pname = "System.Dynamic.Runtime";
+    version = "4.0.11";
+    hash = "sha256-qWqFVxuXioesVftv2RVJZOnmojUvRjb7cS3Oh3oTit4=";
+  })
+  (fetchNuGet {
+    pname = "System.Dynamic.Runtime";
+    version = "4.3.0";
+    hash = "sha256-k75gjOYimIQtLBD5NDzwwi3ZMUBPRW3jmc3evDMMJbU=";
+  })
+  (fetchNuGet {
+    pname = "System.Globalization";
+    version = "4.0.11";
+    hash = "sha256-rbSgc2PIEc2c2rN6LK3qCREAX3DqA2Nq1WcLrZYsDBw=";
+  })
+  (fetchNuGet {
+    pname = "System.Globalization";
+    version = "4.3.0";
+    hash = "sha256-caL0pRmFSEsaoeZeWN5BTQtGrAtaQPwFi8YOZPZG5rI=";
+  })
+  (fetchNuGet {
+    pname = "System.Globalization.Calendars";
+    version = "4.3.0";
+    hash = "sha256-uNOD0EOVFgnS2fMKvMiEtI9aOw00+Pfy/H+qucAQlPc=";
+  })
+  (fetchNuGet {
+    pname = "System.Globalization.Extensions";
+    version = "4.3.0";
+    hash = "sha256-mmJWA27T0GRVuFP9/sj+4TrR4GJWrzNIk2PDrbr7RQk=";
+  })
+  (fetchNuGet {
+    pname = "System.IO";
+    version = "4.1.0";
+    hash = "sha256-V6oyQFwWb8NvGxAwvzWnhPxy9dKOfj/XBM3tEC5aHrw=";
+  })
+  (fetchNuGet {
+    pname = "System.IO";
+    version = "4.3.0";
+    hash = "sha256-ruynQHekFP5wPrDiVyhNiRIXeZ/I9NpjK5pU+HPDiRY=";
+  })
+  (fetchNuGet {
+    pname = "System.IO.Compression";
+    version = "4.1.0";
+    hash = "sha256-UT4KEfJNZOk7b4X0AqLFUsqfHu6myVH/BhbRKYc+1Uc=";
+  })
+  (fetchNuGet {
+    pname = "System.IO.Compression";
+    version = "4.3.0";
+    hash = "sha256-f5PrQlQgj5Xj2ZnHxXW8XiOivaBvfqDao9Sb6AVinyA=";
+  })
+  (fetchNuGet {
+    pname = "System.IO.Compression.ZipFile";
+    version = "4.3.0";
+    hash = "sha256-WQl+JgWs+GaRMeiahTFUbrhlXIHapzcpTFXbRvAtvvs=";
+  })
+  (fetchNuGet {
+    pname = "System.IO.FileSystem";
+    version = "4.0.1";
+    hash = "sha256-4VKXFgcGYCTWVXjAlniAVq0dO3o5s8KHylg2wg2/7k0=";
+  })
+  (fetchNuGet {
+    pname = "System.IO.FileSystem";
+    version = "4.3.0";
+    hash = "sha256-vNIYnvlayuVj0WfRfYKpDrhDptlhp1pN8CYmlVd2TXw=";
+  })
+  (fetchNuGet {
+    pname = "System.IO.FileSystem.Primitives";
+    version = "4.0.1";
+    hash = "sha256-IpigKMomqb6pmYWkrlf0ZdpILtRluX2cX5sOKVW0Feg=";
+  })
+  (fetchNuGet {
+    pname = "System.IO.FileSystem.Primitives";
+    version = "4.3.0";
+    hash = "sha256-LMnfg8Vwavs9cMnq9nNH8IWtAtSfk0/Fy4s4Rt9r1kg=";
+  })
+  (fetchNuGet {
+    pname = "System.IO.Pipelines";
+    version = "5.0.1";
+    hash = "sha256-2zT5uBiyYm+jLIoJppIKJttTtpcMNKxd7Li0QEVjbv8=";
+  })
+  (fetchNuGet {
+    pname = "System.IO.Pipelines";
+    version = "7.0.0";
+    hash = "sha256-W2181khfJUTxLqhuAVRhCa52xZ3+ePGOLIPwEN8WisY=";
+  })
+  (fetchNuGet {
+    pname = "System.IO.Pipes";
+    version = "4.0.0";
+    hash = "sha256-6qMAD6DCZ5c1wswLWi1msqwu8GwI8un1RzjpUhzbrjs=";
+  })
+  (fetchNuGet {
+    pname = "System.Linq";
+    version = "4.1.0";
+    hash = "sha256-ZQpFtYw5N1F1aX0jUK3Tw+XvM5tnlnshkTCNtfVA794=";
+  })
+  (fetchNuGet {
+    pname = "System.Linq";
+    version = "4.3.0";
+    hash = "sha256-R5uiSL3l6a3XrXSSL6jz+q/PcyVQzEAByiuXZNSqD/A=";
+  })
+  (fetchNuGet {
+    pname = "System.Linq.Expressions";
+    version = "4.1.0";
+    hash = "sha256-7zqB+FXgkvhtlBzpcZyd81xczWP0D3uWssyAGw3t7b4=";
+  })
+  (fetchNuGet {
+    pname = "System.Linq.Expressions";
+    version = "4.3.0";
+    hash = "sha256-+3pvhZY7rip8HCbfdULzjlC9FPZFpYoQxhkcuFm2wk8=";
+  })
+  (fetchNuGet {
+    pname = "System.Linq.Parallel";
+    version = "4.0.1";
+    hash = "sha256-TV1F3KYFipPmPnWFjX6hOZQNFsG2m729EdgPSFzqY0Q=";
+  })
+  (fetchNuGet {
+    pname = "System.Memory";
+    version = "4.5.4";
+    hash = "sha256-3sCEfzO4gj5CYGctl9ZXQRRhwAraMQfse7yzKoRe65E=";
+  })
+  (fetchNuGet {
+    pname = "System.Net.Http";
+    version = "4.3.0";
+    hash = "sha256-UoBB7WPDp2Bne/fwxKF0nE8grJ6FzTMXdT/jfsphj8Q=";
+  })
+  (fetchNuGet {
+    pname = "System.Net.Primitives";
+    version = "4.0.11";
+    hash = "sha256-2YSijNhCdw/ZU2yfH7vE+ReA8pgxRCXPnWr+ab36v4M=";
+  })
+  (fetchNuGet {
+    pname = "System.Net.Primitives";
+    version = "4.3.0";
+    hash = "sha256-MY7Z6vOtFMbEKaLW9nOSZeAjcWpwCtdO7/W1mkGZBzE=";
+  })
+  (fetchNuGet {
+    pname = "System.Net.Sockets";
+    version = "4.1.0";
+    hash = "sha256-muK7oXIX7ykqhXskuUt0KX6Hzg5VogJhUS0JiOB2BY0=";
+  })
+  (fetchNuGet {
+    pname = "System.Net.Sockets";
+    version = "4.3.0";
+    hash = "sha256-il7dr5VT/QWDg/0cuh+4Es2u8LY//+qqiY9BZmYxSus=";
+  })
+  (fetchNuGet {
+    pname = "System.Numerics.Vectors";
+    version = "4.4.0";
+    hash = "sha256-auXQK2flL/JpnB/rEcAcUm4vYMCYMEMiWOCAlIaqu2U=";
+  })
+  (fetchNuGet {
+    pname = "System.ObjectModel";
+    version = "4.0.12";
+    hash = "sha256-MudZ/KYcvYsn2cST3EE049mLikrNkmE7QoUoYKKby+s=";
+  })
+  (fetchNuGet {
+    pname = "System.ObjectModel";
+    version = "4.3.0";
+    hash = "sha256-gtmRkWP2Kwr3nHtDh0yYtce38z1wrGzb6fjm4v8wN6Q=";
+  })
+  (fetchNuGet {
+    pname = "System.Reflection";
+    version = "4.1.0";
+    hash = "sha256-idZHGH2Yl/hha1CM4VzLhsaR8Ljo/rV7TYe7mwRJSMs=";
+  })
+  (fetchNuGet {
+    pname = "System.Reflection";
+    version = "4.3.0";
+    hash = "sha256-NQSZRpZLvtPWDlvmMIdGxcVuyUnw92ZURo0hXsEshXY=";
+  })
+  (fetchNuGet {
+    pname = "System.Reflection.Emit";
+    version = "4.0.1";
+    hash = "sha256-F1MvYoQWHCY89/O4JBwswogitqVvKuVfILFqA7dmuHk=";
+  })
+  (fetchNuGet {
+    pname = "System.Reflection.Emit";
+    version = "4.3.0";
+    hash = "sha256-5LhkDmhy2FkSxulXR+bsTtMzdU3VyyuZzsxp7/DwyIU=";
+  })
+  (fetchNuGet {
+    pname = "System.Reflection.Emit.ILGeneration";
+    version = "4.0.1";
+    hash = "sha256-YG+eJBG5P+5adsHiw/lhJwvREnvdHw6CJyS8ZV4Ujd0=";
+  })
+  (fetchNuGet {
+    pname = "System.Reflection.Emit.ILGeneration";
+    version = "4.3.0";
+    hash = "sha256-mKRknEHNls4gkRwrEgi39B+vSaAz/Gt3IALtS98xNnA=";
+  })
+  (fetchNuGet {
+    pname = "System.Reflection.Emit.Lightweight";
+    version = "4.0.1";
+    hash = "sha256-uVvNOnL64CPqsgZP2OLqNmxdkZl6Q0fTmKmv9gcBi+g=";
+  })
+  (fetchNuGet {
+    pname = "System.Reflection.Emit.Lightweight";
+    version = "4.3.0";
+    hash = "sha256-rKx4a9yZKcajloSZHr4CKTVJ6Vjh95ni+zszPxWjh2I=";
+  })
+  (fetchNuGet {
+    pname = "System.Reflection.Extensions";
+    version = "4.0.1";
+    hash = "sha256-NsfmzM9G/sN3H8X2cdnheTGRsh7zbRzvegnjDzDH/FQ=";
+  })
+  (fetchNuGet {
+    pname = "System.Reflection.Extensions";
+    version = "4.3.0";
+    hash = "sha256-mMOCYzUenjd4rWIfq7zIX9PFYk/daUyF0A8l1hbydAk=";
+  })
+  (fetchNuGet {
+    pname = "System.Reflection.Metadata";
+    version = "1.0.21";
+    hash = "sha256-0yqDWxwaw57YQ5dl8qdo+2o6VvG8qKp4il093uWWAUs=";
+  })
+  (fetchNuGet {
+    pname = "System.Reflection.Metadata";
+    version = "1.3.0";
+    hash = "sha256-a/RQr++mSsziWaOTknicfIQX/zJrwPFExfhK6PM0tfg=";
+  })
+  (fetchNuGet {
+    pname = "System.Reflection.Metadata";
+    version = "1.6.0";
+    hash = "sha256-JJfgaPav7UfEh4yRAQdGhLZF1brr0tUWPl6qmfNWq/E=";
+  })
+  (fetchNuGet {
+    pname = "System.Reflection.Metadata";
+    version = "5.0.0";
+    hash = "sha256-Wo+MiqhcP9dQ6NuFGrQTw6hpbJORFwp+TBNTq2yhGp8=";
+  })
+  (fetchNuGet {
+    pname = "System.Reflection.Metadata";
+    version = "7.0.0";
+    hash = "sha256-GwAKQhkhPBYTqmRdG9c9taqrKSKDwyUgOEhWLKxWNPI=";
+  })
+  (fetchNuGet {
+    pname = "System.Reflection.Primitives";
+    version = "4.0.1";
+    hash = "sha256-SFSfpWEyCBMAOerrMCOiKnpT+UAWTvRcmoRquJR6Vq0=";
+  })
+  (fetchNuGet {
+    pname = "System.Reflection.Primitives";
+    version = "4.3.0";
+    hash = "sha256-5ogwWB4vlQTl3jjk1xjniG2ozbFIjZTL9ug0usZQuBM=";
+  })
+  (fetchNuGet {
+    pname = "System.Reflection.TypeExtensions";
+    version = "4.1.0";
+    hash = "sha256-R0YZowmFda+xzKNR4kKg7neFoE30KfZwp/IwfRSKVK4=";
+  })
+  (fetchNuGet {
+    pname = "System.Reflection.TypeExtensions";
+    version = "4.3.0";
+    hash = "sha256-4U4/XNQAnddgQIHIJq3P2T80hN0oPdU2uCeghsDTWng=";
+  })
+  (fetchNuGet {
+    pname = "System.Resources.ResourceManager";
+    version = "4.0.1";
+    hash = "sha256-cZ2/3/fczLjEpn6j3xkgQV9ouOVjy4Kisgw5xWw9kSw=";
+  })
+  (fetchNuGet {
+    pname = "System.Resources.ResourceManager";
+    version = "4.3.0";
+    hash = "sha256-idiOD93xbbrbwwSnD4mORA9RYi/D/U48eRUsn/WnWGo=";
+  })
+  (fetchNuGet {
+    pname = "System.Runtime";
+    version = "4.1.0";
+    hash = "sha256-FViNGM/4oWtlP6w0JC0vJU+k9efLKZ+yaXrnEeabDQo=";
+  })
+  (fetchNuGet {
+    pname = "System.Runtime";
+    version = "4.3.0";
+    hash = "sha256-51813WXpBIsuA6fUtE5XaRQjcWdQ2/lmEokJt97u0Rg=";
+  })
+  (fetchNuGet {
+    pname = "System.Runtime.CompilerServices.Unsafe";
+    version = "4.5.3";
+    hash = "sha256-lnZMUqRO4RYRUeSO8HSJ9yBHqFHLVbmenwHWkIU20ak=";
+  })
+  (fetchNuGet {
+    pname = "System.Runtime.CompilerServices.Unsafe";
+    version = "4.7.1";
+    hash = "sha256-UvyoDV8O0oY3HPG1GbA56YVdvwTGEfjYR5gW1O7IK4U=";
+  })
+  (fetchNuGet {
+    pname = "System.Runtime.CompilerServices.Unsafe";
+    version = "5.0.0";
+    hash = "sha256-neARSpLPUzPxEKhJRwoBzhPxK+cKIitLx7WBYncsYgo=";
+  })
+  (fetchNuGet {
+    pname = "System.Runtime.CompilerServices.Unsafe";
+    version = "6.0.0";
+    hash = "sha256-bEG1PnDp7uKYz/OgLOWs3RWwQSVYm+AnPwVmAmcgp2I=";
+  })
+  (fetchNuGet {
+    pname = "System.Runtime.Extensions";
+    version = "4.1.0";
+    hash = "sha256-X7DZ5CbPY7jHs20YZ7bmcXs9B5Mxptu/HnBUvUnNhGc=";
+  })
+  (fetchNuGet {
+    pname = "System.Runtime.Extensions";
+    version = "4.3.0";
+    hash = "sha256-wLDHmozr84v1W2zYCWYxxj0FR0JDYHSVRaRuDm0bd/o=";
+  })
+  (fetchNuGet {
+    pname = "System.Runtime.Handles";
+    version = "4.0.1";
+    hash = "sha256-j2QgVO9ZOjv7D1het98CoFpjoYgxjupuIhuBUmLLH7w=";
+  })
+  (fetchNuGet {
+    pname = "System.Runtime.Handles";
+    version = "4.3.0";
+    hash = "sha256-KJ5aXoGpB56Y6+iepBkdpx/AfaJDAitx4vrkLqR7gms=";
+  })
+  (fetchNuGet {
+    pname = "System.Runtime.InteropServices";
+    version = "4.1.0";
+    hash = "sha256-QceAYlJvkPRJc/+5jR+wQpNNI3aqGySWWSO30e/FfQY=";
+  })
+  (fetchNuGet {
+    pname = "System.Runtime.InteropServices";
+    version = "4.3.0";
+    hash = "sha256-8sDH+WUJfCR+7e4nfpftj/+lstEiZixWUBueR2zmHgI=";
+  })
+  (fetchNuGet {
+    pname = "System.Runtime.InteropServices.RuntimeInformation";
+    version = "4.0.0";
+    hash = "sha256-5j53amb76A3SPiE3B0llT2XPx058+CgE7OXL4bLalT4=";
+  })
+  (fetchNuGet {
+    pname = "System.Runtime.InteropServices.RuntimeInformation";
+    version = "4.3.0";
+    hash = "sha256-MYpl6/ZyC6hjmzWRIe+iDoldOMW1mfbwXsduAnXIKGA=";
+  })
+  (fetchNuGet {
+    pname = "System.Runtime.Loader";
+    version = "4.0.0";
+    hash = "sha256-gE5/ehU3Qq5phhSxGuPmSv1DFVQeiyl1/+YyrO+I7lI=";
+  })
+  (fetchNuGet {
+    pname = "System.Runtime.Numerics";
+    version = "4.3.0";
+    hash = "sha256-P5jHCgMbgFMYiONvzmaKFeOqcAIDPu/U8bOVrNPYKqc=";
+  })
+  (fetchNuGet {
+    pname = "System.Runtime.Serialization.Primitives";
+    version = "4.1.1";
+    hash = "sha256-80B05oxJbPLGq2pGOSl6NlZvintX9A1CNpna2aN0WRA=";
+  })
+  (fetchNuGet {
+    pname = "System.Security.AccessControl";
+    version = "4.5.0";
+    hash = "sha256-AFsKPb/nTk2/mqH/PYpaoI8PLsiKKimaXf+7Mb5VfPM=";
+  })
+  (fetchNuGet {
+    pname = "System.Security.AccessControl";
+    version = "5.0.0";
+    hash = "sha256-ueSG+Yn82evxyGBnE49N4D+ngODDXgornlBtQ3Omw54=";
+  })
+  (fetchNuGet {
+    pname = "System.Security.Cryptography.Algorithms";
+    version = "4.3.0";
+    hash = "sha256-tAJvNSlczYBJ3Ed24Ae27a55tq/n4D3fubNQdwcKWA8=";
+  })
+  (fetchNuGet {
+    pname = "System.Security.Cryptography.Cng";
+    version = "4.3.0";
+    hash = "sha256-u17vy6wNhqok91SrVLno2M1EzLHZm6VMca85xbVChsw=";
+  })
+  (fetchNuGet {
+    pname = "System.Security.Cryptography.Csp";
+    version = "4.3.0";
+    hash = "sha256-oefdTU/Z2PWU9nlat8uiRDGq/PGZoSPRgkML11pmvPQ=";
+  })
+  (fetchNuGet {
+    pname = "System.Security.Cryptography.Encoding";
+    version = "4.3.0";
+    hash = "sha256-Yuge89N6M+NcblcvXMeyHZ6kZDfwBv3LPMDiF8HhJss=";
+  })
+  (fetchNuGet {
+    pname = "System.Security.Cryptography.OpenSsl";
+    version = "4.3.0";
+    hash = "sha256-DL+D2sc2JrQiB4oAcUggTFyD8w3aLEjJfod5JPe+Oz4=";
+  })
+  (fetchNuGet {
+    pname = "System.Security.Cryptography.Primitives";
+    version = "4.3.0";
+    hash = "sha256-fnFi7B3SnVj5a+BbgXnbjnGNvWrCEU6Hp/wjsjWz318=";
+  })
+  (fetchNuGet {
+    pname = "System.Security.Cryptography.ProtectedData";
+    version = "4.3.0";
+    hash = "sha256-CbfRZFmnJZCAsx9cx9UehCtzsbnVo+ce+n4pXDsx4s0=";
+  })
+  (fetchNuGet {
+    pname = "System.Security.Cryptography.X509Certificates";
+    version = "4.3.0";
+    hash = "sha256-MG3V/owDh273GCUPsGGraNwaVpcydupl3EtPXj6TVG0=";
+  })
+  (fetchNuGet {
+    pname = "System.Security.Permissions";
+    version = "4.5.0";
+    hash = "sha256-Fa6dX6Gyse1A/RBoin8cVaHQePbfBvp6jjWxUXPhXKQ=";
+  })
+  (fetchNuGet {
+    pname = "System.Security.Principal";
+    version = "4.0.1";
+    hash = "sha256-9wBgPnJfFOtrhKZ7wDXZ4q12GklQ49Ka02/9v7Frf9k=";
+  })
+  (fetchNuGet {
+    pname = "System.Security.Principal.Windows";
+    version = "4.5.0";
+    hash = "sha256-BkUYNguz0e4NJp1kkW7aJBn3dyH9STwB5N8XqnlCsmY=";
+  })
+  (fetchNuGet {
+    pname = "System.Security.Principal.Windows";
+    version = "5.0.0";
+    hash = "sha256-CBOQwl9veFkrKK2oU8JFFEiKIh/p+aJO+q9Tc2Q/89Y=";
+  })
+  (fetchNuGet {
+    pname = "System.Text.Encoding";
+    version = "4.0.11";
+    hash = "sha256-PEailOvG05CVgPTyKLtpAgRydlSHmtd5K0Y8GSHY2Lc=";
+  })
+  (fetchNuGet {
+    pname = "System.Text.Encoding";
+    version = "4.3.0";
+    hash = "sha256-GctHVGLZAa/rqkBNhsBGnsiWdKyv6VDubYpGkuOkBLg=";
+  })
+  (fetchNuGet {
+    pname = "System.Text.Encoding.CodePages";
+    version = "4.5.1";
+    hash = "sha256-PIhkv59IXjyiuefdhKxS9hQfEwO9YWRuNudpo53HQfw=";
+  })
+  (fetchNuGet {
+    pname = "System.Text.Encoding.Extensions";
+    version = "4.0.11";
+    hash = "sha256-+kf7J3dEhgCbnCM5vHYlsTm5/R/Ud0Jr6elpHm922iI=";
+  })
+  (fetchNuGet {
+    pname = "System.Text.Encoding.Extensions";
+    version = "4.3.0";
+    hash = "sha256-vufHXg8QAKxHlujPHHcrtGwAqFmsCD6HKjfDAiHyAYc=";
+  })
+  (fetchNuGet {
+    pname = "System.Text.RegularExpressions";
+    version = "4.1.0";
+    hash = "sha256-x6OQN6MCN7S0fJ6EFTfv4rczdUWjwuWE9QQ0P6fbh9c=";
+  })
+  (fetchNuGet {
+    pname = "System.Text.RegularExpressions";
+    version = "4.3.0";
+    hash = "sha256-VLCk1D1kcN2wbAe3d0YQM/PqCsPHOuqlBY1yd2Yo+K0=";
+  })
+  (fetchNuGet {
+    pname = "System.Threading";
+    version = "4.0.11";
+    hash = "sha256-mob1Zv3qLQhQ1/xOLXZmYqpniNUMCfn02n8ZkaAhqac=";
+  })
+  (fetchNuGet {
+    pname = "System.Threading";
+    version = "4.3.0";
+    hash = "sha256-ZDQ3dR4pzVwmaqBg4hacZaVenQ/3yAF/uV7BXZXjiWc=";
+  })
+  (fetchNuGet {
+    pname = "System.Threading.Channels";
+    version = "7.0.0";
+    hash = "sha256-Cu0gjQsLIR8Yvh0B4cOPJSYVq10a+3F9pVz/C43CNeM=";
+  })
+  (fetchNuGet {
+    pname = "System.Threading.Overlapped";
+    version = "4.0.1";
+    hash = "sha256-CAWZlavcuBQHs+kaSX9CmkpHF7wC8rFrug3XPb5KJzo=";
+  })
+  (fetchNuGet {
+    pname = "System.Threading.Tasks";
+    version = "4.0.11";
+    hash = "sha256-5SLxzFg1df6bTm2t09xeI01wa5qQglqUwwJNlQPJIVs=";
+  })
+  (fetchNuGet {
+    pname = "System.Threading.Tasks";
+    version = "4.3.0";
+    hash = "sha256-Z5rXfJ1EXp3G32IKZGiZ6koMjRu0n8C1NGrwpdIen4w=";
+  })
+  (fetchNuGet {
+    pname = "System.Threading.Tasks.Dataflow";
+    version = "4.6.0";
+    hash = "sha256-YYrT3GRzVBdendxt8FUDCnOBJi0nw/CJ9VrzcPJWLSg=";
+  })
+  (fetchNuGet {
+    pname = "System.Threading.Tasks.Extensions";
+    version = "4.0.0";
+    hash = "sha256-+YdcPkMhZhRbMZHnfsDwpNbUkr31X7pQFGxXYcAPZbE=";
+  })
+  (fetchNuGet {
+    pname = "System.Threading.Tasks.Extensions";
+    version = "4.3.0";
+    hash = "sha256-X2hQ5j+fxcmnm88Le/kSavjiGOmkcumBGTZKBLvorPc=";
+  })
+  (fetchNuGet {
+    pname = "System.Threading.Tasks.Extensions";
+    version = "4.5.4";
+    hash = "sha256-owSpY8wHlsUXn5xrfYAiu847L6fAKethlvYx97Ri1ng=";
+  })
+  (fetchNuGet {
+    pname = "System.Threading.Thread";
+    version = "4.0.0";
+    hash = "sha256-7EtSJuKqcW107FYA5Ko9NFXEWUPIzNDtlfKaQV2pvb8=";
+  })
+  (fetchNuGet {
+    pname = "System.Threading.Thread";
+    version = "4.3.0";
+    hash = "sha256-pMs6RNFC3nQOGz9EqIcyWmO8YLaqay+q/Qde5hqPXXg=";
+  })
+  (fetchNuGet {
+    pname = "System.Threading.ThreadPool";
+    version = "4.0.10";
+    hash = "sha256-/fowWjM/0ZZFC1Rwu0i5N71iRxV2JOd3jQV2Jn0wuTk=";
+  })
+  (fetchNuGet {
+    pname = "System.Threading.ThreadPool";
+    version = "4.3.0";
+    hash = "sha256-wW0QdvssRoaOfQLazTGSnwYTurE4R8FxDx70pYkL+gg=";
+  })
+  (fetchNuGet {
+    pname = "System.Threading.Timer";
+    version = "4.3.0";
+    hash = "sha256-pmhslmhQhP32TWbBzoITLZ4BoORBqYk25OWbru04p9s=";
+  })
+  (fetchNuGet {
+    pname = "System.ValueTuple";
+    version = "4.5.0";
+    hash = "sha256-niH6l2fU52vAzuBlwdQMw0OEoRS/7E1w5smBFoqSaAI=";
+  })
+  (fetchNuGet {
+    pname = "System.Xml.ReaderWriter";
+    version = "4.0.11";
+    hash = "sha256-haZAFFQ9Sl2DhfvEbdx2YRqKEoxNMU5STaqpMmXw0zA=";
+  })
+  (fetchNuGet {
+    pname = "System.Xml.ReaderWriter";
+    version = "4.3.0";
+    hash = "sha256-QQ8KgU0lu4F5Unh+TbechO//zaAGZ4MfgvW72Cn1hzA=";
+  })
+  (fetchNuGet {
+    pname = "System.Xml.XDocument";
+    version = "4.0.11";
+    hash = "sha256-KPz1kxe0RUBM+aoktJ/f9p51GudMERU8Pmwm//HdlFg=";
+  })
+  (fetchNuGet {
+    pname = "System.Xml.XDocument";
+    version = "4.3.0";
+    hash = "sha256-rWtdcmcuElNOSzCehflyKwHkDRpiOhJJs8CeQ0l1CCI=";
+  })
+  (fetchNuGet {
+    pname = "System.Xml.XmlDocument";
+    version = "4.0.1";
+    hash = "sha256-gdoFrPo54v1LjkBF79f8EvtltVVjHz9ZI9kc5ve0GkY=";
+  })
+  (fetchNuGet {
+    pname = "System.Xml.XPath";
+    version = "4.0.1";
+    hash = "sha256-lQCoK2M51SGRuGjfiuIW26Y2goABY2RLE6cZ4816WDo=";
+  })
+  (fetchNuGet {
+    pname = "System.Xml.XPath.XmlDocument";
+    version = "4.0.1";
+    hash = "sha256-bK9AfAYrdSipdRbmo8Rk7394ku92UFNe2TEQF5+k/lA=";
+  })
+  (fetchNuGet {
+    pname = "xunit";
+    version = "2.4.2";
+    hash = "sha256-tePXTtlRgTAhfnUzc13Y9MwowU/cKttl1qlzHLqhWS0=";
+  })
+  (fetchNuGet {
+    pname = "xunit.abstractions";
+    version = "2.0.3";
+    hash = "sha256-0D1y/C34iARI96gb3bAOG8tcGPMjx+fMabTPpydGlAM=";
+  })
+  (fetchNuGet {
+    pname = "xunit.analyzers";
+    version = "1.0.0";
+    hash = "sha256-hZEaTaJN0bWw9q8tha5RziGlZ/lkDrj2S+QLQxgRjlw=";
+  })
+  (fetchNuGet {
+    pname = "xunit.assert";
+    version = "2.3.0";
+    hash = "sha256-lN+NiUEQoHWmoamUjvsNt2PVhHXYeHJHjHRk1BTs6R8=";
+  })
+  (fetchNuGet {
+    pname = "xunit.assert";
+    version = "2.4.2";
+    hash = "sha256-wMyRXZzDn9Se4c0Pzzn0U4YuKRiUtu6o4MoPjJPPzUU=";
+  })
+  (fetchNuGet {
+    pname = "xunit.core";
+    version = "2.4.2";
+    hash = "sha256-jRFoW8LSuqDINuJlno3xT3VfdkHFVEbDKctU/mISIMc=";
+  })
+  (fetchNuGet {
+    pname = "xunit.extensibility.core";
+    version = "2.4.2";
+    hash = "sha256-wlTMUOQg5NaAPEsWkNSr8QSPbbCNSicpFajp1rowCsA=";
+  })
+  (fetchNuGet {
+    pname = "xunit.extensibility.execution";
+    version = "2.4.2";
+    hash = "sha256-l5Q60IBYWE5tYJCdFEEQnO5rIlXcNEM5S4Ut8vFnL2U=";
+  })
+  (fetchNuGet {
+    pname = "xunit.runner.visualstudio";
+    version = "2.4.5";
+    hash = "sha256-Gv7U1VPKfNb7IOWrwUGUKAeurKtE3AtQmegDFNkYHHk=";
+  })
+]

--- a/pkgs/godot_4-mono/make-deps.nix
+++ b/pkgs/godot_4-mono/make-deps.nix
@@ -1,0 +1,63 @@
+{ pkgs
+, nuget-to-nix
+,
+}:
+let
+  godot4-mono = pkgs.callPackage ./default.nix { deps = null; };
+in
+godot4-mono.overrideAttrs (base: {
+  pname = "godot_4-mono-make-deps";
+
+  nativeBuildInputs = base.nativeBuildInputs ++ [ nuget-to-nix ];
+
+  outputs = [ "out" ];
+
+  dontBuild = true;
+
+  installPhase = ''echo "No output intended. Run make-deps.sh instead." > $out'';
+
+  # This script is used to update the accompanying deps.nix file, a nix expression listing the
+  # nuget packages that the godot-mono code depends on, along with their sha256 hashes. This
+  # file is referenced by the godot-mono derivation and needs to be updated every time the
+  # godot version is updated. The way it works is:
+  #
+  # 1) Creates and navigates to a temporary directory and then explicitly runs the unpack,
+  # patch, and configure phases from the godot-mono derivation.
+  # 2) Instead of building at this point, a nuget restore is performed, downloading all the
+  # nuget dependencies of godot-mono into a local folder.
+  # 3) Once these have been downloaded, the nuget-to-nix tool is used to generate a nix
+  # expression listing the locally obtained nuget packages, along with their sha256 hashes.
+  # 4) This nix expression is saved as deps.nix in the PWD.
+  #
+  # This process is impure, because it entails downloading files with unknown hashes, so it
+  # is run manually by the maintainer within a nix-shell environment. Running the accompanying
+  # make-deps.sh instead simplifies this.
+  makeDeps = ''
+    set -e
+    outdir="$(pwd)"
+    wrkdir="$(mktemp -d)"
+    trap 'rm -rf -- "$wrkdir"' EXIT
+    pushd "$wrkdir" > /dev/null
+      unpackPhase
+      cd source
+      patchPhase
+      configurePhase
+
+      # Without RestorePackagesPath set, it restores packages to a temp directory. Specifying
+      # a path ensures we have a place to run nuget-to-nix.
+      nugetRestore() { dotnet restore --packages ~/.nuget/packages $1; }
+
+      nugetRestore modules/mono/glue/GodotSharp/GodotSharp.sln
+      nugetRestore modules/mono/editor/GodotTools/GodotTools.sln
+      nugetRestore modules/mono/editor/Godot.NET.Sdk/Godot.NET.Sdk.sln
+
+      nuget-to-nix ~/.nuget/packages > "$outdir"/deps.nix
+    popd > /dev/null
+  '';
+
+  meta =
+    base.meta
+    // {
+      description = "Derivation with no output that exists to provide an environment for make-deps.sh";
+    };
+})

--- a/pkgs/godot_4-mono/make-deps.sh
+++ b/pkgs/godot_4-mono/make-deps.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+nix-shell -E 'with import <nixpkgs> {}; callPackage ./default.nix {}' -A make-deps --run 'eval "$makeDeps"'


### PR DESCRIPTION
### :fish: What?

Added `godot_4-mono`, since the package is not available in Nixpkgs yet, nor is the original PR updated. Lets add it until we have a working upstream package.

https://github.com/NixOS/nixpkgs/pull/285941
 
### :fishing_pole_and_fish: Why?

It is a very relevant package for a friend of mine, and me. 

### :fish_cake: Pending

- [x] Complain with linter.
- [x] Build package
- [x] Test package
- [x] Fix error "Unable to load .NET runtime, specifically hostfxr."
- [x] Provide `msbuild` and `dotnet-sdk` via Wrapper