### PR TITLE
chore: bump libdrm_git

### DIFF
--- a/pkgs/mesa-git/version.json
+++ b/pkgs/mesa-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260616230234-4d92a06",
-  "rev": "4d92a069ff93316aa7fb798ed8317476032c5e49",
-  "hash": "sha256-JsyZNqDpG+UEcHOHvWV12RQ74qz4n48itHTmJcP1RI8="
+  "version": "unstable-20260618045652-dac0019",
+  "rev": "dac0019373a2a2cb2ed8b68b066b13dd3d822ef2",
+  "hash": "sha256-oa85rBBjPQUosXNd/haWiALtAcGPjXahOMhM4SYg8mQ="
 }


### PR DESCRIPTION
Automated package bump for `[
  "libdrm_git",
  "wayland-protocols_git",
  "mesa_git",
  "wayland_git",
  "wlroots_git",
  "sway-unwrapped_git",
  "xdg-desktop-portal-wlr_git"
]`.