### PR TITLE
linux_cachyos: ZEN5 Optimizations

### DIFF
--- a/README.md
+++ b/README.md
@@ -393,7 +393,7 @@ enable_seq  hotplug_seq  nr_rejected  root  state  switch_all
 }
 </code></pre>
 
-<p>Use either <code>GENERIC_V2</code>, <code>GENERIC_V3</code>, <code>GENERIC_V4</code>, or <code>ZEN4</code>. We don't provide cache for these.</p>
+<p>Use either <code>GENERIC_V2</code>, <code>GENERIC_V3</code>, <code>GENERIC_V4</code>, <code>ZEN4</code>, or <code>ZEN5</code>. We don't provide cache for these.</p>
 
 <h2 id="criteria-for-new-packages">Criteria for new packages</h2>
 

--- a/pkgs/linux-cachyos/prepare.nix
+++ b/pkgs/linux-cachyos/prepare.nix
@@ -134,6 +134,12 @@ let
         "-e MZEN4"
         "-d X86_NATIVE_CPU"
       ]
+    else if cachyConfig.mArch == "ZEN5" then
+      [
+        "-d GENERIC_CPU"
+        "-e MZEN5"
+        "-d X86_NATIVE_CPU"
+      ]
     else if builtins.match "GENERIC_V[1-4]" cachyConfig.mArch != null then
       let
         v = lib.strings.removePrefix "GENERIC_V" cachyConfig.mArch;
@@ -145,7 +151,7 @@ let
         "--set-val X86_64_VERSION ${v}"
       ]
     else
-      throw "Unsuppoted cachyos mArch";
+      throw "Unsupported cachyos mArch";
 
   # _cpusched, defaults to "cachyos"
   cpuSchedConfig =


### PR DESCRIPTION
### :fish: What?

Added a ZEN5 option in the cachyOverrides mArch field.

### :fishing_pole_and_fish: Why?

I've got a ZEN5 CPU and want these optimizations, and they have been supported by both clang and GCC for quite a while now so there doesn't seem to be anything stopping me.

### :fish_cake: Pending

Nothing pending, it builds fine on my machine at least and seems pretty straight forward.

### :whale: Extras

- Also fixed a typo in an error message.
