### PR TITLE
chore: bump nix_git

### DIFF
--- a/pkgs/nix-git/version.json
+++ b/pkgs/nix-git/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260605093841-d1f04a7",
-  "rev": "d1f04a798cf4276da59567c07a3bf4a628669288",
-  "hash": "sha256-o/6YXRB6AbeL4SYtSHlJ9oEROl6Wmf7yheJNa3fAv2I=",
-  "lastModifiedDate": "20260605093841"
+  "version": "unstable-20260607225744-bdef58e",
+  "rev": "bdef58e96d26ac3748e3fcb6bec348bea4dffd9e",
+  "hash": "sha256-yuuRLw3YcsEXNX6h7UJSpAsftjL/7wCNc57Y0rMn50k=",
+  "lastModifiedDate": "20260607225744"
 }


### PR DESCRIPTION
Automated package bump for `[
  "nix_git"
]`.