### PR TITLE
chore: bump nss_git

### DIFF
--- a/pkgs/firefox-nightly/version.json
+++ b/pkgs/firefox-nightly/version.json
@@ -1,5 +1,5 @@
 {
   "version": "153.0a1",
-  "rev": "64cf8ee55e0dd5979a94437af209ba36a3335840",
-  "hash": "sha256-+x7UexpP7WBMnAcYW3oKKh/e9MppHA3YUqD60noPRXs="
+  "rev": "7d5a1bf5ff11123dc578ae1d0a9c2b3ae0d0509b",
+  "hash": "sha256-jeqbowR7E/RNdv+4qJ5NjeOtd1/2Nhpf5YB26T65SL8="
 }

--- a/pkgs/nss-git/version.json
+++ b/pkgs/nss-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260604022701-4806888",
-  "rev": "48068880fa96f750429c4ec5933019a1f435124d",
-  "hash": "sha256-uzUMl9Y/gyvShLGJkGjpG+3Yrd2zFkddBFQzuWX5Ro4="
+  "version": "unstable-20260609225411-3c772c5",
+  "rev": "3c772c53f6e75a732759b93989403789bda99b9f",
+  "hash": "sha256-hDU7Ia/5rgWOR8K1edMYGBOpDm0Kq6PFAkDIeCqumXg="
 }


### PR DESCRIPTION
Automated package bump for `[
  "nss_git",
  "firefox-unwrapped_nightly"
]`.