### PR TITLE
chore: bump libdrm_git

### DIFF
--- a/pkgs/mesa-git/version.json
+++ b/pkgs/mesa-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260609165348-f6dd632",
-  "rev": "f6dd632b313bad941118529ad68167f4c0572128",
-  "hash": "sha256-7OwjfcmrHkAIBc8eQHK51lHmG2Z/KbOJ2+Lz1jYcpZE="
+  "version": "unstable-20260610162159-178a3d7",
+  "rev": "178a3d7396849f8dee99a4ee6048b2eef40190ec",
+  "hash": "sha256-OGTFEYAEn8bntp4kvJ4eq69tbsZ9bHR7bpqQsmJpmPo="
 }

--- a/pkgs/wlroots-git/version.json
+++ b/pkgs/wlroots-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260602091546-a94cd29",
-  "rev": "a94cd29eb13fc2fb68f2fe2d053fef29fb6ae712",
-  "hash": "sha256-4CSASFBiQFjTHw/73sKKqKLcVYOaRBxaNT7bBAaxHVM="
+  "version": "unstable-20260609192943-fc1cc76",
+  "rev": "fc1cc7656a54256e94e41ad4992b8b753daf4c8a",
+  "hash": "sha256-kC5lukwuFipTiQJ6M+gTHcIeiUhvWIHlkbSdPsEq+L0="
 }


### PR DESCRIPTION
Automated package bump for `[
  "libdrm_git",
  "wayland-protocols_git",
  "mesa_git",
  "wayland_git",
  "wlroots_git",
  "sway-unwrapped_git",
  "xdg-desktop-portal-wlr_git"
]`.