### PR TITLE
chore: bump nix_git

### DIFF
--- a/pkgs/nix-git/version.json
+++ b/pkgs/nix-git/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260604211127-3f091c2",
-  "rev": "3f091c26826c53d105b6d03c9945b7b5a790bbde",
-  "hash": "sha256-cqhG5sTq9Kx3kj0Bh8SIptKX9ouSYEny9cVSqnCCxA8=",
-  "lastModifiedDate": "20260604211127"
+  "version": "unstable-20260605093841-d1f04a7",
+  "rev": "d1f04a798cf4276da59567c07a3bf4a628669288",
+  "hash": "sha256-o/6YXRB6AbeL4SYtSHlJ9oEROl6Wmf7yheJNa3fAv2I=",
+  "lastModifiedDate": "20260605093841"
 }


### PR DESCRIPTION
Automated package bump for `[
  "nix_git"
]`.