### PR TITLE
chore: bump lan-mouse_git

### DIFF
--- a/pkgs/lan-mouse-git/version.json
+++ b/pkgs/lan-mouse-git/version.json
@@ -1,7 +1,7 @@
 {
-  "version": "unstable-20260611152704-7ef4341",
-  "rev": "7ef43418c90b39422a8bf9e439a918ae3175c21f",
-  "hash": "sha256-AMOTP1imHdNV2w1kzGCcwnOdIyMZRElUx3KbO+b/gqs=",
-  "cargoHash": "sha256-Oy81fQxAuM7BzH8FcHwsHNPxfAp0QMznHhde7aDsh0E=",
-  "lastModified": "1781191624"
+  "version": "unstable-20260612130711-0d2190e",
+  "rev": "0d2190e787db9e482e17d4c16fb7c00ef4841bcb",
+  "hash": "sha256-6EqA9WfiukOymUT4FkNdMvzmFKByW0LLoI/9sv4TzBU=",
+  "cargoHash": "sha256-Lxs0qWvNAv4KCeJ+cDBYBzwlbJfQJshcxPRdg9w0szc=",
+  "lastModified": "1781269631"
 }


### PR DESCRIPTION
Automated package bump for `[
  "lan-mouse_git"
]`.