### PR TITLE
chore: bump helix_git

### DIFF
--- a/pkgs/helix-git/version.json
+++ b/pkgs/helix-git/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260605070244-7eb1a28",
-  "rev": "7eb1a2874af919caab8e69cf8bb6222d32fa6445",
-  "hash": "sha256-GJU6FNPEf5CkJxsHa+1FIjQ3lWBH77DmcrVDeDgsk9g=",
-  "cargoHash": "sha256-ial22HTPQQHB2xdDFx1q03gtl/Bxod4F8NqKuKWyHMw="
+  "version": "unstable-20260607182213-4c1f3ac",
+  "rev": "4c1f3ac87bc5fce29cb224ced6b1b2d438892517",
+  "hash": "sha256-yljxQwRydhMcJWX1FTcZlQ73DyV1zisR2p9GjOindUI=",
+  "cargoHash": "sha256-9cVz6sTy0N3k/YV50jt+Z6cvjLWIbseR7jcxzGRMicg="
 }


### PR DESCRIPTION
Automated package bump for `[
  "helix_git"
]`.