### PR TITLE
chore: bump zed-editor_git

### DIFF
--- a/pkgs/zed-editor-git/version.json
+++ b/pkgs/zed-editor-git/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260525170158-a6780a5",
-  "rev": "a6780a5a4769463ba787b48abe36effefd07f0b7",
-  "hash": "sha256-WjYRm0fhHmOMoPGIrakPqjP5grq6fTI48a4P4TGbHUQ=",
-  "cargoHash": "sha256-94fJgFv6hYjYq56torilpqzBJZMipJWWJsOQgd3Whpg="
+  "version": "unstable-20260601162639-a921edb",
+  "rev": "a921edb5300581a62376cf32a95fd99362e86ddc",
+  "hash": "sha256-lFkiN95yFEMBcqw2u8ChhVh2HkfovCtaIA8kgXk+EQo=",
+  "cargoHash": "sha256-YmAioCFqrdr+vG+g7G4Hi5K8dMcUS4guMH6KgGgcBCo="
 }


### PR DESCRIPTION
Automated package bump for `[
  "zed-editor_git"
]`.