### PR TITLE
chore: bump tde2e_git

### DIFF
--- a/pkgs/telegram-desktop-git/version.json
+++ b/pkgs/telegram-desktop-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260618045721-0152fa2",
-  "rev": "0152fa2aaab8376486be050abe9096ad3fd79772",
-  "hash": "sha256-P2sFVzIIiLFW4fR9Z7c9WG1QuADaNtlFXSjgZ4sUzt4="
+  "version": "unstable-20260619082145-cb97504",
+  "rev": "cb9750427f57e5518ddb8a0fda9f0bb2291c487f",
+  "hash": "sha256-zKIazcb/DSw+NrMpQIcTG7z+Kt9y1GnSU2sjfCThVOE="
 }


### PR DESCRIPTION
Automated package bump for `[
  "tde2e_git",
  "tg-owt_git",
  "telegram-desktop-unwrapped_git",
  "telegram-desktop_git"
]`.