### PR TITLE
chore: bump shadps4_git

### DIFF
--- a/pkgs/shadps4-git/version.json
+++ b/pkgs/shadps4-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260612233059-8c4e392",
-  "rev": "8c4e3926bb5403ef245aabb6a25cf838e6fc28d7",
-  "hash": "sha256-S4ftX4XIMGyOPNYNvTCvX8hOIyclEzuElqlIron9LOM="
+  "version": "unstable-20260613112209-3590426",
+  "rev": "3590426ab8059cec74220340470138ae0b3aa515",
+  "hash": "sha256-xgcWVsfO2+on3cT+w+OtExRT5ATyN/NGF7u2fhl3em8="
 }


### PR DESCRIPTION
Automated package bump for `[
  "shadps4_git"
]`.