### PR TITLE
chore: bump tde2e_git

### DIFF
--- a/pkgs/telegram-desktop-git/version.json
+++ b/pkgs/telegram-desktop-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260617045548-641a43d",
-  "rev": "641a43da654913bfd60288f2ce61da64a73a8dcd",
-  "hash": "sha256-kzfwgb/OOaMUjdktT3/Xcm8nTmiTJmdzK1S5J41HzE8="
+  "version": "unstable-20260618045721-0152fa2",
+  "rev": "0152fa2aaab8376486be050abe9096ad3fd79772",
+  "hash": "sha256-P2sFVzIIiLFW4fR9Z7c9WG1QuADaNtlFXSjgZ4sUzt4="
 }


### PR DESCRIPTION
Automated package bump for `[
  "tde2e_git",
  "tg-owt_git",
  "telegram-desktop-unwrapped_git",
  "telegram-desktop_git"
]`.