### PR TITLE
chore: bump nix_git

### DIFF
--- a/pkgs/nix-git/version.json
+++ b/pkgs/nix-git/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260607225744-bdef58e",
-  "rev": "bdef58e96d26ac3748e3fcb6bec348bea4dffd9e",
-  "hash": "sha256-yuuRLw3YcsEXNX6h7UJSpAsftjL/7wCNc57Y0rMn50k=",
-  "lastModifiedDate": "20260607225744"
+  "version": "unstable-20260609140235-e471eb7",
+  "rev": "e471eb71fa5182bc7420dbcc3eaec75c7290e940",
+  "hash": "sha256-U0fW6rfz14Gt6X5Fpm06TnG7A8VV63ILmGCvAp9Mrgc=",
+  "lastModifiedDate": "20260609140235"
 }


### PR DESCRIPTION
Automated package bump for `[
  "nix_git"
]`.