### PR TITLE
chore: bump libportal_git

### DIFF
--- a/pkgs/libportal-git/version.json
+++ b/pkgs/libportal-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260504114557-567019d",
-  "rev": "567019d813dccfbb42fbfd3aaf7d6c7a4bad7c48",
-  "hash": "sha256-24A/8GYqqcrbGkijC2rrFmSG/MrCoUWYjfCS4eHCh8Q="
+  "version": "unstable-20260531204808-4f2337f",
+  "rev": "4f2337f166027bf7e1eed19a62e311c95113d376",
+  "hash": "sha256-dOsBTjWnaiGDSqAo4F2PZ6OsneWQaGnKdYnnWwM3t0I="
 }


### PR DESCRIPTION
Automated package bump for `[
  "libportal_git"
]`.