### PR TITLE
firefox-nightly: upgrade ICU dependency from icu77 to icu78

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -79,11 +79,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1764667669,
-        "narHash": "sha256-7WUCZfmqLAssbDqwg9cUDAXrSoXN79eEEq17qhTNM/Y=",
+        "lastModified": 1764950072,
+        "narHash": "sha256-BmPWzogsG2GsXZtlT+MTcAWeDK5hkbGRZTeZNW42fwA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "418468ac9527e799809c900eda37cbff999199b6",
+        "rev": "f61125a668a320878494449750330ca58b78c557",
         "type": "github"
       },
       "original": {

--- a/pkgs/firefox-nightly/default.nix
+++ b/pkgs/firefox-nightly/default.nix
@@ -13,6 +13,7 @@
   fetchFromGitHub,
   rustPlatform,
   apple-sdk_26,
+  icu78,
 }:
 
 let
@@ -92,6 +93,7 @@ let
 
   newInputs = {
     nss_latest = nss_git;
+    icu77 = icu78;
   };
 in
 nyxUtils.multiOverride mach newInputs postOverride


### PR DESCRIPTION
### :fish: What?

firefox-nightly: upgrade ICU dependency from icu77 to icu78

### :fishing_pole_and_fish: Why?

- (1) This new package is interesting to myself;
- (2) This new module makes it easier to rice my linux;
- (3) Fixes error [log](https://pastebin.com/example);
- (4) Faster build times.

### :fish_cake: Pending

- [ ] Complain with linter;
- [ ] Remove some temporary fix;
- [ ] Publishing to news' channel.

### :whale: Extras

- I've changed something unrelated in X because Y was worse.
- I like chocolate cake.](firefox-nightly: upgrade ICU dependency from icu77 to icu78)
