### PR TITLE
chore: bump shadps4_git

### DIFF
--- a/pkgs/shadps4-git/version.json
+++ b/pkgs/shadps4-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260615102824-7de583b",
-  "rev": "7de583b4c396eee6975dd9058a8607b885eafb1b",
-  "hash": "sha256-/o71XGk6IaOwiRPre9+cT5FiVieiQRMDSiBhiy5txhw="
+  "version": "unstable-20260616184707-bc74c60",
+  "rev": "bc74c604eb5596563fb35fc062dfa7184e198cbf",
+  "hash": "sha256-QyBLw2B1XOW8OP8cdAvCUGOLRlkCOWc45SYPlW1VM04="
 }


### PR DESCRIPTION
Automated package bump for `[
  "shadps4_git"
]`.