### PR TITLE
chore: bump helix_git

### DIFF
--- a/pkgs/helix-git/version.json
+++ b/pkgs/helix-git/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260612190653-14eda10",
-  "rev": "14eda106f0a3e6a5fc6fb5cbd96bda9774f64ae1",
-  "hash": "sha256-PR1w7b2AJaOFRSNr1nin3fgEtR0bKZgFFhehKzI0dUM=",
-  "cargoHash": "sha256-fOYpwgnbQOt/Cuho9O4OqFWpf46lDCqdQ9hHUwmdzFg="
+  "version": "unstable-20260614070240-43bf7c2",
+  "rev": "43bf7c2dc219606c64003aef21151f49f48d0939",
+  "hash": "sha256-XRjbG1piXMR2fHrxcavz/UEIIDuDXPgwlu+2089qROU=",
+  "cargoHash": "sha256-mRt05s72hjpv9GkDy1FaVPWmyEtlwRsPn3UymXCSC2c="
 }


### PR DESCRIPTION
Automated package bump for `[
  "helix_git"
]`.