### PR TITLE
chore: bump niri_git

### DIFF
--- a/pkgs/niri-git/version.json
+++ b/pkgs/niri-git/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260529120150-f9f43d8",
-  "rev": "f9f43d826ab4014a7c302be28d7da33e12f5be37",
-  "hash": "sha256-t7lKVshV/srD0G06j4r5P5qj9zaDeZ9JYFCxHDGROZU=",
+  "version": "unstable-20260605052852-f717ae0",
+  "rev": "f717ae030fe56fc52522ebef69f17f3f09064ac4",
+  "hash": "sha256-FeKyLRxLZu2EUnhifijZPDZRl0sVnPVHMtizAINNiN4=",
   "cargoHash": "sha256-gfnalA3qI3a9h3PvsxgQLCrzapfjLLkxhTMJpwRh+ro="
 }


### PR DESCRIPTION
Automated package bump for `[
  "niri_git"
]`.