### PR TITLE
Fix overlay on NixOS 24.11

### DIFF
--- a/modules/common/nyx-overlay.nix
+++ b/modules/common/nyx-overlay.nix
@@ -20,7 +20,7 @@ let
         else
           import "${flakes.nixpkgs}" {
             inherit (cfg.flakeNixpkgs) config;
-            localSystem = stdenv.hostPlatform;
+            localSystem = flakes.nixpkgs.legacyPackages."${pkgs.stdenv.hostPlatform.system}".stdenv.hostPlatform;
           };
     in
     flakes.self.utils.applyOverlay { pkgs = prev; };


### PR DESCRIPTION
### :fish: What?

This PR fixes the overlay, so that binary caches work on NixOS 24.11.

### :fishing_pole_and_fish: Why?

It seems that using `pkgs.stdenv.hostPlatform` (if `pkgs` is from `nixos-24.11`) when importing `inputs.nixpkgs` (`nixpkgs-unstable`) causes the output hashes to diverge. This PR makes sure that we always use `stdenv.hostPlatform` from the Flake `nixpkgs` when using the Flake `nixpkgs` and not cross-compiling.

### :fish_cake: Pending

- [x] Complain with linter;
- [x] Remove some temporary fix;
- [ ] Publishing to news' channel.

### :whale: Extras

I tested this on my system and it fixed the output hashes mismatching and thus fixed the binary cache.

The "Why am I building a kernel?" section was really helpful while debugging this. Thanks!
