### PR TITLE
zed-editor-fhs_git: init alias to zed-editor_git.fhs

### DIFF
--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -276,6 +276,7 @@ in
   zed-editor_git = callOverride ../pkgs/zed-editor-git {
     zedPins = importJSON ../pkgs/zed-editor-git/pins.json;
   };
+  zed-editor-fhs_git = final.zed-editor_git.fhs;
 
   zfs_cachyos = cachyosPackages.zfs;
 


### PR DESCRIPTION
This makes it so we also cache zed-editor-fhs_git.

Followup of https://github.com/NixOS/nixpkgs/pull/387808