### PR TITLE
chore: bump libdrm_git

### DIFF
--- a/pkgs/libdrm-git/version.json
+++ b/pkgs/libdrm-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260427162320-b8b7c57",
-  "rev": "b8b7c57c00954b22ac182543602bd8f654ea1c30",
-  "hash": "sha256-BrUIoA3mwykCB0O4kaMHNcqw+RV0zsacEt8RcTCpx6Y="
+  "version": "unstable-20260529084942-e984d44",
+  "rev": "e984d448b8b17aab853369e6c203e53719f46de1",
+  "hash": "sha256-btHG+p8FJObTl/k04bDaRb7hclVtyijjLHqrFJ9aIM8="
 }

--- a/pkgs/mesa-git/version.json
+++ b/pkgs/mesa-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260529033855-26280cb",
-  "rev": "26280cbc2344a3ce550175ea198d136eba454a51",
-  "hash": "sha256-hRdxNF1pEOcd23l32x5QurLu8hPzXSYua+GLCRjT8D0="
+  "version": "unstable-20260601160241-74d38a6",
+  "rev": "74d38a6271194fe5c9cf0203d2374285c15e6d43",
+  "hash": "sha256-WXeCSsUyLIrHEWp0ndA2SPC49ezenxlY36OQVn/CVGc="
 }

--- a/pkgs/sway-unwrapped-git/version.json
+++ b/pkgs/sway-unwrapped-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260525113644-f1b40bc",
-  "rev": "f1b40bc288f3be3bcc6a3c71f28ca9bb2529e70b",
-  "hash": "sha256-fWAZ+aW05zo663wj6yJiVf3cFRL0brsLSNxrEDRgO6w="
+  "version": "unstable-20260531081531-3302f1c",
+  "rev": "3302f1ce5c1a84229673c96451576ab25674f125",
+  "hash": "sha256-IVA6PUdHk8cQiXIabfnvh2Y2lu4pjbSTcPtsdbNrrWU="
 }

--- a/pkgs/wayland-protocols-git/version.json
+++ b/pkgs/wayland-protocols-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260508074658-c364bf6",
-  "rev": "c364bf61ec0c8fed865aa6fcfd79c2078fb6d356",
-  "hash": "sha256-QCVystAelLH1XiggB83cpzDqQ7kldIl3bDupoVcqYf8="
+  "version": "unstable-20260530080848-3de6742",
+  "rev": "3de6742006076df4be038cbd325d011c93a1db90",
+  "hash": "sha256-B6DKqyVFGIkKkK23uQr12whN2d73El94CUMZbMroDDM="
 }

--- a/pkgs/wlroots-git/version.json
+++ b/pkgs/wlroots-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260528091336-15a3783",
-  "rev": "15a378316e469470ae1cee45fe4cab2382b89658",
-  "hash": "sha256-xyKnNts5o2YvSF43lSlUxCmsPLh+asOQN7sjOHFvAKQ="
+  "version": "unstable-20260531080346-bd99e8c",
+  "rev": "bd99e8c2bd077251e8fe1f21ed5ed2ddb92c9cf0",
+  "hash": "sha256-L9fOmooRGUfX6ir3NE+rjL116b8/pX/NFasMefB424I="
 }


### PR DESCRIPTION
Automated package bump for `[
  "libdrm_git",
  "wayland-protocols_git",
  "mesa_git",
  "wayland_git",
  "wlroots_git",
  "sway-unwrapped_git",
  "xdg-desktop-portal-wlr_git"
]`.