### PR TITLE
chore: bump pcsx2_git

### DIFF
--- a/pkgs/pcsx2-git/version.json
+++ b/pkgs/pcsx2-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260609072207-904a094",
-  "rev": "904a0942f059544ff208d63b7d8d875e0ea4df5b",
-  "hash": "sha256-OKBXR9gtAqAD+4Bd2xWnhoQ7y+ONawLHW6Vomc8pkMs="
+  "version": "unstable-20260610002628-d5f75c9",
+  "rev": "d5f75c9e42064a77036466f1f4594b0507888633",
+  "hash": "sha256-3kSiE8IcoacRKCwGfPuHk8vBLTPbRSAyURALukFvG+o="
 }


### PR DESCRIPTION
Automated package bump for `[
  "pcsx2_git"
]`.