### PR TITLE
zed-editor_git: fix icon

### DIFF
--- a/pkgs/zed-editor-git/default.nix
+++ b/pkgs/zed-editor-git/default.nix
@@ -29,7 +29,10 @@ gitOverride (current: {
     };
     installPhase =
       builtins.replaceStrings [ "zed-remote-server-stable-$version" ] [ "zed-remote-server-dev-build" ]
-        prevAttrs.installPhase;
+        (
+          builtins.replaceStrings [ "dev.zed.Zed.desktop" ] [ "dev.zed.Zed-Dev.desktop" ]
+            prevAttrs.installPhase
+        );
     # duplicated cargo deps is a mess
     patches =
       (nyxUtils.removeByBaseNames [


### PR DESCRIPTION
Opening Zed showed a generic Wayland icon, due to the mismatching app_id and .desktop name. This change should fix it.
See [the official flake](https://github.com/zed-industries/zed/blob/main/flake.nix).
(The icon and the app name aren't changed in this PR.) 
Untested.
