### PR TITLE
chore: bump openrgb_git

### DIFF
--- a/pkgs/openrgb-git/version.json
+++ b/pkgs/openrgb-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260616125228-1339666",
-  "rev": "133966677bd0104a356a34be848fb17b96b24259",
-  "hash": "sha256-f2C9UsICiOM+Mk64lQbHICJm4qFAGy7k1Lc4woYHQyk="
+  "version": "unstable-20260617134501-e7f8bc0",
+  "rev": "e7f8bc013694c04463266f48683324cede067b09",
+  "hash": "sha256-InPvEsXHKntEb/GDR3rwTYHYy0eJ68wHD8wOoaS3yAw="
 }


### PR DESCRIPTION
Automated package bump for `[
  "openrgb_git"
]`.