### PR TITLE
chore: bump pcsx2_git

### DIFF
--- a/pkgs/pcsx2-git/version.json
+++ b/pkgs/pcsx2-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260604005646-426d77a",
-  "rev": "426d77a932183f04b2f48926d8d7b959ebe0e057",
-  "hash": "sha256-Fzp0RJGERxSdGIMZi8s5aiJZYyDdP5FPwOIDtKSeyRw="
+  "version": "unstable-20260606135921-3df128d",
+  "rev": "3df128d9f9cd89cfc47d08d94b3439136ba22b33",
+  "hash": "sha256-E7M2UEY7OwhFX9Sq1xfgbY+yXwrn9J8w8i5qwEAB01A="
 }


### PR DESCRIPTION
Automated package bump for `[
  "pcsx2_git"
]`.