### PR TITLE
chore: bump libdrm_git

### DIFF
--- a/pkgs/mesa-git/version.json
+++ b/pkgs/mesa-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260603011223-f1c30d6",
-  "rev": "f1c30d65e155effa4a746b89e038fc246ae3a23e",
-  "hash": "sha256-dX0lRpMF5JvgQgTW3818ZPFMp0YTdtpWEh1knv/Kw54="
+  "version": "unstable-20260604053022-fdb9ce6",
+  "rev": "fdb9ce608758bd63ff9cde151b31612f38cb3c84",
+  "hash": "sha256-etHrv/cT44kV6vMW3rqSruHBXtn4EaEL0VUxhrbtPDE="
 }


### PR DESCRIPTION
Automated package bump for `[
  "libdrm_git",
  "wayland-protocols_git",
  "mesa_git",
  "wayland_git",
  "wlroots_git",
  "sway-unwrapped_git",
  "xdg-desktop-portal-wlr_git"
]`.