### PR TITLE
linux_cachyos: adopt thin LTO in mainline

### DIFF
--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -199,17 +199,19 @@ in
 
   libportal_git = callOverride ../pkgs/libportal-git { };
 
-  linux_cachyos = drvDropUpdateScript cachyosPackages.cachyos.kernel;
+  linux_cachyos = drvDropUpdateScript cachyosPackages.cachyos-lto.kernel;
+  linux_cachyos-lto = drvDropUpdateScript cachyosPackages.cachyos-lto.kernel;
+  linux_cachyos-gcc = drvDropUpdateScript cachyosPackages.cachyos-gcc.kernel;
+  linux_cachyos-server = drvDropUpdateScript cachyosPackages.cachyos-server.kernel;
   linux_cachyos-hardened = drvDropUpdateScript cachyosPackages.cachyos-hardened.kernel;
   linux_cachyos-rc = cachyosPackages.cachyos-rc.kernel;
-  linux_cachyos-server = drvDropUpdateScript cachyosPackages.cachyos-server.kernel;
-  linux_cachyos-lto = cachyosPackages.cachyos-lto.kernel;
 
-  linuxPackages_cachyos = cachyosPackages.cachyos;
-  linuxPackages_cachyos-hardened = cachyosPackages.cachyos-hardened;
+  linuxPackages_cachyos = cachyosPackages.cachyos-lto;
   linuxPackages_cachyos-lto = cachyosPackages.cachyos-lto;
-  linuxPackages_cachyos-rc = cachyosPackages.cachyos-rc;
+  linuxPackages_cachyos-gcc = cachyosPackages.cachyos-gcc;
   linuxPackages_cachyos-server = cachyosPackages.cachyos-server;
+  linuxPackages_cachyos-hardened = cachyosPackages.cachyos-hardened;
+  linuxPackages_cachyos-rc = cachyosPackages.cachyos-rc;
 
   luxtorpeda = final.callPackage ../pkgs/luxtorpeda {
     luxtorpedaVersion = importJSON ../pkgs/luxtorpeda/version.json;

--- a/pkgs/linux-cachyos/default.nix
+++ b/pkgs/linux-cachyos/default.nix
@@ -33,7 +33,7 @@ let
         // attrs
       );
 
-  mainKernel = mkCachyKernel {
+  gccKernel = mkCachyKernel {
     taste = "linux-cachyos";
     configPath = ./config-nix/cachyos.x86_64-linux.nix;
     # since all flavors use the same versions.json, we just need the updateScript in one of them
@@ -48,7 +48,7 @@ in
     mkCachyKernel
     ;
 
-  cachyos = mainKernel;
+  cachyos-gcc = gccKernel;
 
   cachyos-rc = mkCachyKernel {
     taste = "linux-cachyos-rc";
@@ -103,7 +103,7 @@ in
   };
 
   zfs = final.zfs_2_3.overrideAttrs (prevAttrs: {
-    src = if isDarwin then brokenDarwin else mainKernel.zfs_cachyos.src;
+    src = if isDarwin then brokenDarwin else gccKernel.zfs_cachyos.src;
     patches = [ ];
     passthru = prevAttrs.passthru // {
       kernelModuleAttribute = "zfs_cachyos";


### PR DESCRIPTION
### :fish: What?

1. Enables thin LLVM+LTO in `linux_cachyos`;
2. Introduces `linux_cachyos-gcc` as a flavor permanently built with GCC (and without LTO).

### :fishing_pole_and_fish: Why?

Following changes from CachyOS.