### PR TITLE
chore: bump pcsx2_git

### DIFF
--- a/pkgs/pcsx2-git/version.json
+++ b/pkgs/pcsx2-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260607192508-06c67b0",
-  "rev": "06c67b03194a2030616fd70728e0575feaa0af8a",
-  "hash": "sha256-E+2LJ4TUqNXsGMY+zRTJQc0V4TFqlqQbcOqU0Yr/8B8="
+  "version": "unstable-20260609072207-904a094",
+  "rev": "904a0942f059544ff208d63b7d8d875e0ea4df5b",
+  "hash": "sha256-OKBXR9gtAqAD+4Bd2xWnhoQ7y+ONawLHW6Vomc8pkMs="
 }


### PR DESCRIPTION
Automated package bump for `[
  "pcsx2_git"
]`.