### PR TITLE
chore: bump zed-editor_git

### DIFF
--- a/pkgs/zed-editor-git/version.json
+++ b/pkgs/zed-editor-git/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260617015323-45afbac",
-  "rev": "45afbac0a5ab0d396e316ce0247fd41330c94d88",
-  "hash": "sha256-paNkOKXiNJpzd6ZIwUfkvsclNNaURYWZ9yPT2HPbI0s=",
-  "cargoHash": "sha256-IBcrK/DfK1fVEWEUcDC7xrHQrLUNLDt2S5mesmerqrc="
+  "version": "unstable-20260618024710-6076ce2",
+  "rev": "6076ce27384ca14bb9f6fb8b1218acf1d78f2878",
+  "hash": "sha256-m49veVWAildy6+GJWXcMQa8aNx4dZ1cln+YUzhpZZ40=",
+  "cargoHash": "sha256-uPWBX52bdbM3vkkYurUQtreIgyjk4MJGeRXzhV6J4mQ="
 }


### PR DESCRIPTION
Automated package bump for `[
  "zed-editor_git"
]`.