### PR TITLE
chore: bump libdrm_git

### DIFF
--- a/pkgs/mesa-git/version.json
+++ b/pkgs/mesa-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260613192959-ce4654e",
-  "rev": "ce4654ead659aa68f88cfb898a0fcca4da6f329b",
-  "hash": "sha256-d9NTdTjLc8HUPUD+D7qs8th8CEegXOvNLEj+1JTyaEg="
+  "version": "unstable-20260616033944-a7575d7",
+  "rev": "a7575d7e981cac410752e047fa7922ef2d8425fa",
+  "hash": "sha256-2piW7fqlMqMt38RwwDYAcyh2h991nau0MD2t1eoK3mU="
 }


### PR DESCRIPTION
Automated package bump for `[
  "libdrm_git",
  "wayland-protocols_git",
  "mesa_git",
  "wayland_git",
  "wlroots_git",
  "sway-unwrapped_git",
  "xdg-desktop-portal-wlr_git"
]`.