### PR TITLE
chore: bump pcsx2_git

### DIFF
--- a/pkgs/pcsx2-git/version.json
+++ b/pkgs/pcsx2-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260601215519-b383442",
-  "rev": "b3834427bcac0196a348741ea3bbd2fae11eacbb",
-  "hash": "sha256-uZ1R+RYFleskHYg8fP2KjlDAwbxPjyZRHWtHo44/b3w="
+  "version": "unstable-20260603033857-57e46f0",
+  "rev": "57e46f07fedfad7a2f9c8fc5811398035d88e9fa",
+  "hash": "sha256-P9DECQelm50Gu8ycbQGO0TFAMTwEBXoQhnTa4okz/H0="
 }


### PR DESCRIPTION
Automated package bump for `[
  "pcsx2_git"
]`.