### PR TITLE
chore: bump pcsx2_git

### DIFF
--- a/pkgs/pcsx2-git/version.json
+++ b/pkgs/pcsx2-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260612220803-d187c61",
-  "rev": "d187c6159962db5405018496855b8b58e8ec7836",
-  "hash": "sha256-13b7HuvWLP9rPMGbFpZjwiXZDoud0tLIrA6k/hmnK8g="
+  "version": "unstable-20260614002929-1d8fb3d",
+  "rev": "1d8fb3d407188223da62c06514dbc0bcabad695d",
+  "hash": "sha256-3Rf6/jNzmo4rG6peODr4U6u80fCT/Av4BNzHsB1CAqI="
 }


### PR DESCRIPTION
Automated package bump for `[
  "pcsx2_git"
]`.