### PR TITLE
chore: bump nix_git

### DIFF
--- a/pkgs/nix-git/version.json
+++ b/pkgs/nix-git/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260612145615-02abc7a",
-  "rev": "02abc7a8c990cf8bf97b084dfc2852b59dfcdfef",
-  "hash": "sha256-16KKQFMS26pzguUE/zuof1ufgsKsSXtcJodwa2Zh/+4=",
-  "lastModifiedDate": "20260612145615"
+  "version": "unstable-20260614193731-67e162b",
+  "rev": "67e162bded21604ae7ba35aea5921bf7272ab11e",
+  "hash": "sha256-4A0w1gp+v1yf6xCYjh8o+dNrhSHIvS3gczPwLQ662xU=",
+  "lastModifiedDate": "20260614193731"
 }


### PR DESCRIPTION
Automated package bump for `[
  "nix_git"
]`.