### PR TITLE
chore: bump libdrm_git

### DIFF
--- a/pkgs/mesa-git/version.json
+++ b/pkgs/mesa-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260525164928-e2e7fce",
-  "rev": "e2e7fce6e9e7df52b6d66af13b6f2d4bb8c28855",
-  "hash": "sha256-HS363CHz37v0fHYX42ChGAUcOyXDfzpqFQecKHXcY+M="
+  "version": "unstable-20260528121459-a5d34f8",
+  "rev": "a5d34f85f83da516af5c72fcbfadc6bf98b43754",
+  "hash": "sha256-8CIy+l9ecb0615oAltYwh57O/UjMzNLy2NdZjWCFqFo="
 }

--- a/pkgs/wlroots-git/version.json
+++ b/pkgs/wlroots-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260525084235-7265a79",
-  "rev": "7265a79e46ebf85f4402bb672e82b2747cfd4ad7",
-  "hash": "sha256-Pt8Lfp+pf148fEQ/t3HixJThGbH3RW9+zODVcH9Ew1c="
+  "version": "unstable-20260528091336-15a3783",
+  "rev": "15a378316e469470ae1cee45fe4cab2382b89658",
+  "hash": "sha256-xyKnNts5o2YvSF43lSlUxCmsPLh+asOQN7sjOHFvAKQ="
 }


### PR DESCRIPTION
Automated package bump for `[
  "libdrm_git",
  "wayland-protocols_git",
  "mesa_git",
  "wayland_git",
  "wlroots_git",
  "sway-unwrapped_git",
  "xdg-desktop-portal-wlr_git"
]`.