### PR TITLE
chore: bump pcsx2_git

### DIFF
--- a/pkgs/pcsx2-git/version.json
+++ b/pkgs/pcsx2-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260603033857-57e46f0",
-  "rev": "57e46f07fedfad7a2f9c8fc5811398035d88e9fa",
-  "hash": "sha256-P9DECQelm50Gu8ycbQGO0TFAMTwEBXoQhnTa4okz/H0="
+  "version": "unstable-20260604005646-426d77a",
+  "rev": "426d77a932183f04b2f48926d8d7b959ebe0e057",
+  "hash": "sha256-Fzp0RJGERxSdGIMZi8s5aiJZYyDdP5FPwOIDtKSeyRw="
 }


### PR DESCRIPTION
Automated package bump for `[
  "pcsx2_git"
]`.