### PR TITLE
linux_cachyos: default to the gcc flavor

### DIFF
--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -199,7 +199,7 @@ in
 
   libportal_git = callOverride ../pkgs/libportal-git { };
 
-  linux_cachyos = drvDropUpdateScript cachyosPackages.cachyos-lto.kernel;
+  linux_cachyos = drvDropUpdateScript cachyosPackages.cachyos-gcc.kernel;
   linux_cachyos-lto = drvDropUpdateScript cachyosPackages.cachyos-lto.kernel;
   linux_cachyos-gcc = drvDropUpdateScript cachyosPackages.cachyos-gcc.kernel;
   linux_cachyos-server = drvDropUpdateScript cachyosPackages.cachyos-server.kernel;
@@ -207,7 +207,7 @@ in
   linux_cachyos-rc = cachyosPackages.cachyos-rc.kernel;
   linux_cachyos-lts = cachyosPackages.cachyos-lts.kernel;
 
-  linuxPackages_cachyos = cachyosPackages.cachyos-lto;
+  linuxPackages_cachyos = cachyosPackages.cachyos-gcc;
   linuxPackages_cachyos-lto = cachyosPackages.cachyos-lto;
   linuxPackages_cachyos-gcc = cachyosPackages.cachyos-gcc;
   linuxPackages_cachyos-server = cachyosPackages.cachyos-server;


### PR DESCRIPTION
### :fish: What?

default to the gcc flavor

### :fishing_pole_and_fish: Why?

- We are having troubles with zfs on the  lto  flavor
