### PR TITLE
chore: bump nix_git

### DIFF
--- a/pkgs/nix-git/version.json
+++ b/pkgs/nix-git/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260614193731-67e162b",
-  "rev": "67e162bded21604ae7ba35aea5921bf7272ab11e",
-  "hash": "sha256-4A0w1gp+v1yf6xCYjh8o+dNrhSHIvS3gczPwLQ662xU=",
-  "lastModifiedDate": "20260614193731"
+  "version": "unstable-20260615190642-2c25a9a",
+  "rev": "2c25a9aa8c561577922ea158eb372a0e5e832d74",
+  "hash": "sha256-19Ou6fy26SZ1lOo8HPsQ90uGB+jQsMu13Tz1s/ri+qE=",
+  "lastModifiedDate": "20260615190642"
 }


### PR DESCRIPTION
Automated package bump for `[
  "nix_git"
]`.