### PR TITLE
chore: bump libdrm_git

### DIFF
--- a/pkgs/mesa-git/version.json
+++ b/pkgs/mesa-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260618045652-dac0019",
-  "rev": "dac0019373a2a2cb2ed8b68b066b13dd3d822ef2",
-  "hash": "sha256-oa85rBBjPQUosXNd/haWiALtAcGPjXahOMhM4SYg8mQ="
+  "version": "unstable-20260619104924-ad4e3ca",
+  "rev": "ad4e3cad54dde5fbb97483d51a325039ab18fce2",
+  "hash": "sha256-Ef0Off0biTat4TBpxlsEK8zYZ1c7vzBVub/CtNjjPrY="
 }

--- a/pkgs/portal-wlr-git/version.json
+++ b/pkgs/portal-wlr-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260426075025-5b047df",
-  "rev": "5b047df2492d6772df2089835b579f34ab4048b7",
-  "hash": "sha256-R0oeuca9HmgeOkZpFpOwl7M3zZ1+DJgsTVcIxhr7L34="
+  "version": "unstable-20260618151856-a2e0d1e",
+  "rev": "a2e0d1e735bafefe115359de3505f51d814cd09a",
+  "hash": "sha256-T7iV0lIZO8rY36iafAtt1Ias44QkNZd1+GRLE6frYDo="
 }

--- a/pkgs/sway-unwrapped-git/version.json
+++ b/pkgs/sway-unwrapped-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260616222055-20f70a9",
-  "rev": "20f70a94b320edde1c292e3a5b763a29570224e5",
-  "hash": "sha256-jEVhODvrsALa1xELDwXWHF9hYfDrf10UGpLr6GHvq3E="
+  "version": "unstable-20260618155929-9727113",
+  "rev": "9727113c60b8b17efe63095349c7d38c59d450ab",
+  "hash": "sha256-lQ6yJfVdGEawMqMlyEIdHaD3brFHVi12kEnoJuCBk6A="
 }


### PR DESCRIPTION
Automated package bump for `[
  "libdrm_git",
  "wayland-protocols_git",
  "mesa_git",
  "wayland_git",
  "wlroots_git",
  "sway-unwrapped_git",
  "xdg-desktop-portal-wlr_git"
]`.