### PR TITLE
linux_cachyos-lto: avoid callPackage

### DIFF
--- a/pkgs/linux-cachyos/default.nix
+++ b/pkgs/linux-cachyos/default.nix
@@ -67,7 +67,7 @@ in
     taste = "linux-cachyos";
     configPath = ./config-nix/cachyos-lto.x86_64-linux.nix;
 
-    inherit (final.pkgsLLVM.extend flakes.self.overlays.default) stdenv linuxManualConfig linuxPackages linuxPackagesFor;
+    inherit (final.pkgsLLVM.extend flakes.self.overlays.default) stdenv linuxManualConfig;
     useLTO = "thin";
 
     description = "Linux EEVDF-BORE scheduler Kernel by CachyOS built with LLVM and Thin LTO";

--- a/pkgs/linux-cachyos/default.nix
+++ b/pkgs/linux-cachyos/default.nix
@@ -67,7 +67,7 @@ in
     taste = "linux-cachyos";
     configPath = ./config-nix/cachyos-lto.x86_64-linux.nix;
 
-    inherit (final.pkgsLLVM.extend flakes.self.overlays.default) callPackage;
+    inherit (final.pkgsLLVM.extend flakes.self.overlays.default) stdenv linuxManualConfig linuxPackages linuxPackagesFor;
     useLTO = "thin";
 
     description = "Linux EEVDF-BORE scheduler Kernel by CachyOS built with LLVM and Thin LTO";

--- a/pkgs/linux-cachyos/packages-for.nix
+++ b/pkgs/linux-cachyos/packages-for.nix
@@ -4,6 +4,7 @@
   configPath,
   versions,
   callPackage,
+  linuxManualConfig,
   linuxPackages,
   linuxPackagesFor,
   fetchFromGitHub,
@@ -75,7 +76,7 @@ let
   linuxConfigTransfomed = import configPath;
 
   kernel = callPackage ./kernel.nix {
-    inherit cachyConfig stdenv kconfigToNix;
+    inherit cachyConfig stdenv kconfigToNix linuxManualConfig;
     kernelPatches = [ ];
     configfile = preparedConfigfile;
     config = linuxConfigTransfomed;


### PR DESCRIPTION
### :fish: What?

Avoids overriding `callPackage` with the `pkgsLLVM` version.

### :fishing_pole_and_fish: Why?

Attempt to fix #1178 