### PR TITLE
chore: bump shadps4_git

### DIFF
--- a/pkgs/shadps4-git/version.json
+++ b/pkgs/shadps4-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260602050318-0b9eb3d",
-  "rev": "0b9eb3dd17bbd5566b46e3daff7de5e3024c5cd2",
-  "hash": "sha256-vLDFXPBsqwb7Xqz1f4Fu3Rqzm4FexoDCy8+Ws9Q+wVM="
+  "version": "unstable-20260612233059-8c4e392",
+  "rev": "8c4e3926bb5403ef245aabb6a25cf838e6fc28d7",
+  "hash": "sha256-S4ftX4XIMGyOPNYNvTCvX8hOIyclEzuElqlIron9LOM="
 }


### PR DESCRIPTION
Automated package bump for `[
  "shadps4_git"
]`.