### PR TITLE
chore: bump libdrm_git

### DIFF
--- a/pkgs/mesa-git/version.json
+++ b/pkgs/mesa-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260610162159-178a3d7",
-  "rev": "178a3d7396849f8dee99a4ee6048b2eef40190ec",
-  "hash": "sha256-OGTFEYAEn8bntp4kvJ4eq69tbsZ9bHR7bpqQsmJpmPo="
+  "version": "unstable-20260611032829-2a681c4",
+  "rev": "2a681c4f8b56b6f1eb70fbd7ab353be0068867eb",
+  "hash": "sha256-ExgCx2GifxZwvXKA4TmBGPjb3RaSzWXoMLQDAO1z92I="
 }


### PR DESCRIPTION
Automated package bump for `[
  "libdrm_git",
  "wayland-protocols_git",
  "mesa_git",
  "wayland_git",
  "wlroots_git",
  "sway-unwrapped_git",
  "xdg-desktop-portal-wlr_git"
]`.