### PR TITLE
chore: bump nix_git

### DIFF
--- a/pkgs/nix-git/version.json
+++ b/pkgs/nix-git/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260531205848-b4f9970",
-  "rev": "b4f997014c512b1513b0b61418e693d1c6bba7c1",
-  "hash": "sha256-5lhByGNj1cXg9sKllVyJs0F1pMMiujTa2ErK1El2S+8=",
-  "lastModifiedDate": "20260531205848"
+  "version": "unstable-20260602004805-cbbc07c",
+  "rev": "cbbc07c6b04f5ecfae73f1504aaa7a4bdddbd84c",
+  "hash": "sha256-oVu3KjTWQ21ISNQ2rjpUiJoGZhd1Ex7yArSXQ5G5u9c=",
+  "lastModifiedDate": "20260602004805"
 }


### PR DESCRIPTION
Automated package bump for `[
  "nix_git"
]`.