### PR TITLE
chore: bump proton-cachyos_x86_64_v3

### DIFF
--- a/pkgs/proton-bin/cachyos-v3-version.json
+++ b/pkgs/proton-bin/cachyos-v3-version.json
@@ -1,5 +1,5 @@
 {
   "base": "11.0",
-  "release": "20260520",
-  "hash": "sha256-YSDaUcoYYfT/UMkxpULfq7fVvELAhi8b/wIrpSv4yJQ="
+  "release": "20260521",
+  "hash": "sha256-hWkZ+22va9Icx8DEj80k3lZId/jv/ETxXmB8UdwIz6U="
 }


### PR DESCRIPTION
Automated package bump for `[
  "proton-cachyos_x86_64_v3"
]`.