### PR TITLE
chore: bump shadps4_git

### DIFF
--- a/pkgs/shadps4-git/version.json
+++ b/pkgs/shadps4-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260613112209-3590426",
-  "rev": "3590426ab8059cec74220340470138ae0b3aa515",
-  "hash": "sha256-xgcWVsfO2+on3cT+w+OtExRT5ATyN/NGF7u2fhl3em8="
+  "version": "unstable-20260614171718-6a20eba",
+  "rev": "6a20ebacdec47c914e8848341242f40c97af2875",
+  "hash": "sha256-quHYmQ1noQ2U7S6ZIgLM0x2NYgXY/9aTS5gCRr57Vio="
 }


### PR DESCRIPTION
Automated package bump for `[
  "shadps4_git"
]`.