### PR TITLE
chore: bump spirv-headers_git

### DIFF
--- a/pkgs/spirv-headers-git/version.json
+++ b/pkgs/spirv-headers-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260527154838-1e770e7",
-  "rev": "1e770e7de8373a8dd49f23416cf7ca4001d01040",
-  "hash": "sha256-t8Shkoa90TJt1MbTOefnLaguW4eYKsRFO1Jd0AUc70Y="
+  "version": "unstable-20260617153853-c63848e",
+  "rev": "c63848ecf2200425511319fd8bf2c17b751e501e",
+  "hash": "sha256-SLysXcE16JYuHkv5vq2+mfu6A/K6JbcfKz5/CMzfkmA="
 }


### PR DESCRIPTION
Automated package bump for `[
  "spirv-headers_git"
]`.