### PR TITLE
chore: bump shadps4_git

### DIFF
--- a/pkgs/shadps4-git/version.json
+++ b/pkgs/shadps4-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260525162142-0f094cb",
-  "rev": "0f094cb6c8ccb960af14c44e9a1fd5d4956a7f7f",
-  "hash": "sha256-HxOgrkxSK4lp3EkVHBBbX77CrwWly4a+1iWZPctMWS0="
+  "version": "unstable-20260601170609-9a6d2d1",
+  "rev": "9a6d2d155360a95c0c38b2529717fca004c1b574",
+  "hash": "sha256-nrZZE7a7ezS3WGCQdh9e+GngY66QEu9vhEzZ32TLO70="
 }


### PR DESCRIPTION
Automated package bump for `[
  "shadps4_git"
]`.