### PR TITLE
chore: bump libdrm_git

### DIFF
--- a/pkgs/mesa-git/version.json
+++ b/pkgs/mesa-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260616033944-a7575d7",
-  "rev": "a7575d7e981cac410752e047fa7922ef2d8425fa",
-  "hash": "sha256-2piW7fqlMqMt38RwwDYAcyh2h991nau0MD2t1eoK3mU="
+  "version": "unstable-20260616230234-4d92a06",
+  "rev": "4d92a069ff93316aa7fb798ed8317476032c5e49",
+  "hash": "sha256-JsyZNqDpG+UEcHOHvWV12RQ74qz4n48itHTmJcP1RI8="
 }

--- a/pkgs/sway-unwrapped-git/version.json
+++ b/pkgs/sway-unwrapped-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260613095023-47ec005",
-  "rev": "47ec005a58d5f7e63a97c564a4bb877754f68e6f",
-  "hash": "sha256-oAkKstil0j7xMRsof+Idwsy0iF95iMg4wc1wEi+e15E="
+  "version": "unstable-20260616222055-20f70a9",
+  "rev": "20f70a94b320edde1c292e3a5b763a29570224e5",
+  "hash": "sha256-jEVhODvrsALa1xELDwXWHF9hYfDrf10UGpLr6GHvq3E="
 }


### PR DESCRIPTION
Automated package bump for `[
  "libdrm_git",
  "wayland-protocols_git",
  "mesa_git",
  "wayland_git",
  "wlroots_git",
  "sway-unwrapped_git",
  "xdg-desktop-portal-wlr_git"
]`.