### PR TITLE
chore: bump libdrm_git

### DIFF
--- a/pkgs/mesa-git/version.json
+++ b/pkgs/mesa-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260612215541-8faf71d",
-  "rev": "8faf71d84f0ef92538107d132ff48f7179e922d4",
-  "hash": "sha256-GSInJ7hUcZ2bI7LhYOaST1fpRNgLdAUHKxqK8WPB4OY="
+  "version": "unstable-20260613192959-ce4654e",
+  "rev": "ce4654ead659aa68f88cfb898a0fcca4da6f329b",
+  "hash": "sha256-d9NTdTjLc8HUPUD+D7qs8th8CEegXOvNLEj+1JTyaEg="
 }

--- a/pkgs/sway-unwrapped-git/version.json
+++ b/pkgs/sway-unwrapped-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260602224140-97c342f",
-  "rev": "97c342f9e1e1f6ac640f58d53950d92bc48dd889",
-  "hash": "sha256-d1azpQVNuQdUTr5KffV4HmlhQTi5AqvG7mnfvopNKTQ="
+  "version": "unstable-20260613095023-47ec005",
+  "rev": "47ec005a58d5f7e63a97c564a4bb877754f68e6f",
+  "hash": "sha256-oAkKstil0j7xMRsof+Idwsy0iF95iMg4wc1wEi+e15E="
 }

--- a/pkgs/wlroots-git/version.json
+++ b/pkgs/wlroots-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260612181123-5d15026",
-  "rev": "5d150267e267a5c80d391bb423b8668f999078fc",
-  "hash": "sha256-dmp1neAYSzbrbMpNNo1J9bJWYNxYLXQgLxNITd4tIYc="
+  "version": "unstable-20260613095946-f141edc",
+  "rev": "f141edcd0233d86d9e9aab605b2b6f0803be5e98",
+  "hash": "sha256-sDKLKhYKUFxL6TlaWIVo3GVCNy3zJewFjkxbCBCqUgc="
 }


### PR DESCRIPTION
Automated package bump for `[
  "libdrm_git",
  "wayland-protocols_git",
  "mesa_git",
  "wayland_git",
  "wlroots_git",
  "sway-unwrapped_git",
  "xdg-desktop-portal-wlr_git"
]`.