### PR TITLE
chore: bump zed-editor_git

### DIFF
--- a/pkgs/zed-editor-git/version.json
+++ b/pkgs/zed-editor-git/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260613163916-df9c9f0",
-  "rev": "df9c9f055e55c891e627ffe17cce51ac9e20c648",
-  "hash": "sha256-g0+ljvZRuzd9UUZJaSHsyMSqc+MjcRhfAtxlYGUCeJc=",
-  "cargoHash": "sha256-lJ2jwGe0u8W7OD/s+Xw6A7rMng/Ls2Z7Bj7y14r33og="
+  "version": "unstable-20260615035400-cccc7b2",
+  "rev": "cccc7b2d4408ee75d5c2e9dadad2cc0b7f992dd0",
+  "hash": "sha256-zJMu6Ef0s3bchOZnJCrwchP5hDZ4aPobQ7jJpWVMisQ=",
+  "cargoHash": "sha256-eRwfuT2mJDvXNMfFcYhVwRA05Wi3neD09cLYEf+Xswc="
 }


### PR DESCRIPTION
Automated package bump for `[
  "zed-editor_git"
]`.