### PR TITLE
chore: bump spirv-headers_git

### DIFF
--- a/pkgs/spirv-headers-git/version.json
+++ b/pkgs/spirv-headers-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260520153951-8c5559c",
-  "rev": "8c5559c134abcf432ec59db842404087b9906c1a",
-  "hash": "sha256-NiwsoUZhFWugwtVUyXZdy+PTwUbat1fYSW3j6HfpF94="
+  "version": "unstable-20260527154838-1e770e7",
+  "rev": "1e770e7de8373a8dd49f23416cf7ca4001d01040",
+  "hash": "sha256-t8Shkoa90TJt1MbTOefnLaguW4eYKsRFO1Jd0AUc70Y="
 }


### PR DESCRIPTION
Automated package bump for `[
  "spirv-headers_git"
]`.