### PR TITLE
chore: bump libdrm_git

### DIFF
--- a/pkgs/libdrm-git/version.json
+++ b/pkgs/libdrm-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260529084942-e984d44",
-  "rev": "e984d448b8b17aab853369e6c203e53719f46de1",
-  "hash": "sha256-btHG+p8FJObTl/k04bDaRb7hclVtyijjLHqrFJ9aIM8="
+  "version": "unstable-20260611152330-35c7c53",
+  "rev": "35c7c536d5d1c0124a416a531df4432508d7d2f1",
+  "hash": "sha256-7+PoH4c98Hf30wxX2mooD9OMTGpSqjJueMrVrmF6w98="
 }

--- a/pkgs/mesa-git/version.json
+++ b/pkgs/mesa-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260611032829-2a681c4",
-  "rev": "2a681c4f8b56b6f1eb70fbd7ab353be0068867eb",
-  "hash": "sha256-ExgCx2GifxZwvXKA4TmBGPjb3RaSzWXoMLQDAO1z92I="
+  "version": "unstable-20260612041308-a07ded8",
+  "rev": "a07ded8e8cf1d2f2b758ebb0520a7845f608c284",
+  "hash": "sha256-oj1+jUZR8cxN4SDEk2Cn7x0SQV5F+we9/Qj76zxkBHw="
 }

--- a/pkgs/wlroots-git/version.json
+++ b/pkgs/wlroots-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260609192943-fc1cc76",
-  "rev": "fc1cc7656a54256e94e41ad4992b8b753daf4c8a",
-  "hash": "sha256-kC5lukwuFipTiQJ6M+gTHcIeiUhvWIHlkbSdPsEq+L0="
+  "version": "unstable-20260611150059-63318d2",
+  "rev": "63318d28b1ea86873eeb1023d88e56d57bdd2453",
+  "hash": "sha256-YGMXx72kWxQAta0s7dp0/gV08w3OgM+hQc3aoYQUJb8="
 }


### PR DESCRIPTION
Automated package bump for `[
  "libdrm_git",
  "wayland-protocols_git",
  "mesa_git",
  "wayland_git",
  "wlroots_git",
  "sway-unwrapped_git",
  "xdg-desktop-portal-wlr_git"
]`.