### PR TITLE
chore: bump libdrm_git

### DIFF
--- a/pkgs/mesa-git/version.json
+++ b/pkgs/mesa-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260604053022-fdb9ce6",
-  "rev": "fdb9ce608758bd63ff9cde151b31612f38cb3c84",
-  "hash": "sha256-etHrv/cT44kV6vMW3rqSruHBXtn4EaEL0VUxhrbtPDE="
+  "version": "unstable-20260604213902-a6172f1",
+  "rev": "a6172f19a0915fc690104a02e894b263d982e247",
+  "hash": "sha256-vzsdiy+Ed6YUIIqm0ZBNnkp8GC274mK7h4Xe3Y7go48="
 }


### PR DESCRIPTION
Automated package bump for `[
  "libdrm_git",
  "wayland-protocols_git",
  "mesa_git",
  "wayland_git",
  "wlroots_git",
  "sway-unwrapped_git",
  "xdg-desktop-portal-wlr_git"
]`.