### PR TITLE
helix_git: fix broken symlinks for grammars

### DIFF
--- a/pkgs/helix-git/default.nix
+++ b/pkgs/helix-git/default.nix
@@ -23,7 +23,7 @@ let
       name,
       ...
     }@source:
-    "ln -s ${grammarArtifact source}/${name}.so $out/${name}.so";
+    "ln -s ${grammarArtifact source}/parser $out/${name}.so";
 
   grammarLinks = builtins.map grammarLink languages;
 


### PR DESCRIPTION
### :fish: What?

Minor bug fix:

Based on the grammar utility in nixpkgs located at https://github.com/NixOS/nixpkgs/blob/master/pkgs/development/tools/parsing/tree-sitter/grammar.nix, which is used by the `helix_git` package, the output artifact that should be expected is called `parser` and not `<lang>.so` as is currently the case.

### :fishing_pole_and_fish: Why?

Fixes an error:

In Nix land all is well, but at runtime due to the broken symlinks, the Helix editor is unable to locate the tree-sitter grammar when it starts up.

### :whale: Extras

More of a question really, but is it intentional that  https://github.com/chaotic-cx/nyx/blob/main/pkgs/helix-git/languages.json does not receive updates by the CI job? It is fairly behind at the moment.
