### PR TITLE
Registry and stable channels

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,8 +85,8 @@
 
 <p>This tutorial does not apply for users using NixOS unstable channel. This tutorial is for 24.11 and other stable channels.</p>
 
-<p>You won't have access to all the modules and options avaiable to unstable users as those are prone to break due to the divergence between the channels.
-But, you'll have access to all packages, the cache and the registry.</p>
+<p>You won't have access to all the modules and options available to unstable users, as those are prone to breaking due to the divergence between the channels.
+But you'll have access to all packages, the cache, and the registry.</p>
 
 <p>We recommend integrating this repo using Flakes:</p>
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@
   <li>
     <a href="#how-to-use-it">How to use it</a><br/>
     <ul>
-      <li><a href="#on-nixos">On NixOS</a><br/></li>
+      <li><a href="#on-nixos-unstable">On NixOS unstable</a><br/></li>
+      <li><a href="#on-nixos-stable">On NixOS stable</a><br/></li>
       <li><a href="#on-home-manager">On Home-Manager</a><br/></li>
       <li><a href="#running-packages-without-installing">Running packages (without installing)</a><br/></li>
       <li><a href="#binary-cache-notes">Binary Cache notes</a><br/></li>
@@ -41,7 +42,9 @@
 
 <h2 id="how-to-use-it">How to use it</h2>
 
-<h3 id="on-nixos">On NixOS</h3>
+<h3 id="on-nixos-unstable">On NixOS unstable</h3>
+
+<p>This tutorial does not apply for users using NixOS 24.11 and other stable channels. This tutorial is for unstable users.</p>
 
 <p>We recommend integrating this repo using Flakes:</p>
 
@@ -75,6 +78,50 @@
 {
   environment.systemPackages = [ pkgs.lan-mouse_git ];
   chaotic.mesa-git.enable = true;
+}
+</code></pre>
+
+<h3 id="on-nixos-stable">On NixOS stable</h3>
+
+<p>This tutorial does not apply for users using NixOS unstable channel. This tutorial is for 24.11 and other stable channels.</p>
+
+<p>You won't have access to all the modules and options avaiable to unstable users as those are prone to break due to the divergence between the channels.
+But, you'll have access to all packages, the cache and the registry.</p>
+
+<p>We recommend integrating this repo using Flakes:</p>
+
+<pre lang="nix"><code class="language-nix">
+{
+  description = "My configuration";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.11";
+    chaotic.url = "github:chaotic-cx/nyx/nyxpkgs-unstable";
+  };
+
+  outputs = { nixpkgs, chaotic, ... }: {
+    nixosConfigurations = {
+      hostname = nixpkgs.lib.nixosSystem {
+        system = "x86_64-linux";
+        modules = [
+          ./configuration.nix # Your system configuration.
+          chaotic.nixosModules.nyx-cache
+          chaotic.nixosModules.nyx-overlay
+          chaotic.nixosModules.nyx-registry
+        ];
+      };
+    };
+  };
+}
+</code></pre>
+
+<p>In your <code>configuration.nix</code> enable the packages that you prefer:</p>
+
+<pre lang="nix"><code class="language-nix">
+{ pkgs, ... }:
+{
+  environment.systemPackages = [ pkgs.lan-mouse_git ];
+  boot.kernelPackages = pkgs.linuxPackages_cachyos;
 }
 </code></pre>
 

--- a/modules/common/nyx-registry.nix
+++ b/modules/common/nyx-registry.nix
@@ -31,7 +31,7 @@ in
       "chaotic=${flakes.self}"
     ];
     nix.registry = lib.mkIf pathCfg.enable {
-      chaotic.flake.path = flakes.self;
+      chaotic.flake = flakes.self;
     };
   };
 }

--- a/modules/common/nyx-registry.nix
+++ b/modules/common/nyx-registry.nix
@@ -1,0 +1,36 @@
+{ flakes }: { config, lib, ... }:
+let
+  registryCfg = config.chaotic.nyx.registry;
+  pathCfg = config.chaotic.nyx.nixPath;
+in
+{
+  options = with lib; {
+    chaotic.nyx.registry.enable =
+      mkOption {
+        default = true;
+        example = false;
+        type = types.bool;
+        description = ''
+          Whether to add Chaotic-Nyx to `nix.registry`.
+        '';
+      };
+    options = with lib; {
+      chaotic.nyx.nixPath.enable =
+        mkOption {
+          default = true;
+          example = false;
+          type = types.bool;
+          description = ''
+            Whether to add Chaotic-Nyx to `nix.nixPath`.
+          '';
+        };
+    };
+    config = {
+      nix.nixPath = lib.lists.optionals cfg.enable [
+        "chaotic=${flakes.self}"
+      ];
+      nix.registry = lib.mkIf cfg.enable {
+        chaotic.flake.path = flakes.self;
+      };
+    };
+  }

--- a/modules/common/nyx-registry.nix
+++ b/modules/common/nyx-registry.nix
@@ -33,4 +33,5 @@ in
         chaotic.flake.path = flakes.self;
       };
     };
-  }
+  };
+}

--- a/modules/common/nyx-registry.nix
+++ b/modules/common/nyx-registry.nix
@@ -5,17 +5,17 @@ let
 in
 {
   options = with lib; {
-    chaotic.nyx.registry.enable =
-      mkOption {
-        default = true;
-        example = false;
-        type = types.bool;
-        description = ''
-          Whether to add Chaotic-Nyx to `nix.registry`.
-        '';
-      };
-    options = with lib; {
-      chaotic.nyx.nixPath.enable =
+    chaotic.nyx = {
+      registry.enable =
+        mkOption {
+          default = true;
+          example = false;
+          type = types.bool;
+          description = ''
+            Whether to add Chaotic-Nyx to `nix.registry`.
+          '';
+        };
+      nixPath.enable =
         mkOption {
           default = true;
           example = false;
@@ -25,13 +25,13 @@ in
           '';
         };
     };
-    config = {
-      nix.nixPath = lib.lists.optionals cfg.enable [
-        "chaotic=${flakes.self}"
-      ];
-      nix.registry = lib.mkIf cfg.enable {
-        chaotic.flake.path = flakes.self;
-      };
+  };
+  config = {
+    nix.nixPath = lib.lists.optionals cfg.enable [
+      "chaotic=${flakes.self}"
+    ];
+    nix.registry = lib.mkIf cfg.enable {
+      chaotic.flake.path = flakes.self;
     };
   };
 }

--- a/modules/common/nyx-registry.nix
+++ b/modules/common/nyx-registry.nix
@@ -27,10 +27,10 @@ in
     };
   };
   config = {
-    nix.nixPath = lib.lists.optionals cfg.enable [
+    nix.nixPath = lib.lists.optionals registryCfg.enable [
       "chaotic=${flakes.self}"
     ];
-    nix.registry = lib.mkIf cfg.enable {
+    nix.registry = lib.mkIf pathCfg.enable {
       chaotic.flake.path = flakes.self;
     };
   };

--- a/modules/home-manager/default.nix
+++ b/modules/home-manager/default.nix
@@ -3,6 +3,7 @@ let
   modulesPerFile = {
     nyx-cache = import ./nyx-cache.nix fromFlakes;
     nyx-overlay = import ../common/nyx-overlay.nix fromFlakes;
+    nyx-registry = import ../common/nyx-registry.nix fromFlakes;
   };
 
   default = { ... }: {

--- a/modules/nixos/default.nix
+++ b/modules/nixos/default.nix
@@ -8,6 +8,7 @@ let
     nordvpn = import ./nordvpn.nix;
     nyx-cache = import ./nyx-cache.nix fromFlakes;
     nyx-overlay = import ../common/nyx-overlay.nix fromFlakes;
+    nyx-registry = import ../common/nyx-registry.nix fromFlakes;
     zfs-impermanence-on-shutdown = import ./zfs-impermanence-on-shutdown.nix;
     owl-wlr = import ./owl-wlr.nix;
   };


### PR DESCRIPTION
### :fish: What?

1. Adds a module for users to use chaotic easily through Nix tooling;
2. Document usage with stable channels.

### :fishing_pole_and_fish: Why?

- (1) Allows usage like `nix run chaotic#gamescope_git`;
- (2) Plenty of stable users are showing up in chat.
