### PR TITLE
mesa-git: enable anti-lag layer

### DIFF
--- a/pkgs/mesa-git/default.nix
+++ b/pkgs/mesa-git/default.nix
@@ -53,6 +53,9 @@ gitOverride (current: {
               hash = "sha256-CDmzKdV40EExLpOHPAUnytqG9x1+IGW4AZldfYs5YJk=";
             };
           });
+        vulkanLayers = prev.mesa.vulkanLayers ++ [
+          "anti-lag"
+        ];
       }
       // (
         if is32bit then


### PR DESCRIPTION
### :fish: What?

https://www.phoronix.com/news/Mesa-Vulkan-AMD-Anti-Lag

### :fishing_pole_and_fish: Why?

The input lag is definitely why I miss all the time with hitscan characters in Marvel Rivals.

### :fish_cake: Pending

Untested.
