### PR TITLE
chore: bump pcsx2_git

### DIFF
--- a/pkgs/pcsx2-git/version.json
+++ b/pkgs/pcsx2-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260524120439-ae0b583",
-  "rev": "ae0b5834a03265e327d3dbe3c68e0ef69cdf9e80",
-  "hash": "sha256-h4EiEe84UqGwWcEoU90q/YN3lA1St6I3VtXeC9ehMnQ="
+  "version": "unstable-20260527215223-db16fa4",
+  "rev": "db16fa4403ca8357a2cc9054593ae9761b007905",
+  "hash": "sha256-BoYTvpKGgEC6PTZbIXar0llNjFbA8j/tnCZHnimJelM="
 }


### PR DESCRIPTION
Automated package bump for `[
  "pcsx2_git"
]`.