### PR TITLE
mwc-git: set mainProgram since package and binary names differ

### DIFF
--- a/pkgs/mwc-git/package.nix
+++ b/pkgs/mwc-git/package.nix
@@ -74,5 +74,6 @@ stdenv.mkDerivation rec {
     license = lib.licenses.mit;
     maintainers = with lib.maintainers; [ s0me1newithhand7s ];
     platforms = with lib; [ "x86_64-linux" ];
+    mainProgram = "mwc";
   };
 }


### PR DESCRIPTION
### :fish: What?

Added mainProgram to mwc-git package

### :fishing_pole_and_fish: Why?

- Fixes
```
$ nix run github:chaotic-cx/nyx/nyxpkgs-unstable#mwc_git
error: unable to execute '/nix/store/qb98fshyszw70iwsyxva27wywg2if27j-mwc-wlr-unstable-20250316235640-33b4968/bin/mwc-wlr': No such file or directory
```
