### PR TITLE
chore: bump tde2e_git

### DIFF
--- a/pkgs/telegram-desktop-git/version.json
+++ b/pkgs/telegram-desktop-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260615175454-9cca005",
-  "rev": "9cca0059b5cdc6be94ba355bf91d69d890dfdf75",
-  "hash": "sha256-seEw8oDCje+1rLL9MAdQvmQy8wH+cAVMmt8mK4A2YaU="
+  "version": "unstable-20260617045548-641a43d",
+  "rev": "641a43da654913bfd60288f2ce61da64a73a8dcd",
+  "hash": "sha256-kzfwgb/OOaMUjdktT3/Xcm8nTmiTJmdzK1S5J41HzE8="
 }


### PR DESCRIPTION
Automated package bump for `[
  "tde2e_git",
  "tg-owt_git",
  "telegram-desktop-unwrapped_git",
  "telegram-desktop_git"
]`.