### PR TITLE
chore: bump nss_git

### DIFF
--- a/pkgs/nss-git/version.json
+++ b/pkgs/nss-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260609225411-3c772c5",
-  "rev": "3c772c53f6e75a732759b93989403789bda99b9f",
-  "hash": "sha256-hDU7Ia/5rgWOR8K1edMYGBOpDm0Kq6PFAkDIeCqumXg="
+  "version": "unstable-20260610153112-2d19f8f",
+  "rev": "2d19f8fd7f4c8b42f22f302acaa42d06de871605",
+  "hash": "sha256-zqfnAsVcs9Fj12uMCrDL4CWadny/vZ3/UpZgDmfSwEg="
 }


### PR DESCRIPTION
Automated package bump for `[
  "nss_git"
]`.