### PR TITLE
chore: bump libdrm_git

### DIFF
--- a/pkgs/mesa-git/version.json
+++ b/pkgs/mesa-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260605234311-31db17f",
-  "rev": "31db17f653cbba464e432b3c4e2a144e2785425d",
-  "hash": "sha256-5URtmdollIjhJpPjsJI+3Yv5JycRs233S5XorVPpgKY="
+  "version": "unstable-20260606222056-b9c7634",
+  "rev": "b9c763454e6642dc90e47506d5b56f00c4b9b773",
+  "hash": "sha256-x6jbCpnQtVEN5Oyt27i0rRn1AOvr+D3G4+537jjsFtM="
 }


### PR DESCRIPTION
Automated package bump for `[
  "libdrm_git",
  "wayland-protocols_git",
  "mesa_git",
  "wayland_git",
  "wlroots_git",
  "sway-unwrapped_git",
  "xdg-desktop-portal-wlr_git"
]`.