### PR TITLE
chore: bump tde2e_git

### DIFF
--- a/pkgs/telegram-desktop-git/version.json
+++ b/pkgs/telegram-desktop-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260525150656-292d073",
-  "rev": "292d07308f605f115f0d0802bfbc24f469134c31",
-  "hash": "sha256-0joKjM1y2hcaP6hA6XxQQx5TaIEc7r+4oi9KFx+dh78="
+  "version": "unstable-20260601172415-134b1be",
+  "rev": "134b1be4066c986112be0aa08d06394673ec42a2",
+  "hash": "sha256-ks1BbBHxN2aMN24PF/n7e1Rebp3q+mgsLhHch4+YR6E="
 }


### PR DESCRIPTION
Automated package bump for `[
  "tde2e_git",
  "tg-owt_git",
  "telegram-desktop-unwrapped_git",
  "telegram-desktop_git"
]`.