### PR TITLE
chore: bump shadps4_git

### DIFF
--- a/pkgs/shadps4-git/default.nix
+++ b/pkgs/shadps4-git/default.nix
@@ -24,7 +24,22 @@ gitOverride (current: {
     fetchSubmodules = true;
   };
 
-  postOverride = _prevAttrs: {
+  postOverride = prevAttrs: {
+    cmakeFlags = (prevAttrs.cmakeFlags or [ ]) ++ [
+      "-DSPDLOG_FMT_EXTERNAL=ON"
+      "-DENABLE_SYSTEM_LIBRARIES=ON"
+      # ponytail: protobuf 36.0.0 (bundled) needs abseil 20250512.1.
+      # System abseil is 20260107.1 → ABI mismatch at link time.
+      # Provide the matching source so FetchContent skips the network clone.
+      "-DFETCHCONTENT_SOURCE_DIR_ABSL=${
+        final.fetchFromGitHub {
+          owner = "abseil";
+          repo = "abseil-cpp";
+          rev = "20250512.1";
+          hash = "sha256-eB7OqTO9Vwts9nYQ/Mdq0Ds4T1KgmmpYdzU09VPWOhk=";
+        }
+      }"
+    ];
     # Generate COMMIT and SOURCE_DATE_EPOCH in prePatch (before nixpkgs's
     # postPatch uses $(cat COMMIT)). nixpkgs uses postFetch with leaveDotGit
     # because it pins a fixed immutable tag (v.0.13.0). We pin a git rev

--- a/pkgs/shadps4-git/version.json
+++ b/pkgs/shadps4-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260616184707-bc74c60",
-  "rev": "bc74c604eb5596563fb35fc062dfa7184e198cbf",
-  "hash": "sha256-QyBLw2B1XOW8OP8cdAvCUGOLRlkCOWc45SYPlW1VM04="
+  "version": "unstable-20260710135426-cf3bb34",
+  "rev": "cf3bb346bf9d73471e7bb64a8bcafd52f36c3685",
+  "hash": "sha256-fc/eAe1JdSG2M2r5izERsFTBOSxcofuZqkY0Rp5lOZk="
 }


### PR DESCRIPTION
Automated package bump for `[
  "shadps4_git"
]`.