### PR TITLE
chore: bump libportal_git

### DIFF
--- a/pkgs/libportal-git/version.json
+++ b/pkgs/libportal-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260617010153-aea4c0f",
-  "rev": "aea4c0fbb70255d7683d68fa440e5646810993fd",
-  "hash": "sha256-iTV55AdDF7Io3HU+9JB8h5GffB+sk5VAQPPF7+C5Fco="
+  "version": "unstable-20260617013325-9489e1d",
+  "rev": "9489e1dfb8d14adf28b75db172d7ce47a3f0349b",
+  "hash": "sha256-F0JOhlQr0ajOiQdzIhpDcxSJNLhc4wSCo1Y3mWM49uU="
 }


### PR DESCRIPTION
Automated package bump for `[
  "libportal_git"
]`.