### PR TITLE
chore: bump tde2e_git

### DIFF
--- a/pkgs/tdlib-git/version.json
+++ b/pkgs/tdlib-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260611210438-d6debbb",
-  "rev": "d6debbb2aae29a39e280f86e25ec0e54960dc838",
-  "hash": "sha256-CTU+aU1/6pDVxFAM2W4xKC/yKcoIZ1ugIA0ATQr5Ij0="
+  "version": "unstable-20260612081511-062f260",
+  "rev": "062f26052623dbecedb42075cab78a759e9f9987",
+  "hash": "sha256-aBU67zvJaOWpC0v+2KalT8vA9wNm6kF0Yxd6UjUdySo="
 }

--- a/pkgs/telegram-desktop-git/version.json
+++ b/pkgs/telegram-desktop-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260611210425-8165c7c",
-  "rev": "8165c7c6c065c8abc94ec5076f75bee0a29b82e1",
-  "hash": "sha256-IzaBZIiFEkcUcOIiQzdVeuPANuFeHmjwVIGArtAyUDg="
+  "version": "unstable-20260612185045-7db0d5d",
+  "rev": "7db0d5dac5c6179291dcd182154c0d7f5bd1f4e5",
+  "hash": "sha256-rUDUtVAgvIKaAr11tBRAUUNQoSpN9PuVKtYpdOkTF2c="
 }


### PR DESCRIPTION
Automated package bump for `[
  "tde2e_git",
  "tg-owt_git",
  "telegram-desktop-unwrapped_git",
  "telegram-desktop_git"
]`.