### PR TITLE
owl-wlr: module init

### DIFF
--- a/modules/nixos/default.nix
+++ b/modules/nixos/default.nix
@@ -9,6 +9,7 @@ let
     nyx-cache = import ./nyx-cache.nix fromFlakes;
     nyx-overlay = import ../common/nyx-overlay.nix fromFlakes;
     zfs-impermanence-on-shutdown = import ./zfs-impermanence-on-shutdown.nix;
+    owl-wlr = import ./owl-wlr.nix;
   };
 
   default = { ... }: {

--- a/modules/nixos/owl-wlr.nix
+++ b/modules/nixos/owl-wlr.nix
@@ -1,0 +1,69 @@
+{ config, lib, pkgs, ... }:
+
+let
+  cfg = config.chaotic.owl-wlr;
+in
+{
+  options.programs.owl-wlr = {
+    enable = lib.mkEnableOption ''
+      Owl - tiling wayland compositor based on wlroots. 
+      Enabling this option will add owl to your system.
+    '';
+
+    package = lib.mkPackageOption pkgs "owl-wlr" {
+      nullable = true;
+      extraDescription = ''
+        This option can provide different version of Owl compositor.
+      '';
+    };
+
+    extraPackages = lib.mkOption {
+      type = with lib.types; listOf package;
+      default = with pkgs; [
+        kitty
+        rofi
+      ]; # because default.conf requires both pkgs.kitty and pkgs.rofi
+      defaultText = lib.literalExpression ''
+        with pkgs; [
+          kitty 
+          rofi
+        ];
+      '';
+      example = lib.literalExpression ''
+        with pkgs; [
+          foot
+          fuzzel
+          gtklock
+          mako
+          grimblast
+        ];
+      '';
+      description = ''
+        Extra packages to be installed system wide.
+        Both pkgs.kitty and pkgs.rofi is required by default config.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable
+    (
+      lib.mkMerge [
+        {
+          environment.systemPackages = [ cfg.package ];
+
+          systemd.packages = [ cfg.package ];
+
+          services = {
+            displayManager.sessionPackages = [ cfg.package ];
+          };
+
+          xdg.portal = {
+            enable = lib.mkDefault true;
+            configPackages = [ cfg.package ];
+          };
+        };
+      ];
+    );
+
+  meta.maintainers = with lib.maintainers; [ s0me1newithhand7s ];
+}

--- a/modules/nixos/owl-wlr.nix
+++ b/modules/nixos/owl-wlr.nix
@@ -4,13 +4,13 @@ let
   cfg = config.chaotic.owl-wlr;
 in
 {
-  options.programs.owl-wlr = {
+  options.chaotic.owl-wlr = {
     enable = lib.mkEnableOption ''
       Owl - tiling wayland compositor based on wlroots. 
       Enabling this option will add owl to your system.
     '';
 
-    package = lib.mkPackageOption pkgs "owl-wlr" {
+    package = lib.mkPackageOption pkgs "owl-wlr_git" {
       nullable = true;
       extraDescription = ''
         This option can provide different version of Owl compositor.
@@ -53,16 +53,12 @@ in
 
           systemd.packages = [ cfg.package ];
 
-          services = {
-            displayManager.sessionPackages = [ cfg.package ];
-          };
-
           xdg.portal = {
             enable = lib.mkDefault true;
             configPackages = [ cfg.package ];
           };
-        };
-      ];
+        }
+      ]
     );
 
   meta.maintainers = with lib.maintainers; [ s0me1newithhand7s ];


### PR DESCRIPTION
### :fish: What?

1. `owl-wlr` inits as module! available at `chaotic.owl-wlr.enable = true;`.

### :fishing_pole_and_fish: Why?

- (🏆) To make `owl-wlr`  even more accessible! 

### :whale: Extras

- You see, one loves the sunset when one is so sad. (c) Antuan De Sent Exupery, Little Prince 
