### PR TITLE
chore: bump tde2e_git

### DIFF
--- a/pkgs/telegram-desktop-git/version.json
+++ b/pkgs/telegram-desktop-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260525150656-292d073",
-  "rev": "292d07308f605f115f0d0802bfbc24f469134c31",
-  "hash": "sha256-0joKjM1y2hcaP6hA6XxQQx5TaIEc7r+4oi9KFx+dh78="
+  "version": "unstable-20260528055442-9caf32d",
+  "rev": "9caf32dffc90ddd9bb08ad5777b865f729fa167b",
+  "hash": "sha256-Ef1FITuMkEp1osGZqD3ZYiY7BZxDsG7880NyFdSYB2w="
 }


### PR DESCRIPTION
Automated package bump for `[
  "tde2e_git",
  "tg-owt_git",
  "telegram-desktop-unwrapped_git",
  "telegram-desktop_git"
]`.