### PR TITLE
chore: bump tde2e_git

### DIFF
--- a/pkgs/tdlib-git/version.json
+++ b/pkgs/tdlib-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260518151249-e0943d0",
-  "rev": "e0943d068ce90b5010f1aea946e6901e25b43bf6",
-  "hash": "sha256-H6R959XVkMB9OVAynRvBYB53hzUPKY0Us+HkbiuPZN0="
+  "version": "unstable-20260611210438-d6debbb",
+  "rev": "d6debbb2aae29a39e280f86e25ec0e54960dc838",
+  "hash": "sha256-CTU+aU1/6pDVxFAM2W4xKC/yKcoIZ1ugIA0ATQr5Ij0="
 }

--- a/pkgs/telegram-desktop-git/default.nix
+++ b/pkgs/telegram-desktop-git/default.nix
@@ -13,7 +13,7 @@ gitOverride {
       let
         realCall = callPackage file args;
       in
-      if builtins.baseNameOf file == "tg_owt.nix" then tg-owt_git else realCall;
+      if baseNameOf file == "tg_owt.nix" then tg-owt_git else realCall;
   };
 
   nyxKey = "telegram-desktop-unwrapped_git";
@@ -31,6 +31,9 @@ gitOverride {
   postOverride = prevAttrs: {
     patches = [ ];
     postPatch = "";
-    buildInputs = prevAttrs.buildInputs ++ [ final.tde2e_git ];
+    buildInputs = prevAttrs.buildInputs ++ [
+      final.tde2e_git
+      final.minizip
+    ];
   };
 }

--- a/pkgs/telegram-desktop-git/version.json
+++ b/pkgs/telegram-desktop-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260601201134-e7f34eb",
-  "rev": "e7f34ebbae977c0182cc59634d3662d1463f235c",
-  "hash": "sha256-FcAO6vPx0s28gxum8V9RD05qtvtjjGEBxpSLwRVO7gU="
+  "version": "unstable-20260611210425-8165c7c",
+  "rev": "8165c7c6c065c8abc94ec5076f75bee0a29b82e1",
+  "hash": "sha256-IzaBZIiFEkcUcOIiQzdVeuPANuFeHmjwVIGArtAyUDg="
 }


### PR DESCRIPTION
Automated package bump for `[
  "tde2e_git",
  "tg-owt_git",
  "telegram-desktop-unwrapped_git",
  "telegram-desktop_git"
]`.