### PR TITLE
chore: bump nix_git

### DIFF
--- a/pkgs/nix-git/version.json
+++ b/pkgs/nix-git/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260610135613-bfa2b07",
-  "rev": "bfa2b07a99da3164851177a6b3de58ed913c4fd8",
-  "hash": "sha256-O00CQO/SogJzHAvHz8IV8G0szGW7xRLd8GFBmCcMebM=",
-  "lastModifiedDate": "20260610135613"
+  "version": "unstable-20260610222141-3cb25f4",
+  "rev": "3cb25f4d5a1a5ae4ae480cd0f79638c4c317941e",
+  "hash": "sha256-kQFjQtTWuqQHk18l87kKAATF9DvXvpdMoh5ACVE1cuY=",
+  "lastModifiedDate": "20260610222141"
 }


### PR DESCRIPTION
Automated package bump for `[
  "nix_git"
]`.