### PR TITLE
chore: bump libportal_git

### DIFF
--- a/pkgs/libportal-git/version.json
+++ b/pkgs/libportal-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260612165855-0fb8a82",
-  "rev": "0fb8a8298fe86f50b473f0b0ababa7a6cf4e2ac3",
-  "hash": "sha256-RBX8E7/TnHe1IjWO1s5Q63VaxxhlOAL0AERU8EQ3CCE="
+  "version": "unstable-20260616003452-383f05e",
+  "rev": "383f05eec54ab217b85032709c7f640d3676ea04",
+  "hash": "sha256-Dxj9tMFd6w7pU/2p5N9mzX1CrRHthN+Ikyfx9wzqCT8="
 }


### PR DESCRIPTION
Automated package bump for `[
  "libportal_git"
]`.