### PR TITLE
chore: bump nix_git

### DIFF
--- a/pkgs/nix-git/version.json
+++ b/pkgs/nix-git/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260611150604-ce9fda4",
-  "rev": "ce9fda43e5cb8d2f6c57c7240d05d10ad0415799",
-  "hash": "sha256-uP1AYpXYHdzmuz+a4AcScRIHa1uy7l9ObZovS0OqN70=",
-  "lastModifiedDate": "20260611150604"
+  "version": "unstable-20260612145615-02abc7a",
+  "rev": "02abc7a8c990cf8bf97b084dfc2852b59dfcdfef",
+  "hash": "sha256-16KKQFMS26pzguUE/zuof1ufgsKsSXtcJodwa2Zh/+4=",
+  "lastModifiedDate": "20260612145615"
 }


### PR DESCRIPTION
Automated package bump for `[
  "nix_git"
]`.