### PR TITLE
chore: bump mangohud_git

### DIFF
--- a/pkgs/mangohud-git/version.json
+++ b/pkgs/mangohud-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260607214243-7d56089",
-  "rev": "7d56089e23336999a6c5ac1356041839a495faf5",
-  "hash": "sha256-d3RnjOekTiYjNnmm5JF62DfqGfRq931ijvp6NYeohpQ="
+  "version": "unstable-20260608222440-ea2b0bc",
+  "rev": "ea2b0bc55e57dbd025b0aed9c410bb18644e0bb4",
+  "hash": "sha256-2Hu5F0oIEbK9mN1p9fXhy0W17KmDazN1KMp8RWcA2Eg="
 }


### PR DESCRIPTION
Automated package bump for `[
  "mangohud_git"
]`.