### PR TITLE
chore: bump nix_git

### DIFF
--- a/pkgs/nix-git/version.json
+++ b/pkgs/nix-git/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260603000746-3530056",
-  "rev": "35300564b15e3fb079f45a2c40bc4d364ba1b9c4",
-  "hash": "sha256-b0/1Hq8r5UuGKaorQteG1gFU7mx1FGyk5o2FXtCmyes=",
-  "lastModifiedDate": "20260603000746"
+  "version": "unstable-20260603210704-1506565",
+  "rev": "1506565ef191621de91d71aaead8a5b66a26c0d4",
+  "hash": "sha256-k2pEE0So3KvDg/huoc4TYCbFv1nOSCXuU0ipXmYINVs=",
+  "lastModifiedDate": "20260603210704"
 }


### PR DESCRIPTION
Automated package bump for `[
  "nix_git"
]`.