### PR TITLE
chore: bump qtile-module_git

### DIFF
--- a/pkgs/qtile-git/version.json
+++ b/pkgs/qtile-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260604103619-db9b1cf",
-  "rev": "db9b1cfda6f3470abdab2d83457c5fbccec677c9",
-  "hash": "sha256-V+3sTarl/OHJMEb2zAMpLlLrp2KGHww7ovUd5dw/LCE="
+  "version": "unstable-20260605235129-1ec7a15",
+  "rev": "1ec7a152db6ca0c5eae4378924f728389f5c152e",
+  "hash": "sha256-+iO0/6heEujKyAlf+9CT1glu2QSecumbUk4iDpiLnQY="
 }


### PR DESCRIPTION
Automated package bump for `[
  "qtile-module_git",
  "qtile-extras_git"
]`.