### PR TITLE
nixos/duckdns: remove non existing option reference

### DIFF
--- a/modules/nixos/duckdns.nix
+++ b/modules/nixos/duckdns.nix
@@ -125,7 +125,6 @@ in
       acceptTerms = true;
       certs.${cfg.domain} = {
         inherit group;
-        inherit (cfg) email;
         dnsProvider = lib.mkIf (!cfg.certs.useHttpServer) "duckdns";
         credentialsFile = lib.mkIf (!cfg.certs.useHttpServer) cfg.environmentFile;
         listenHTTP = lib.mkIf cfg.certs.useHttpServer ":${toString httpPort}"; # any other port needs to be proxied


### PR DESCRIPTION
Closes https://github.com/chaotic-cx/nyx/issues/980