### PR TITLE
chore: bump zed-editor_git

### DIFF
--- a/pkgs/zed-editor-git/version.json
+++ b/pkgs/zed-editor-git/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260612030042-fef979d",
-  "rev": "fef979dec45c8ee83231aeb1d782ccb536093f65",
-  "hash": "sha256-fSvcZUe6IQ4AoPfZlqL9Ae/FiNxisFAAC7vNg9sii0U=",
-  "cargoHash": "sha256-cVXd6pBz3b4G1sC89og3UGWKATcGu2+h2kvKEh2P+xA="
+  "version": "unstable-20260612193652-fca2ccd",
+  "rev": "fca2ccd403e8d13c8f4b968cda2f2c322f420f5a",
+  "hash": "sha256-SSQI2KUAyBVnR8MrMnWGuqlVeRbhrfOHSagCFViUdbk=",
+  "cargoHash": "sha256-lJ2jwGe0u8W7OD/s+Xw6A7rMng/Ls2Z7Bj7y14r33og="
 }


### PR DESCRIPTION
Automated package bump for `[
  "zed-editor_git"
]`.