### PR TITLE
chore: bump niri_git

### DIFF
--- a/pkgs/niri-git/version.json
+++ b/pkgs/niri-git/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260608170655-6f1a2c5",
-  "rev": "6f1a2c5f0e8274223d4204b1f8d6f7f91538967e",
-  "hash": "sha256-QHyIMGSbCQW8d5qbOrMsm6gem10bO3Au2YLa3alJfHo=",
-  "cargoHash": "sha256-gfnalA3qI3a9h3PvsxgQLCrzapfjLLkxhTMJpwRh+ro="
+  "version": "unstable-20260616053758-fdb6d85",
+  "rev": "fdb6d85fc78355762bcf3cf71fe4037681a766f9",
+  "hash": "sha256-Fw/Zo0hwgn9ulgY5duQy51WHtqpNoLjNDZYLdEI1SS4=",
+  "cargoHash": "sha256-jGORNwJ/F9UrajObXdGLbOTGEpCv919puUuWojbuVwo="
 }


### PR DESCRIPTION
Automated package bump for `[
  "niri_git"
]`.