### PR TITLE
chore: bump openrgb_git

### DIFF
--- a/pkgs/openrgb-git/version.json
+++ b/pkgs/openrgb-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260605060329-f6a678c",
-  "rev": "f6a678c1a4f5825a86461ec4ddae61b3b0361d23",
-  "hash": "sha256-DBanYptZvbO3U+I3QOh+Yef6IRE17PtaZZ4SrCl99Ic="
+  "version": "unstable-20260607190834-f15c3c1",
+  "rev": "f15c3c1420f37edaeaaecc520f917b518aa53435",
+  "hash": "sha256-n+jDMT1K3Qjw4o6WSpZbtBfKCQNCK2gd1tVuFnTvQk4="
 }


### PR DESCRIPTION
Automated package bump for `[
  "openrgb_git"
]`.