### PR TITLE
chore: bump proton-cachyos_x86_64_v3

### DIFF
--- a/pkgs/proton-bin/cachyos-v3-version.json
+++ b/pkgs/proton-bin/cachyos-v3-version.json
@@ -1,5 +1,5 @@
 {
   "base": "11.0",
-  "release": "20260601",
-  "hash": "sha256-bxGB0L/MZ0TwZ//rffW52LeD1nWeF4ZK4fIjPPNuAIE="
+  "release": "20260602",
+  "hash": "sha256-g74Xzfp1LKNVyTYssAsTZJl/MN/GScFvLwgMKsBxJYs="
 }


### PR DESCRIPTION
Automated package bump for `[
  "proton-cachyos_x86_64_v3"
]`.