### PR TITLE
firedragon: disable LTO

### DIFF
--- a/pkgs/firedragon/default.nix
+++ b/pkgs/firedragon/default.nix
@@ -45,6 +45,8 @@ let
         crashreporterSupport = false;
         enableOfficialBranding = false;
         pgoSupport = true;
+        # https://github.com/NixOS/nixpkgs/issues/418473
+        ltoSupport = false;
         privacySupport = true;
         webrtcSupport = true;
       }


### PR DESCRIPTION
See https://github.com/NixOS/nixpkgs/issues/418473

### :fish: What?

1. Disabled LTO for Firedragon as you get an upstream Floorp/ESR128 bug.

### :fishing_pole_and_fish: Why?

- (1) Might fix this issue: https://github.com/NixOS/nixpkgs/issues/418473 I think
- (2) Speeds up build times and reduces amount of needed memory

### :fish_cake: Pending

- [ ] Actually get someone who reported issues there to test whether this works

### :whale: Extras
