### PR TITLE
chore: bump tde2e_git

### DIFF
--- a/pkgs/telegram-desktop-git/version.json
+++ b/pkgs/telegram-desktop-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260612190345-3887c78",
-  "rev": "3887c78b035b47f179ef366e3a8a56c08c44ad0b",
-  "hash": "sha256-QCGtESg+38lHWCFcsevHdc0kQ7LKJQmJjUJWszphah8="
+  "version": "unstable-20260615055605-49ff0bc",
+  "rev": "49ff0bcc09341a18f5d51b151ee6fbe726aa441d",
+  "hash": "sha256-rjaMXf5pDEB7DJLjmj/zdHJYgcV3rnglX6bw3Nk+UUg="
 }


### PR DESCRIPTION
Automated package bump for `[
  "tde2e_git",
  "tg-owt_git",
  "telegram-desktop-unwrapped_git",
  "telegram-desktop_git"
]`.