### PR TITLE
chore: bump nix_git

### DIFF
--- a/pkgs/nix-git/version.json
+++ b/pkgs/nix-git/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260618002502-a879081",
-  "rev": "a8790812a02e920a6844940c2bce4211174d886c",
-  "hash": "sha256-aI3AfR2xTK7yC/1mPLKO+ovbbDi3yRXRa39/UFs8VPU=",
-  "lastModifiedDate": "20260618002502"
+  "version": "unstable-20260619055048-f8bb823",
+  "rev": "f8bb823a23bf6d62f4c8feb792a77702d7a49fe1",
+  "hash": "sha256-eWBQ01zjUjTF6VyWzmt6fN6jI+vlCDtqYaJG1McIKpc=",
+  "lastModifiedDate": "20260619055048"
 }


### PR DESCRIPTION
Automated package bump for `[
  "nix_git"
]`.