### PR TITLE
chore: bump openrgb_git

### DIFF
--- a/pkgs/openrgb-git/version.json
+++ b/pkgs/openrgb-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260609131639-554f834",
-  "rev": "554f834a907d88266cf4a1b49eab2289573fe68b",
-  "hash": "sha256-sXLrSRu9WoGLKghG/zIeUIlgxebeUylKZ8+/9Jytf20="
+  "version": "unstable-20260610035841-4306603",
+  "rev": "4306603a28c86e91f4dd4f89b41efd3005f0b810",
+  "hash": "sha256-U16or6XrTflpC5r2eOCWK4SfMmj6lN9+QObwPzuvs0U="
 }


### PR DESCRIPTION
Automated package bump for `[
  "openrgb_git"
]`.