### PR TITLE
chore: bump openrgb_git

### DIFF
--- a/pkgs/openrgb-git/version.json
+++ b/pkgs/openrgb-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260616050241-a8354ee",
-  "rev": "a8354ee0464150df8650f7a11396a607227bb65b",
-  "hash": "sha256-eiLGQd9TkLiGpWT1Ijn146T73UM6Nj44KRh3WcPwg8Q="
+  "version": "unstable-20260616125228-1339666",
+  "rev": "133966677bd0104a356a34be848fb17b96b24259",
+  "hash": "sha256-f2C9UsICiOM+Mk64lQbHICJm4qFAGy7k1Lc4woYHQyk="
 }


### PR DESCRIPTION
Automated package bump for `[
  "openrgb_git"
]`.