### PR TITLE
Add bazaar (flatpak gui store)

### DIFF
--- a/modules/nixos/bazaar.nix
+++ b/modules/nixos/bazaar.nix
@@ -1,0 +1,67 @@
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.services.bazaar;
+
+  contentConfigFile = pkgs.writeText "bazaar-content.yml" cfg.contentConfig;
+  blocklistFile = pkgs.writeText "bazaar-blocklist.txt" cfg.blocklist;
+in {
+  options.services.bazaar = {
+    enable = mkEnableOption "Bazaar service";
+
+    package = mkOption {
+      type = types.package;
+      default = pkgs.bazaar;
+      description = "The Bazaar package to use.";
+    };
+
+    contentConfig = mkOption {
+      type = types.str;
+      default = ''
+      sections:
+        - title: "Bazaar for nix default selection"
+          subtitle: "You should change this with services.bazaar.contentConfig"
+          description: "These are some of my favorite apps!"
+          rows: 3
+          banner-fit: cover
+          appids:
+            - net.lutris.Lutris
+            - org.mozilla.firefox
+            - com.modrinth.ModrinthApp
+            - org.blender.Blender
+            - org.desmume.DeSmuME
+            - com.system76.Popsicle
+            - com.valvesoftware.Steam
+            - org.gimp.GIMP
+            - org.gnome.Builder
+            - org.gnome.Loupe
+            - org.inkscape.Inkscape
+            - org.kde.krita
+    '';
+      description = "The bazaar configuration file content.";
+    };
+
+    blocklist = mkOption {
+      type = types.str;
+      default = ''
+
+    '';
+      description = "The bazaar blocklist file content.";
+    };
+
+  };
+
+  config = mkIf cfg.enable {
+    systemd.user.services.bazaar = {
+      description = "Bazaar background service";
+      wantedBy = [ "default.target" ];
+      serviceConfig = {
+        Type = "simple";
+        ExecStart =
+          "${cfg.package}/bin/bazaar service --extra-content-config ${contentConfigFile} --extra-blocklist ${blocklistFile}";
+      };
+    };
+  };
+}

--- a/modules/nixos/default.nix
+++ b/modules/nixos/default.nix
@@ -12,6 +12,7 @@ let
     zfs-impermanence-on-shutdown = import ./zfs-impermanence-on-shutdown.nix;
     owl-wlr = import ./owl-wlr.nix;
     conduwuit = import ./conduwuit.nix;
+    bazaar = import ./bazaar.nix;
   };
 
   default =

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -139,6 +139,8 @@ in
 
   appmenu-gtk3-module = final.callPackage ../pkgs/appmenu-gtk3-module { };
 
+  bazaar = final.callPackage ../pkgs/bazaar { };
+
   beautyline-icons = final.callPackage ../pkgs/beautyline-icons { };
 
   bpftools_full =

--- a/pkgs/bazaar/default.nix
+++ b/pkgs/bazaar/default.nix
@@ -1,0 +1,54 @@
+{ lib, blueprint-compiler, desktop-file-utils, fetchFromGitHub, flatpak
+, flatpak-xdg-utils, glib, libxmlb, libglycin, cmake, gobject-introspection
+, gtk4, libdex, libadwaita, appstream, meson, ninja, nix-update-script
+, pkg-config, libyaml, libsoup_3, stdenv, wrapGAppsHook4, json-glib, curl, fetchurl }:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "bazaar";
+  version = "v0.1.0"; # First pre-release version
+
+  src = fetchFromGitHub {
+    owner = "kolunmi";
+    repo = "bazaar";
+    tag = finalAttrs.version;
+    hash = "sha256-QzzWj6KjyKNMBHQ/RqvUSL6QeokgvK2Fc+23kkt3SMM=";
+  };
+
+  nativeBuildInputs = [
+    blueprint-compiler
+    desktop-file-utils
+    meson
+    cmake
+    ninja
+    pkg-config
+    wrapGAppsHook4
+    gobject-introspection
+  ];
+
+  buildInputs = [
+    flatpak
+    flatpak-xdg-utils
+    glib
+    gtk4
+    libadwaita
+    libdex
+    appstream
+    libxmlb
+    libglycin
+    libyaml
+    json-glib
+    libsoup_3
+  ];
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    changelog = "https://github.com/kolunmi/bazaar/commits/master/";
+    description = "A new app store idea for GNOME";
+    homepage = "https://github.com/kolunmi/bazaar";
+    license = lib.licenses.gpl3Plus;
+    mainProgram = "bazaar";
+    maintainers = with lib.maintainers; [ jumpyvi ];
+    platforms = lib.platforms.linux;
+  };
+})


### PR DESCRIPTION
### :fish: What?

1. Added a new package; (https://github.com/kolunmi/bazaar)
2. Added a new module;

### :fishing_pole_and_fish: Why?

- (1) This new package is interesting to myself;

It is a newer, faster flatpak software store (in early development). It is much faster and lighter than gnome-software.

### :fish_cake: Pending

- [ ] Complain with linter;
- [ ] Remove some temporary fix;
- [ ] Publishing to news' channel.

### :whale: Extras

The home page can be configured in yaml with contentConfig
The blocklist can be configured in plain text with blocklist
The service can be enable user-wide with enable

It can be run with ``bazaar window``` or with the icon

example:

```
services.bazaar = {
    enable = true;
    blocklist = ''
      org.gnu.emacs
      '';

    contentConfig = ''
      sections:
        - title: "Mine"
          subtitle: "You should change this with services.bazaar.contentConfig"
          description: "These are some of my favorite apps!"
          rows: 3
          banner-fit: cover
          appids:
            - net.lutris.Lutris
            - org.mozilla.firefox
            - net.pcsx2.PCSX2
            - org.blender.Blender
            - com.modrinth.ModrinthApp
            - com.system76.Popsicle
            - com.valvesoftware.Steam
            - org.gimp.GIMP
            - org.gnome.Builder
            - org.gnome.Loupe
            - org.inkscape.Inkscape
            - org.kde.krita
    '';
   ```