### PR TITLE
chore: bump openrgb_git

### DIFF
--- a/pkgs/openrgb-git/version.json
+++ b/pkgs/openrgb-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260610035841-4306603",
-  "rev": "4306603a28c86e91f4dd4f89b41efd3005f0b810",
-  "hash": "sha256-U16or6XrTflpC5r2eOCWK4SfMmj6lN9+QObwPzuvs0U="
+  "version": "unstable-20260616050241-a8354ee",
+  "rev": "a8354ee0464150df8650f7a11396a607227bb65b",
+  "hash": "sha256-eiLGQd9TkLiGpWT1Ijn146T73UM6Nj44KRh3WcPwg8Q="
 }


### PR DESCRIPTION
Automated package bump for `[
  "openrgb_git"
]`.