### PR TITLE
chore: bump pcsx2_git

### DIFF
--- a/pkgs/pcsx2-git/version.json
+++ b/pkgs/pcsx2-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260606135921-3df128d",
-  "rev": "3df128d9f9cd89cfc47d08d94b3439136ba22b33",
-  "hash": "sha256-E7M2UEY7OwhFX9Sq1xfgbY+yXwrn9J8w8i5qwEAB01A="
+  "version": "unstable-20260607192508-06c67b0",
+  "rev": "06c67b03194a2030616fd70728e0575feaa0af8a",
+  "hash": "sha256-E+2LJ4TUqNXsGMY+zRTJQc0V4TFqlqQbcOqU0Yr/8B8="
 }


### PR DESCRIPTION
Automated package bump for `[
  "pcsx2_git"
]`.