### PR TITLE
chore: bump libportal_git

### DIFF
--- a/pkgs/libportal-git/version.json
+++ b/pkgs/libportal-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260616003452-383f05e",
-  "rev": "383f05eec54ab217b85032709c7f640d3676ea04",
-  "hash": "sha256-Dxj9tMFd6w7pU/2p5N9mzX1CrRHthN+Ikyfx9wzqCT8="
+  "version": "unstable-20260617010153-aea4c0f",
+  "rev": "aea4c0fbb70255d7683d68fa440e5646810993fd",
+  "hash": "sha256-iTV55AdDF7Io3HU+9JB8h5GffB+sk5VAQPPF7+C5Fco="
 }


### PR DESCRIPTION
Automated package bump for `[
  "libportal_git"
]`.