### PR TITLE
chore: bump tde2e_git

### DIFF
--- a/pkgs/tdlib-git/version.json
+++ b/pkgs/tdlib-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260612081511-062f260",
-  "rev": "062f26052623dbecedb42075cab78a759e9f9987",
-  "hash": "sha256-aBU67zvJaOWpC0v+2KalT8vA9wNm6kF0Yxd6UjUdySo="
+  "version": "unstable-20260613094822-a17f87c",
+  "rev": "a17f87c4cff7b90b278d12b91ba0614383aaee82",
+  "hash": "sha256-xNAC9DpbLH4Fsl83We13PaXX9WjY8MUSZ3kA5bUo2s8="
 }

--- a/pkgs/telegram-desktop-git/version.json
+++ b/pkgs/telegram-desktop-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260612185045-7db0d5d",
-  "rev": "7db0d5dac5c6179291dcd182154c0d7f5bd1f4e5",
-  "hash": "sha256-rUDUtVAgvIKaAr11tBRAUUNQoSpN9PuVKtYpdOkTF2c="
+  "version": "unstable-20260612190345-3887c78",
+  "rev": "3887c78b035b47f179ef366e3a8a56c08c44ad0b",
+  "hash": "sha256-QCGtESg+38lHWCFcsevHdc0kQ7LKJQmJjUJWszphah8="
 }


### PR DESCRIPTION
Automated package bump for `[
  "tde2e_git",
  "tg-owt_git",
  "telegram-desktop-unwrapped_git",
  "telegram-desktop_git"
]`.