### PR TITLE
chore: bump zed-editor_git

### DIFF
--- a/pkgs/zed-editor-git/version.json
+++ b/pkgs/zed-editor-git/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260615035400-cccc7b2",
-  "rev": "cccc7b2d4408ee75d5c2e9dadad2cc0b7f992dd0",
-  "hash": "sha256-zJMu6Ef0s3bchOZnJCrwchP5hDZ4aPobQ7jJpWVMisQ=",
-  "cargoHash": "sha256-eRwfuT2mJDvXNMfFcYhVwRA05Wi3neD09cLYEf+Xswc="
+  "version": "unstable-20260616035751-c3c38c5",
+  "rev": "c3c38c5c09d887817229b133d904e6eb3f7e7011",
+  "hash": "sha256-qZ4YDvlq1b3F3nSwnHjT4aM5DTT6MNfBMJZen5czyvk=",
+  "cargoHash": "sha256-pqDFYYXCXJQokjBAiMJ6DjPb0ZhSDfP7V/ChAW2SB8I="
 }


### PR DESCRIPTION
Automated package bump for `[
  "zed-editor_git"
]`.