### PR TITLE
update service file for scx to actually disable journal logs

### DIFF
--- a/modules/nixos/scx.nix
+++ b/modules/nixos/scx.nix
@@ -47,7 +47,7 @@ in
         User = "root";
         ExecStart = "${lib.getExe' cfg.package cfg.scheduler}";
         Restart = "on-failure";
-        StandardError = "journal";
+        StandardError = "null";
         StandardOutput = "null";
       };
     };


### PR DESCRIPTION
apparently even the info messages coming from StandardError

### :fish: What?

updating scx service file 

### :fishing_pole_and_fish: Why?

- disabling journal messages for scx service

### :fish_cake: Pending

Nothing to pending

### :whale: Extras

Sorry for not testing it on the first PR
