### PR TITLE
chore: bump libdrm_git

### DIFF
--- a/pkgs/mesa-git/version.json
+++ b/pkgs/mesa-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260612041308-a07ded8",
-  "rev": "a07ded8e8cf1d2f2b758ebb0520a7845f608c284",
-  "hash": "sha256-oj1+jUZR8cxN4SDEk2Cn7x0SQV5F+we9/Qj76zxkBHw="
+  "version": "unstable-20260612215541-8faf71d",
+  "rev": "8faf71d84f0ef92538107d132ff48f7179e922d4",
+  "hash": "sha256-GSInJ7hUcZ2bI7LhYOaST1fpRNgLdAUHKxqK8WPB4OY="
 }

--- a/pkgs/wlroots-git/version.json
+++ b/pkgs/wlroots-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260611150059-63318d2",
-  "rev": "63318d28b1ea86873eeb1023d88e56d57bdd2453",
-  "hash": "sha256-YGMXx72kWxQAta0s7dp0/gV08w3OgM+hQc3aoYQUJb8="
+  "version": "unstable-20260612181123-5d15026",
+  "rev": "5d150267e267a5c80d391bb423b8668f999078fc",
+  "hash": "sha256-dmp1neAYSzbrbMpNNo1J9bJWYNxYLXQgLxNITd4tIYc="
 }


### PR DESCRIPTION
Automated package bump for `[
  "libdrm_git",
  "wayland-protocols_git",
  "mesa_git",
  "wayland_git",
  "wlroots_git",
  "sway-unwrapped_git",
  "xdg-desktop-portal-wlr_git"
]`.