### PR TITLE
chore: bump qtile-module_git

### DIFF
--- a/pkgs/qtile-git/version.json
+++ b/pkgs/qtile-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260524024047-6174c8a",
-  "rev": "6174c8a492ec13867a5182dfa93efe992afecb71",
-  "hash": "sha256-T/JJmdeS3jxaP6E0zf25M/q6E+3hf85Ia8M4SnN0UZQ="
+  "version": "unstable-20260531114740-39df62d",
+  "rev": "39df62daae7ee9c0efcc91c3d4663ac39879ccd5",
+  "hash": "sha256-7u/zXUg8m5esCpoG/OU6T9sDVhvHYnrY+Vvq31ogrn8="
 }


### PR DESCRIPTION
Automated package bump for `[
  "qtile-module_git",
  "qtile-extras_git"
]`.