### PR TITLE
chore: bump lan-mouse_git

### DIFF
--- a/pkgs/lan-mouse-git/version.json
+++ b/pkgs/lan-mouse-git/version.json
@@ -1,7 +1,7 @@
 {
-  "version": "unstable-20260612130711-0d2190e",
-  "rev": "0d2190e787db9e482e17d4c16fb7c00ef4841bcb",
-  "hash": "sha256-6EqA9WfiukOymUT4FkNdMvzmFKByW0LLoI/9sv4TzBU=",
-  "cargoHash": "sha256-Lxs0qWvNAv4KCeJ+cDBYBzwlbJfQJshcxPRdg9w0szc=",
-  "lastModified": "1781269631"
+  "version": "unstable-20260614230138-497a1a0",
+  "rev": "497a1a081aed1dd9ad54b5c90be5bad9f077aeb6",
+  "hash": "sha256-VyMJQIguEVeFuXhG3Yqi2cshcpbpolU3omkYzA4WuqU=",
+  "cargoHash": "sha256-ObBeDISkZ8cBjnR11RoCCUuvGVIudddaeCU+A+yXM+c=",
+  "lastModified": "1781478098"
 }


### PR DESCRIPTION
Automated package bump for `[
  "lan-mouse_git"
]`.