### PR TITLE
chore: bump openrgb_git

### DIFF
--- a/pkgs/openrgb-git/version.json
+++ b/pkgs/openrgb-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260525170843-967153b",
-  "rev": "967153bc10aa37baad49db8d7654b983d29ebcf1",
-  "hash": "sha256-/+z5xQr5zX1lVjNYNeJa0FUnCAk3CDooODVwa2XULjc="
+  "version": "unstable-20260601132717-decf146",
+  "rev": "decf14635d2570bc7c8fc7e589a732758c7d0e13",
+  "hash": "sha256-fL631waIWLgV2WDvt7lzb8dDF4Nqzkae1ayhwtlBksg="
 }


### PR DESCRIPTION
Automated package bump for `[
  "openrgb_git"
]`.