### PR TITLE
chore: bump nix_git

### DIFF
--- a/pkgs/nix-git/version.json
+++ b/pkgs/nix-git/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260609140235-e471eb7",
-  "rev": "e471eb71fa5182bc7420dbcc3eaec75c7290e940",
-  "hash": "sha256-U0fW6rfz14Gt6X5Fpm06TnG7A8VV63ILmGCvAp9Mrgc=",
-  "lastModifiedDate": "20260609140235"
+  "version": "unstable-20260610135613-bfa2b07",
+  "rev": "bfa2b07a99da3164851177a6b3de58ed913c4fd8",
+  "hash": "sha256-O00CQO/SogJzHAvHz8IV8G0szGW7xRLd8GFBmCcMebM=",
+  "lastModifiedDate": "20260610135613"
 }


### PR DESCRIPTION
Automated package bump for `[
  "nix_git"
]`.