### PR TITLE
chore: bump libdrm_git

### DIFF
--- a/pkgs/mesa-git/version.json
+++ b/pkgs/mesa-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260606222056-b9c7634",
-  "rev": "b9c763454e6642dc90e47506d5b56f00c4b9b773",
-  "hash": "sha256-x6jbCpnQtVEN5Oyt27i0rRn1AOvr+D3G4+537jjsFtM="
+  "version": "unstable-20260609165348-f6dd632",
+  "rev": "f6dd632b313bad941118529ad68167f4c0572128",
+  "hash": "sha256-7OwjfcmrHkAIBc8eQHK51lHmG2Z/KbOJ2+Lz1jYcpZE="
 }

--- a/pkgs/wayland-git/version.json
+++ b/pkgs/wayland-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260428221954-c072ae6",
-  "rev": "c072ae6f5f5b01dc895edef677a0f546fb78cc3b",
-  "hash": "sha256-c0nADHSfCjcB1AOs2KvA3Ca4CGfpmEQvNNoNtN/TPHk="
+  "version": "unstable-20260608102928-165504a",
+  "rev": "165504a90edd7d6e51dd42d11f9dd0e8c9384609",
+  "hash": "sha256-ptyff8wTlBP5XaOG4+sBgOwq8IcFMbuwzzBzQxbb7FU="
 }

--- a/pkgs/wayland-protocols-git/version.json
+++ b/pkgs/wayland-protocols-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260530080848-3de6742",
-  "rev": "3de6742006076df4be038cbd325d011c93a1db90",
-  "hash": "sha256-B6DKqyVFGIkKkK23uQr12whN2d73El94CUMZbMroDDM="
+  "version": "unstable-20260607130632-ee78491",
+  "rev": "ee78491a237eaff9389a0ccf8680521d074407d3",
+  "hash": "sha256-kYCbEbh4C4FnqJzwrI+6soYTm5qffEor1Rn2B2f1IKA="
 }


### PR DESCRIPTION
Automated package bump for `[
  "libdrm_git",
  "wayland-protocols_git",
  "mesa_git",
  "wayland_git",
  "wlroots_git",
  "sway-unwrapped_git",
  "xdg-desktop-portal-wlr_git"
]`.