### PR TITLE
chore: bump libdrm_git

### DIFF
--- a/pkgs/mesa-git/version.json
+++ b/pkgs/mesa-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260604213902-a6172f1",
-  "rev": "a6172f19a0915fc690104a02e894b263d982e247",
-  "hash": "sha256-vzsdiy+Ed6YUIIqm0ZBNnkp8GC274mK7h4Xe3Y7go48="
+  "version": "unstable-20260605234311-31db17f",
+  "rev": "31db17f653cbba464e432b3c4e2a144e2785425d",
+  "hash": "sha256-5URtmdollIjhJpPjsJI+3Yv5JycRs233S5XorVPpgKY="
 }


### PR DESCRIPTION
Automated package bump for `[
  "libdrm_git",
  "wayland-protocols_git",
  "mesa_git",
  "wayland_git",
  "wlroots_git",
  "sway-unwrapped_git",
  "xdg-desktop-portal-wlr_git"
]`.