### PR TITLE
chore: bump zed-editor_git

### DIFF
--- a/pkgs/zed-editor-git/version.json
+++ b/pkgs/zed-editor-git/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260612193652-fca2ccd",
-  "rev": "fca2ccd403e8d13c8f4b968cda2f2c322f420f5a",
-  "hash": "sha256-SSQI2KUAyBVnR8MrMnWGuqlVeRbhrfOHSagCFViUdbk=",
+  "version": "unstable-20260613163916-df9c9f0",
+  "rev": "df9c9f055e55c891e627ffe17cce51ac9e20c648",
+  "hash": "sha256-g0+ljvZRuzd9UUZJaSHsyMSqc+MjcRhfAtxlYGUCeJc=",
   "cargoHash": "sha256-lJ2jwGe0u8W7OD/s+Xw6A7rMng/Ls2Z7Bj7y14r33og="
 }


### PR DESCRIPTION
Automated package bump for `[
  "zed-editor_git"
]`.