### PR TITLE
chore: bump proton-cachyos

### DIFF
--- a/pkgs/proton-bin/cachyos-version.json
+++ b/pkgs/proton-bin/cachyos-version.json
@@ -1,5 +1,5 @@
 {
   "base": "11.0",
-  "release": "20260521",
-  "hash": "sha256-svDsjpMbAsvLV1xvTPHzeTKmSKOt0nHdfdEvE5X1tyw="
+  "release": "20260601",
+  "hash": "sha256-N2bcB4voaFNlRpAyQ6NvDCw/tSwfC5tHXuIPV0+puZs="
 }


### PR DESCRIPTION
Automated package bump for `[
  "proton-cachyos"
]`.