### PR TITLE
chore: bump shadps4_git

### DIFF
--- a/pkgs/shadps4-git/version.json
+++ b/pkgs/shadps4-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260601170609-9a6d2d1",
-  "rev": "9a6d2d155360a95c0c38b2529717fca004c1b574",
-  "hash": "sha256-nrZZE7a7ezS3WGCQdh9e+GngY66QEu9vhEzZ32TLO70="
+  "version": "unstable-20260602050318-0b9eb3d",
+  "rev": "0b9eb3dd17bbd5566b46e3daff7de5e3024c5cd2",
+  "hash": "sha256-vLDFXPBsqwb7Xqz1f4Fu3Rqzm4FexoDCy8+Ws9Q+wVM="
 }


### PR DESCRIPTION
Automated package bump for `[
  "shadps4_git"
]`.