### PR TITLE
modules: handle home-manager.useGlobalPkgs with a new module

### DIFF
--- a/modules/nixos/default.nix
+++ b/modules/nixos/default.nix
@@ -6,6 +6,7 @@ let
     hdr = import ./hdr.nix;
     mesa-git = import ./mesa-git.nix;
     nordvpn = import ./nordvpn.nix;
+    nyx-home-check = import ./nyx-home-check.nix;
     nyx-cache = import ./nyx-cache.nix fromFlakes;
     nyx-overlay = import ../common/nyx-overlay.nix fromFlakes;
     nyx-registry = import ../common/nyx-registry.nix fromFlakes;

--- a/modules/nixos/nyx-home-check.nix
+++ b/modules/nixos/nyx-home-check.nix
@@ -1,0 +1,24 @@
+{
+  config,
+  options,
+  lib,
+  ...
+}:
+let
+  inherit (lib.modules) mkDefault mkIf;
+  inherit (lib.attrsets) optionalAttrs;
+in
+{
+  # Under circumstances where a user is using pkgs from their NixOS
+  # configuration,
+  config = optionalAttrs (options ? "home-manager") {
+    home-manager.sharedModules = mkIf config.home-manager.useGlobalPkgs [
+      {
+        # the overlay should not be added to nixpkgs.overlays as this causes a
+        # warning which may eventually become an error, but is also
+        # generally bad form anyway.
+        chaotic.nyx.overlay.enable = mkDefault false;
+      }
+    ];
+  };
+}


### PR DESCRIPTION
### :fish: What?

Added a new module.

### :fishing_pole_and_fish: Why?

In the case a user has chosen to have both `.default` options from the home-manager and NixOS modules in this flake, checks if user is using home-manager, and if home-manager.useGlobalPkgs is used. In circumstances where it is, prevent the use of the overlay since this would cause a warning, potentially in future cause an error.

`nix fmt` was then used.

For people who don't want to do this, but are in the same situation regardless, a `chaotic.nyx.overlay.enable = false;` also suffices, but here we are, thus I don't know if it's ultimately necessary, but here we are.