### PR TITLE
chore: bump pcsx2_git

### DIFF
--- a/pkgs/pcsx2-git/version.json
+++ b/pkgs/pcsx2-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260614002929-1d8fb3d",
-  "rev": "1d8fb3d407188223da62c06514dbc0bcabad695d",
-  "hash": "sha256-3Rf6/jNzmo4rG6peODr4U6u80fCT/Av4BNzHsB1CAqI="
+  "version": "unstable-20260616004159-cd9530e",
+  "rev": "cd9530eec3d4733c56f394da185c64b3bb2eb294",
+  "hash": "sha256-leNzU4meb7VDgoOB1U/udgJmV+kacTvmAmXzprX0gjM="
 }


### PR DESCRIPTION
Automated package bump for `[
  "pcsx2_git"
]`.