### PR TITLE
chore: bump lan-mouse_git

### DIFF
--- a/pkgs/lan-mouse-git/version.json
+++ b/pkgs/lan-mouse-git/version.json
@@ -1,7 +1,7 @@
 {
-  "version": "unstable-20260519092606-a9461ae",
-  "rev": "a9461ae830ea91c5d2bce0c78c405217fd8f91c5",
-  "hash": "sha256-ObXytXej27SZQ3iVOqcbA2MwlXZIUAP/DNNUAsIjuuw=",
+  "version": "unstable-20260608123824-1b53e58",
+  "rev": "1b53e58ba969c03e985ff2d7144eab1698bb9d47",
+  "hash": "sha256-I6ch1iqBxhpKwyLrDVGWkHRjsP4j5McfhrfSS+5erF8=",
   "cargoHash": "sha256-Oy81fQxAuM7BzH8FcHwsHNPxfAp0QMznHhde7aDsh0E=",
-  "lastModified": "1779182766"
+  "lastModified": "1780922304"
 }


### PR DESCRIPTION
Automated package bump for `[
  "lan-mouse_git"
]`.