### PR TITLE
chore: bump pcsx2_git

### DIFF
--- a/pkgs/pcsx2-git/version.json
+++ b/pkgs/pcsx2-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260610002628-d5f75c9",
-  "rev": "d5f75c9e42064a77036466f1f4594b0507888633",
-  "hash": "sha256-3kSiE8IcoacRKCwGfPuHk8vBLTPbRSAyURALukFvG+o="
+  "version": "unstable-20260612220803-d187c61",
+  "rev": "d187c6159962db5405018496855b8b58e8ec7836",
+  "hash": "sha256-13b7HuvWLP9rPMGbFpZjwiXZDoud0tLIrA6k/hmnK8g="
 }


### PR DESCRIPTION
Automated package bump for `[
  "pcsx2_git"
]`.