### PR TITLE
chore: bump niri_git

### DIFF
--- a/pkgs/niri-git/version.json
+++ b/pkgs/niri-git/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260616053758-fdb6d85",
-  "rev": "fdb6d85fc78355762bcf3cf71fe4037681a766f9",
-  "hash": "sha256-Fw/Zo0hwgn9ulgY5duQy51WHtqpNoLjNDZYLdEI1SS4=",
+  "version": "unstable-20260618111104-49fc611",
+  "rev": "49fc6117fd6c043adaa2ead316b82db5ed735d36",
+  "hash": "sha256-Ii/koEm/sRyg65qbAQWqEgboSEIhdH0EL4KglAc14p0=",
   "cargoHash": "sha256-jGORNwJ/F9UrajObXdGLbOTGEpCv919puUuWojbuVwo="
 }


### PR DESCRIPTION
Automated package bump for `[
  "niri_git"
]`.