### PR TITLE
chore: bump helix_git

### DIFF
--- a/pkgs/helix-git/version.json
+++ b/pkgs/helix-git/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260607182213-4c1f3ac",
-  "rev": "4c1f3ac87bc5fce29cb224ced6b1b2d438892517",
-  "hash": "sha256-yljxQwRydhMcJWX1FTcZlQ73DyV1zisR2p9GjOindUI=",
-  "cargoHash": "sha256-9cVz6sTy0N3k/YV50jt+Z6cvjLWIbseR7jcxzGRMicg="
+  "version": "unstable-20260609134809-bbdb509",
+  "rev": "bbdb5094414c79990f5f50e8afc06f42d603576e",
+  "hash": "sha256-0zHMuP5xx4LrYZyaUlwBfcgynJgdRhQXUkc4Ymu0hFA=",
+  "cargoHash": "sha256-fOYpwgnbQOt/Cuho9O4OqFWpf46lDCqdQ9hHUwmdzFg="
 }


### PR DESCRIPTION
Automated package bump for `[
  "helix_git"
]`.