### PR TITLE
chore: bump openrgb_git

### DIFF
--- a/pkgs/openrgb-git/version.json
+++ b/pkgs/openrgb-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260601132717-decf146",
-  "rev": "decf14635d2570bc7c8fc7e589a732758c7d0e13",
-  "hash": "sha256-fL631waIWLgV2WDvt7lzb8dDF4Nqzkae1ayhwtlBksg="
+  "version": "unstable-20260602051519-bbf348d",
+  "rev": "bbf348d2732319f78d2196068db74aae29345e51",
+  "hash": "sha256-bAa7u4YVgzGImVB+ryeUUlv5CxVFCNmytc58oBy6M00="
 }


### PR DESCRIPTION
Automated package bump for `[
  "openrgb_git"
]`.