### PR TITLE
chore: bump nix_git

### DIFF
--- a/pkgs/nix-git/version.json
+++ b/pkgs/nix-git/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260616204454-0048542",
-  "rev": "00485422690332cd1fc96dc6aac6f6da14834bab",
-  "hash": "sha256-g4p64+qmGrnweXwwm0WL/EsJeFj4MPNKXWvLRsvUOts=",
-  "lastModifiedDate": "20260616204454"
+  "version": "unstable-20260618002502-a879081",
+  "rev": "a8790812a02e920a6844940c2bce4211174d886c",
+  "hash": "sha256-aI3AfR2xTK7yC/1mPLKO+ovbbDi3yRXRa39/UFs8VPU=",
+  "lastModifiedDate": "20260618002502"
 }


### PR DESCRIPTION
Automated package bump for `[
  "nix_git"
]`.