### PR TITLE
chore: bump nix_git

### DIFF
--- a/pkgs/nix-git/version.json
+++ b/pkgs/nix-git/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260602004805-cbbc07c",
-  "rev": "cbbc07c6b04f5ecfae73f1504aaa7a4bdddbd84c",
-  "hash": "sha256-oVu3KjTWQ21ISNQ2rjpUiJoGZhd1Ex7yArSXQ5G5u9c=",
-  "lastModifiedDate": "20260602004805"
+  "version": "unstable-20260603000746-3530056",
+  "rev": "35300564b15e3fb079f45a2c40bc4d364ba1b9c4",
+  "hash": "sha256-b0/1Hq8r5UuGKaorQteG1gFU7mx1FGyk5o2FXtCmyes=",
+  "lastModifiedDate": "20260603000746"
 }


### PR DESCRIPTION
Automated package bump for `[
  "nix_git"
]`.