### PR TITLE
chore: bump helix_git

### DIFF
--- a/pkgs/helix-git/version.json
+++ b/pkgs/helix-git/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260610094147-1cbad94",
-  "rev": "1cbad945984e8409d3872b070afbb25fda525a5f",
-  "hash": "sha256-NDpCGVn6FYEnkgU6owOQV3OLYPd+NXu0iLN1+6Rwj78=",
+  "version": "unstable-20260612045642-107758a",
+  "rev": "107758a957f3afae224251d0c2ae71478364b075",
+  "hash": "sha256-x4X66d2eXdizNtXPtMaVhxkvhudZ1Te+gourxZLAdFQ=",
   "cargoHash": "sha256-fOYpwgnbQOt/Cuho9O4OqFWpf46lDCqdQ9hHUwmdzFg="
 }


### PR DESCRIPTION
Automated package bump for `[
  "helix_git"
]`.