### PR TITLE
chore: bump zed-editor_git

### DIFF
--- a/pkgs/zed-editor-git/version.json
+++ b/pkgs/zed-editor-git/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260618024710-6076ce2",
-  "rev": "6076ce27384ca14bb9f6fb8b1218acf1d78f2878",
-  "hash": "sha256-m49veVWAildy6+GJWXcMQa8aNx4dZ1cln+YUzhpZZ40=",
-  "cargoHash": "sha256-uPWBX52bdbM3vkkYurUQtreIgyjk4MJGeRXzhV6J4mQ="
+  "version": "unstable-20260619110707-cc3d4d5",
+  "rev": "cc3d4d58aed840fcdd970efb6c98db80119a7e36",
+  "hash": "sha256-wmD6FKKSjIi8I6fJPVbXVzvwfbx3FRpRXKYty4mYHy0=",
+  "cargoHash": "sha256-9KzH06CzImFgy1Mj/ZB5WPHb4CBnUgPExGv8pdlIZGU="
 }


### PR DESCRIPTION
Automated package bump for `[
  "zed-editor_git"
]`.