### PR TITLE
chore: bump openrgb_git

### DIFF
--- a/pkgs/openrgb-git/version.json
+++ b/pkgs/openrgb-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260602051519-bbf348d",
-  "rev": "bbf348d2732319f78d2196068db74aae29345e51",
-  "hash": "sha256-bAa7u4YVgzGImVB+ryeUUlv5CxVFCNmytc58oBy6M00="
+  "version": "unstable-20260603030717-3dc1365",
+  "rev": "3dc1365d398f9750bd7ade9b45a553ae2c04aea0",
+  "hash": "sha256-7VYsh4tK7Nd/bjtBhOlaG3n3ip1VlIUHEKxX/U+RRJM="
 }


### PR DESCRIPTION
Automated package bump for `[
  "openrgb_git"
]`.