### PR TITLE
chore: bump mangohud_git

### DIFF
--- a/pkgs/mangohud-git/version.json
+++ b/pkgs/mangohud-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260605231622-92ed51f",
-  "rev": "92ed51ff2f1b824d65823a811eed2620dc78f956",
-  "hash": "sha256-wS58acuf+UHGop/KdM77yhCL81kvQAQydPD4zXAPRxQ="
+  "version": "unstable-20260606233039-2c1dc52",
+  "rev": "2c1dc5283c045e9a7e424dc913fbafcdcc7e3be1",
+  "hash": "sha256-d/zaM0gRoYf+mxxSuouP+99tiPVIq7mAEqgEk0s+IBs="
 }


### PR DESCRIPTION
Automated package bump for `[
  "mangohud_git"
]`.