### PR TITLE
chore: bump tde2e_git

### DIFF
--- a/pkgs/telegram-desktop-git/version.json
+++ b/pkgs/telegram-desktop-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260615055605-49ff0bc",
-  "rev": "49ff0bcc09341a18f5d51b151ee6fbe726aa441d",
-  "hash": "sha256-rjaMXf5pDEB7DJLjmj/zdHJYgcV3rnglX6bw3Nk+UUg="
+  "version": "unstable-20260615175454-9cca005",
+  "rev": "9cca0059b5cdc6be94ba355bf91d69d890dfdf75",
+  "hash": "sha256-seEw8oDCje+1rLL9MAdQvmQy8wH+cAVMmt8mK4A2YaU="
 }


### PR DESCRIPTION
Automated package bump for `[
  "tde2e_git",
  "tg-owt_git",
  "telegram-desktop-unwrapped_git",
  "telegram-desktop_git"
]`.