### PR TITLE
chore: bump nix_git

### DIFF
--- a/pkgs/nix-git/version.json
+++ b/pkgs/nix-git/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260610222141-3cb25f4",
-  "rev": "3cb25f4d5a1a5ae4ae480cd0f79638c4c317941e",
-  "hash": "sha256-kQFjQtTWuqQHk18l87kKAATF9DvXvpdMoh5ACVE1cuY=",
-  "lastModifiedDate": "20260610222141"
+  "version": "unstable-20260611150604-ce9fda4",
+  "rev": "ce9fda43e5cb8d2f6c57c7240d05d10ad0415799",
+  "hash": "sha256-uP1AYpXYHdzmuz+a4AcScRIHa1uy7l9ObZovS0OqN70=",
+  "lastModifiedDate": "20260611150604"
 }


### PR DESCRIPTION
Automated package bump for `[
  "nix_git"
]`.