### PR TITLE
chore: bump shadps4_git

### DIFF
--- a/pkgs/shadps4-git/version.json
+++ b/pkgs/shadps4-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260614171718-6a20eba",
-  "rev": "6a20ebacdec47c914e8848341242f40c97af2875",
-  "hash": "sha256-quHYmQ1noQ2U7S6ZIgLM0x2NYgXY/9aTS5gCRr57Vio="
+  "version": "unstable-20260615102824-7de583b",
+  "rev": "7de583b4c396eee6975dd9058a8607b885eafb1b",
+  "hash": "sha256-/o71XGk6IaOwiRPre9+cT5FiVieiQRMDSiBhiy5txhw="
 }


### PR DESCRIPTION
Automated package bump for `[
  "shadps4_git"
]`.