### PR TITLE
chore: bump qtile-module_git

### DIFF
--- a/pkgs/qtile-git/version.json
+++ b/pkgs/qtile-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260531114740-39df62d",
-  "rev": "39df62daae7ee9c0efcc91c3d4663ac39879ccd5",
-  "hash": "sha256-7u/zXUg8m5esCpoG/OU6T9sDVhvHYnrY+Vvq31ogrn8="
+  "version": "unstable-20260604103619-db9b1cf",
+  "rev": "db9b1cfda6f3470abdab2d83457c5fbccec677c9",
+  "hash": "sha256-V+3sTarl/OHJMEb2zAMpLlLrp2KGHww7ovUd5dw/LCE="
 }


### PR DESCRIPTION
Automated package bump for `[
  "qtile-module_git",
  "qtile-extras_git"
]`.