### PR TITLE
chore: bump linux_cachyos-lts

### DIFF
--- a/pkgs/linux-cachyos/versions-lts.json
+++ b/pkgs/linux-cachyos/versions-lts.json
@@ -1,17 +1,17 @@
 {
   "suffix": "-cachyos",
   "linux": {
-    "version": "6.18.33",
-    "hash": "sha256-8Z1tHsxZOM4lRMyEdvCTH8olJ1wySaGHemru2WZ5KWA=",
+    "version": "6.18.35",
+    "hash": "sha256-3t3NinlNbX4VfYz/oRIoje+6lGECgvOv0g7Od6q29t4=",
     "tagrel": 1
   },
   "config": {
-    "rev": "f2c7d18505bc35a89a8d5fcab25671168684e7dd",
-    "hash": "sha256-ar7KGDmSmGQlKWH4aHC61K+VFxu1wxA/HcgIBDxHwOQ="
+    "rev": "39d9d125940996ed2eb32425ffec7f2de6ac7fba",
+    "hash": "sha256-jQHNMqg2+Iey/WnF+RNvEs+HG3HFVdCX5W/7wne3UIM="
   },
   "patches": {
-    "rev": "f1cddb07bac67a19df1d72b51c8e0f33f9fd46e4",
-    "hash": "sha256-5SdIKosgsscCVS16RO2OjH+LK9dq6aDWDIl3ra7W95U="
+    "rev": "bb41330bd4372672f552beda66712fb70b17f0fa",
+    "hash": "sha256-t6c7FTqMB0skEz+4tei5v8GEyL4fRDgx24oW3LrnYiE="
   },
   "zfs": {
     "rev": "6330a45b06d20125de679aae5f63ba14082671ef",


### PR DESCRIPTION
Automated package bump for `[
  "linux_cachyos-lts"
]`.