### PR TITLE
chore: bump openrgb_git

### DIFF
--- a/pkgs/openrgb-git/version.json
+++ b/pkgs/openrgb-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260604165451-30690d0",
-  "rev": "30690d0ebdb97c122d0c98eee0bcf388d076b199",
-  "hash": "sha256-kdcfkWbCxDh0IvacKrrpIPuRotDU6wgP0ZBn7gPP1T4="
+  "version": "unstable-20260605060329-f6a678c",
+  "rev": "f6a678c1a4f5825a86461ec4ddae61b3b0361d23",
+  "hash": "sha256-DBanYptZvbO3U+I3QOh+Yef6IRE17PtaZZ4SrCl99Ic="
 }


### PR DESCRIPTION
Automated package bump for `[
  "openrgb_git"
]`.