### PR TITLE
chore: bump niri_git

### DIFF
--- a/pkgs/niri-git/version.json
+++ b/pkgs/niri-git/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260605052852-f717ae0",
-  "rev": "f717ae030fe56fc52522ebef69f17f3f09064ac4",
-  "hash": "sha256-FeKyLRxLZu2EUnhifijZPDZRl0sVnPVHMtizAINNiN4=",
+  "version": "unstable-20260608170655-6f1a2c5",
+  "rev": "6f1a2c5f0e8274223d4204b1f8d6f7f91538967e",
+  "hash": "sha256-QHyIMGSbCQW8d5qbOrMsm6gem10bO3Au2YLa3alJfHo=",
   "cargoHash": "sha256-gfnalA3qI3a9h3PvsxgQLCrzapfjLLkxhTMJpwRh+ro="
 }


### PR DESCRIPTION
Automated package bump for `[
  "niri_git"
]`.