### PR TITLE
chore: bump zed-editor_git

### DIFF
--- a/pkgs/zed-editor-git/version.json
+++ b/pkgs/zed-editor-git/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260525170158-a6780a5",
-  "rev": "a6780a5a4769463ba787b48abe36effefd07f0b7",
-  "hash": "sha256-WjYRm0fhHmOMoPGIrakPqjP5grq6fTI48a4P4TGbHUQ=",
-  "cargoHash": "sha256-94fJgFv6hYjYq56torilpqzBJZMipJWWJsOQgd3Whpg="
+  "version": "unstable-20260602053536-c57de85",
+  "rev": "c57de855283fe058dc6cd8423749ec7ff6a0475d",
+  "hash": "sha256-0lRnWbgkDgA1vU5CpKCjDJQem4TkEMMKHT9D93teh2o=",
+  "cargoHash": "sha256-nUwKYRX114QAKnXDmjA63loa5BFPfMfak4gq07rQM/0="
 }


### PR DESCRIPTION
Automated package bump for `[
  "zed-editor_git"
]`.