### PR TITLE
chore: bump nix_git

### DIFF
--- a/pkgs/nix-git/version.json
+++ b/pkgs/nix-git/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260615190642-2c25a9a",
-  "rev": "2c25a9aa8c561577922ea158eb372a0e5e832d74",
-  "hash": "sha256-19Ou6fy26SZ1lOo8HPsQ90uGB+jQsMu13Tz1s/ri+qE=",
-  "lastModifiedDate": "20260615190642"
+  "version": "unstable-20260616204454-0048542",
+  "rev": "00485422690332cd1fc96dc6aac6f6da14834bab",
+  "hash": "sha256-g4p64+qmGrnweXwwm0WL/EsJeFj4MPNKXWvLRsvUOts=",
+  "lastModifiedDate": "20260616204454"
 }


### PR DESCRIPTION
Automated package bump for `[
  "nix_git"
]`.