### PR TITLE
chore: bump nix_git

### DIFF
--- a/pkgs/nix-git/version.json
+++ b/pkgs/nix-git/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260603210704-1506565",
-  "rev": "1506565ef191621de91d71aaead8a5b66a26c0d4",
-  "hash": "sha256-k2pEE0So3KvDg/huoc4TYCbFv1nOSCXuU0ipXmYINVs=",
-  "lastModifiedDate": "20260603210704"
+  "version": "unstable-20260604211127-3f091c2",
+  "rev": "3f091c26826c53d105b6d03c9945b7b5a790bbde",
+  "hash": "sha256-cqhG5sTq9Kx3kj0Bh8SIptKX9ouSYEny9cVSqnCCxA8=",
+  "lastModifiedDate": "20260604211127"
 }


### PR DESCRIPTION
Automated package bump for `[
  "nix_git"
]`.