### PR TITLE
chore: bump niri_git

### DIFF
--- a/pkgs/niri-git/version.json
+++ b/pkgs/niri-git/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260521144743-4294948",
-  "rev": "4294948cf1c70c50e938383c2c865d7ca455ac7e",
-  "hash": "sha256-qKWgJ2MUODpg+b8tOwWMdMKREvs8TdGBz63SHaQZCeA=",
+  "version": "unstable-20260529120150-f9f43d8",
+  "rev": "f9f43d826ab4014a7c302be28d7da33e12f5be37",
+  "hash": "sha256-t7lKVshV/srD0G06j4r5P5qj9zaDeZ9JYFCxHDGROZU=",
   "cargoHash": "sha256-gfnalA3qI3a9h3PvsxgQLCrzapfjLLkxhTMJpwRh+ro="
 }


### PR DESCRIPTION
Automated package bump for `[
  "niri_git"
]`.