### PR TITLE
chore: bump tde2e_git

### DIFF
--- a/pkgs/telegram-desktop-git/version.json
+++ b/pkgs/telegram-desktop-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260601172415-134b1be",
-  "rev": "134b1be4066c986112be0aa08d06394673ec42a2",
-  "hash": "sha256-ks1BbBHxN2aMN24PF/n7e1Rebp3q+mgsLhHch4+YR6E="
+  "version": "unstable-20260601201134-e7f34eb",
+  "rev": "e7f34ebbae977c0182cc59634d3662d1463f235c",
+  "hash": "sha256-FcAO6vPx0s28gxum8V9RD05qtvtjjGEBxpSLwRVO7gU="
 }


### PR DESCRIPTION
Automated package bump for `[
  "tde2e_git",
  "tg-owt_git",
  "telegram-desktop-unwrapped_git",
  "telegram-desktop_git"
]`.