### PR TITLE
chore: bump zed-editor_git

### DIFF
--- a/pkgs/zed-editor-git/version.json
+++ b/pkgs/zed-editor-git/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260616035751-c3c38c5",
-  "rev": "c3c38c5c09d887817229b133d904e6eb3f7e7011",
-  "hash": "sha256-qZ4YDvlq1b3F3nSwnHjT4aM5DTT6MNfBMJZen5czyvk=",
-  "cargoHash": "sha256-pqDFYYXCXJQokjBAiMJ6DjPb0ZhSDfP7V/ChAW2SB8I="
+  "version": "unstable-20260617015323-45afbac",
+  "rev": "45afbac0a5ab0d396e316ce0247fd41330c94d88",
+  "hash": "sha256-paNkOKXiNJpzd6ZIwUfkvsclNNaURYWZ9yPT2HPbI0s=",
+  "cargoHash": "sha256-IBcrK/DfK1fVEWEUcDC7xrHQrLUNLDt2S5mesmerqrc="
 }


### PR DESCRIPTION
Automated package bump for `[
  "zed-editor_git"
]`.