### PR TITLE
chore: bump libdrm_git

### DIFF
--- a/pkgs/mesa-git/version.json
+++ b/pkgs/mesa-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260528121459-a5d34f8",
-  "rev": "a5d34f85f83da516af5c72fcbfadc6bf98b43754",
-  "hash": "sha256-8CIy+l9ecb0615oAltYwh57O/UjMzNLy2NdZjWCFqFo="
+  "version": "unstable-20260529033855-26280cb",
+  "rev": "26280cbc2344a3ce550175ea198d136eba454a51",
+  "hash": "sha256-hRdxNF1pEOcd23l32x5QurLu8hPzXSYua+GLCRjT8D0="
 }


### PR DESCRIPTION
Automated package bump for `[
  "libdrm_git",
  "wayland-protocols_git",
  "mesa_git",
  "wayland_git",
  "wlroots_git",
  "sway-unwrapped_git",
  "xdg-desktop-portal-wlr_git"
]`.