### PR TITLE
chore: bump proton-cachyos

### DIFF
--- a/pkgs/proton-bin/cachyos-version.json
+++ b/pkgs/proton-bin/cachyos-version.json
@@ -1,5 +1,5 @@
 {
   "base": "11.0",
-  "release": "20260601",
-  "hash": "sha256-N2bcB4voaFNlRpAyQ6NvDCw/tSwfC5tHXuIPV0+puZs="
+  "release": "20260602",
+  "hash": "sha256-KeYloyihLtG7BzNh4280H+yKYu8KND07vc3vZfwpZAY="
 }


### PR DESCRIPTION
Automated package bump for `[
  "proton-cachyos"
]`.