### PR TITLE
chore: bump openrgb_git

### DIFF
--- a/pkgs/openrgb-git/version.json
+++ b/pkgs/openrgb-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260603030717-3dc1365",
-  "rev": "3dc1365d398f9750bd7ade9b45a553ae2c04aea0",
-  "hash": "sha256-7VYsh4tK7Nd/bjtBhOlaG3n3ip1VlIUHEKxX/U+RRJM="
+  "version": "unstable-20260604165451-30690d0",
+  "rev": "30690d0ebdb97c122d0c98eee0bcf388d076b199",
+  "hash": "sha256-kdcfkWbCxDh0IvacKrrpIPuRotDU6wgP0ZBn7gPP1T4="
 }


### PR DESCRIPTION
Automated package bump for `[
  "openrgb_git"
]`.