### PR TITLE
disable info logging of scx (errors still go to journal)

### DIFF
--- a/modules/nixos/scx.nix
+++ b/modules/nixos/scx.nix
@@ -47,6 +47,8 @@ in
         User = "root";
         ExecStart = "${lib.getExe' cfg.package cfg.scheduler}";
         Restart = "on-failure";
+        StandardError = "journal";
+        StandardOutput = "null";
       };
     };
 


### PR DESCRIPTION
### :fish: What?

modified a module

### :fishing_pole_and_fish: Why?

disables unnecessary info logging into the journal while keeping error logs

### :fish_cake: Pending

nothing pending

### :whale: Extras

no extra
