### PR TITLE
chore: bump proton-cachyos

### DIFF
--- a/pkgs/proton-bin/cachyos-version.json
+++ b/pkgs/proton-bin/cachyos-version.json
@@ -1,5 +1,5 @@
 {
   "base": "11.0",
-  "release": "20260520",
-  "hash": "sha256-2einKIRxRfLegNaH7+kBlrpfkoOCQ6FzBdfczJ0uf5c="
+  "release": "20260521",
+  "hash": "sha256-svDsjpMbAsvLV1xvTPHzeTKmSKOt0nHdfdEvE5X1tyw="
 }


### PR DESCRIPTION
Automated package bump for `[
  "proton-cachyos"
]`.