### PR TITLE
chore: bump nix_git

### DIFF
--- a/pkgs/nix-git/version.json
+++ b/pkgs/nix-git/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260524230200-62adee8",
-  "rev": "62adee899a656516fc43c97782f102011e24e4ed",
-  "hash": "sha256-KzjPLCF0U83JgdyVSZ5Tp6Mu5XZycTdky6Mh+FBYecY=",
-  "lastModifiedDate": "20260524230200"
+  "version": "unstable-20260531205848-b4f9970",
+  "rev": "b4f997014c512b1513b0b61418e693d1c6bba7c1",
+  "hash": "sha256-5lhByGNj1cXg9sKllVyJs0F1pMMiujTa2ErK1El2S+8=",
+  "lastModifiedDate": "20260531205848"
 }


### PR DESCRIPTION
Automated package bump for `[
  "nix_git"
]`.