### PR TITLE
chore: bump shadps4_git

### DIFF
--- a/pkgs/shadps4-git/version.json
+++ b/pkgs/shadps4-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260525162142-0f094cb",
-  "rev": "0f094cb6c8ccb960af14c44e9a1fd5d4956a7f7f",
-  "hash": "sha256-HxOgrkxSK4lp3EkVHBBbX77CrwWly4a+1iWZPctMWS0="
+  "version": "unstable-20260601161407-6d2e6a4",
+  "rev": "6d2e6a439a5228975682f93d84e5dbd3f1581c77",
+  "hash": "sha256-bHi8GdlBJj4eQhGvO3nvzHSnKsHbZdFBLweVMrpf09o="
 }


### PR DESCRIPTION
Automated package bump for `[
  "shadps4_git"
]`.