### PR TITLE
chore: bump helix_git

### DIFF
--- a/pkgs/helix-git/version.json
+++ b/pkgs/helix-git/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260609134809-bbdb509",
-  "rev": "bbdb5094414c79990f5f50e8afc06f42d603576e",
-  "hash": "sha256-0zHMuP5xx4LrYZyaUlwBfcgynJgdRhQXUkc4Ymu0hFA=",
+  "version": "unstable-20260610094147-1cbad94",
+  "rev": "1cbad945984e8409d3872b070afbb25fda525a5f",
+  "hash": "sha256-NDpCGVn6FYEnkgU6owOQV3OLYPd+NXu0iLN1+6Rwj78=",
   "cargoHash": "sha256-fOYpwgnbQOt/Cuho9O4OqFWpf46lDCqdQ9hHUwmdzFg="
 }


### PR DESCRIPTION
Automated package bump for `[
  "helix_git"
]`.