### PR TITLE
chore: bump pcsx2_git

### DIFF
--- a/pkgs/pcsx2-git/version.json
+++ b/pkgs/pcsx2-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260527215223-db16fa4",
-  "rev": "db16fa4403ca8357a2cc9054593ae9761b007905",
-  "hash": "sha256-BoYTvpKGgEC6PTZbIXar0llNjFbA8j/tnCZHnimJelM="
+  "version": "unstable-20260601135112-e1291d5",
+  "rev": "e1291d5b7c5bf913caf1cb988541d99113fb23fa",
+  "hash": "sha256-hHZfJBVd9HHQ0OqnhJZe5T5uKTCrs+UFEcO06cfpXSs="
 }


### PR DESCRIPTION
Automated package bump for `[
  "pcsx2_git"
]`.