### PR TITLE
chore: bump libportal_git

### DIFF
--- a/pkgs/libportal-git/version.json
+++ b/pkgs/libportal-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260531204808-4f2337f",
-  "rev": "4f2337f166027bf7e1eed19a62e311c95113d376",
-  "hash": "sha256-dOsBTjWnaiGDSqAo4F2PZ6OsneWQaGnKdYnnWwM3t0I="
+  "version": "unstable-20260612165855-0fb8a82",
+  "rev": "0fb8a8298fe86f50b473f0b0ababa7a6cf4e2ac3",
+  "hash": "sha256-RBX8E7/TnHe1IjWO1s5Q63VaxxhlOAL0AERU8EQ3CCE="
 }


### PR DESCRIPTION
Automated package bump for `[
  "libportal_git"
]`.