### PR TITLE
chore: bump linuxPackages_cachyos.kernel

### DIFF
--- a/pkgs/linux-cachyos/versions.json
+++ b/pkgs/linux-cachyos/versions.json
@@ -3,14 +3,14 @@
   "suffix": "-cachyos",
   "_linux": "pkgver from config's PKGBUILD",
   "linux": {
-    "version": "7.0.11",
-    "hash": "sha256-YlAvkISJkHD2k5/yQvxqj2dqPjCI0C7GtlOFKldBqkA=",
+    "version": "7.0.12",
+    "hash": "sha256-5+sMsx/J+9eUrwOGwaVFpLGlCMJaV7yXsF2BCqbYVH0=",
     "tagrel": 1
   },
   "_config": "latest commit from https://github.com/CachyOS/linux-cachyos/commits/master/linux-cachyos",
   "config": {
-    "rev": "a61f943f5e94b75c5600a2968cb699d0e37945b3",
-    "hash": "sha256-T15bnskj20rdc4vJ55bFF2lVCVR8edilWn0hiYR7vVs="
+    "rev": "39d9d125940996ed2eb32425ffec7f2de6ac7fba",
+    "hash": "sha256-jQHNMqg2+Iey/WnF+RNvEs+HG3HFVdCX5W/7wne3UIM="
   },
   "_patches": "latest commit from https://github.com/CachyOS/kernel-patches/commits/master/x.y",
   "patches": {


### PR DESCRIPTION
Automated package bump for `[
  "linuxPackages_cachyos.kernel"
]`.