### PR TITLE
chore: bump openrgb_git

### DIFF
--- a/pkgs/openrgb-git/version.json
+++ b/pkgs/openrgb-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260607190834-f15c3c1",
-  "rev": "f15c3c1420f37edaeaaecc520f917b518aa53435",
-  "hash": "sha256-n+jDMT1K3Qjw4o6WSpZbtBfKCQNCK2gd1tVuFnTvQk4="
+  "version": "unstable-20260609131639-554f834",
+  "rev": "554f834a907d88266cf4a1b49eab2289573fe68b",
+  "hash": "sha256-sXLrSRu9WoGLKghG/zIeUIlgxebeUylKZ8+/9Jytf20="
 }


### PR DESCRIPTION
Automated package bump for `[
  "openrgb_git"
]`.