### PR TITLE
chore: bump pcsx2_git

### DIFF
--- a/pkgs/pcsx2-git/version.json
+++ b/pkgs/pcsx2-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260601135112-e1291d5",
-  "rev": "e1291d5b7c5bf913caf1cb988541d99113fb23fa",
-  "hash": "sha256-hHZfJBVd9HHQ0OqnhJZe5T5uKTCrs+UFEcO06cfpXSs="
+  "version": "unstable-20260601215519-b383442",
+  "rev": "b3834427bcac0196a348741ea3bbd2fae11eacbb",
+  "hash": "sha256-uZ1R+RYFleskHYg8fP2KjlDAwbxPjyZRHWtHo44/b3w="
 }


### PR DESCRIPTION
Automated package bump for `[
  "pcsx2_git"
]`.