### PR TITLE
nordvpn: replace libxml2_13 with nixpkgs-unstable version

### DIFF
--- a/pkgs/nordvpn/default.nix
+++ b/pkgs/nordvpn/default.nix
@@ -10,7 +10,7 @@
   iproute2,
   procps,
   cacert,
-  libxml2,
+  libxml2_13,
   libidn2,
   libnl,
   libcap_ng,
@@ -76,14 +76,6 @@ let
         cacert
         wireguard-tools
       ];
-  };
-
-  libxml2_13 = libxml2.overrideAttrs rec {
-    version = "2.13.8";
-    src = fetchurl {
-      url = "mirror://gnome/sources/libxml2/${lib.versions.majorMinor version}/libxml2-${version}.tar.xz";
-      hash = "sha256-J3KUyzMRmrcbK8gfL0Rem8lDW4k60VuyzSsOhZoO6Eo=";
-    };
   };
 in
 stdenv.mkDerivation {


### PR DESCRIPTION
### :fish: What?

1. Replaces the libxml2_13 dependency of nordvpn with the nixpkgs-unstable libxml2_13

### :fishing_pole_and_fish: Why?

This fixes the following error when building the libxml2_13 dependency of nordvpn
```
Running phase: unpackPhase
@nix { "action": "setPhase", "phase": "unpackPhase" }
unpacking source archive /nix/store/gxk2c918qw2ppl2hr0gb9q23w701khyz-libxml2-2.13.8.tar.xz
source root is libxml2-2.13.8
setting SOURCE_DATE_EPOCH to timestamp 1744890702 of file "libxml2-2.13.8/xstc/Makefile.in"
Running phase: patchPhase
@nix { "action": "setPhase", "phase": "patchPhase" }
applying patch /nix/store/g4nybyl2hvcj139kvhl10xbfggy2vnx5-da45a190f718e8e2f0e3d2a6325ffa23abc8b90c.patch
patching file parser.c
Hunk #1 FAILED at 4025.
Hunk #2 FAILED at 8578.
2 out of 2 hunks FAILED -- saving rejects to file parser.c.rej
```

### :fish_cake: Pending

- [x] Complain with linter;
- [x] Build package;
- [ ] Test package;

### :whale: Extras

- Changing to use the nixpkgs libxml2_13 makes it easy because then they maintain it, less work for us.
