### PR TITLE
chore: bump helix_git

### DIFF
--- a/pkgs/helix-git/version.json
+++ b/pkgs/helix-git/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260614070240-43bf7c2",
-  "rev": "43bf7c2dc219606c64003aef21151f49f48d0939",
-  "hash": "sha256-XRjbG1piXMR2fHrxcavz/UEIIDuDXPgwlu+2089qROU=",
+  "version": "unstable-20260618151545-460d3be",
+  "rev": "460d3be574a514d327ea5e55a50dc4fea67d60fc",
+  "hash": "sha256-8fIyIlwnYzeNi0up1MXbUoVO0TGHALNtNwL1k0L/C6c=",
   "cargoHash": "sha256-mRt05s72hjpv9GkDy1FaVPWmyEtlwRsPn3UymXCSC2c="
 }


### PR DESCRIPTION
Automated package bump for `[
  "helix_git"
]`.