### PR TITLE
flake: move third-party flakes to eval-time

### DIFF
--- a/.github/workflows/flakes-bump.yml
+++ b/.github/workflows/flakes-bump.yml
@@ -47,11 +47,17 @@ jobs:
 
           git checkout -b "$BRANCH_NAME"
 
+          OLD_COMMIT=$(git rev-parse HEAD)
+
           nix flake update || exit 1
-          git diff --exit-code flake.lock && exit 0
+          git diff --exit-code flake.lock
 
           git add -A
           git commit -m "flakes: bump $DATE"
+
+          vendor/update.sh
+
+          [ "$(git rev-parse HEAD)" == "$OLD_COMMIT" ] && exit 0
 
           # Check against remote branch: Is this exact state already pushed?
           if git ls-remote --exit-code --heads origin "$BRANCH_NAME" > /dev/null; then

--- a/flake.lock
+++ b/flake.lock
@@ -34,49 +34,6 @@
         "type": "github"
       }
     },
-    "jovian": {
-      "inputs": {
-        "nix-github-actions": [],
-        "nixpkgs": [
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1781714346,
-        "narHash": "sha256-eSkLPid3Pb7ki5OivCp0UQIVSZHgs35lR93IBbS06oY=",
-        "owner": "Jovian-Experiments",
-        "repo": "Jovian-NixOS",
-        "rev": "928678675f4093383a0503b0e6c2f9965fe37309",
-        "type": "github"
-      },
-      "original": {
-        "owner": "Jovian-Experiments",
-        "repo": "Jovian-NixOS",
-        "type": "github"
-      }
-    },
-    "niks3": {
-      "inputs": {
-        "nixpkgs": [
-          "nixpkgs"
-        ],
-        "treefmt-nix": []
-      },
-      "locked": {
-        "lastModified": 1781027181,
-        "narHash": "sha256-IHIUd1/lYTaS4ilHZNV6+x0fchxDpvUdMjwnnEBASu4=",
-        "owner": "Mic92",
-        "repo": "niks3",
-        "rev": "c74d275536d9a38ff279b498612fae0fd68cfe85",
-        "type": "github"
-      },
-      "original": {
-        "owner": "Mic92",
-        "repo": "niks3",
-        "rev": "c74d275536d9a38ff279b498612fae0fd68cfe85",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1781577229,
@@ -97,30 +54,7 @@
       "inputs": {
         "flake-schemas": "flake-schemas",
         "home-manager": "home-manager",
-        "jovian": "jovian",
-        "niks3": "niks3",
-        "nixpkgs": "nixpkgs",
-        "rust-overlay": "rust-overlay"
-      }
-    },
-    "rust-overlay": {
-      "inputs": {
-        "nixpkgs": [
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1781752752,
-        "narHash": "sha256-kVG5tV9hddPviGAgqf9sGSuStvv+HAB9onfKqGptV0k=",
-        "owner": "oxalica",
-        "repo": "rust-overlay",
-        "rev": "c06d86dabe5b92982b9d67acccb9990d58da3a0e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "oxalica",
-        "repo": "rust-overlay",
-        "type": "github"
+        "nixpkgs": "nixpkgs"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -9,34 +9,15 @@
       url = "github:nix-community/home-manager";
       inputs.nixpkgs.follows = "nixpkgs";
     };
-    # Third-party republished repositories
-    jovian = {
-      url = "github:Jovian-Experiments/Jovian-NixOS";
-      inputs = {
-        nixpkgs.follows = "nixpkgs";
-        nix-github-actions.follows = ""; # https://github.com/NixOS/nix/issues/7807
-      };
-    };
     # Used by "schemas" output (for FlakeHub and "nix show", pinned)
     flake-schemas.url = "https://flakehub.com/f/DeterminateSystems/flake-schemas/=0.1.5.tar.gz";
-    # Newer rustc
-    rust-overlay = {
-      url = "github:oxalica/rust-overlay";
-      inputs.nixpkgs.follows = "nixpkgs";
-    };
-    # Pinned to the version we're using (sorry to forward this to your locks, we need it cached)
-    niks3 = {
-      url = "github:Mic92/niks3/c74d275536d9a38ff279b498612fae0fd68cfe85";
-      inputs = {
-        nixpkgs.follows = "nixpkgs";
-        treefmt-nix.follows = ""; # https://github.com/NixOS/nix/issues/7807
-      };
-    };
   };
 
   outputs =
     { self, nixpkgs, ... }@inputs:
     let
+      flakes = (import ./vendor) // inputs;
+
       eachSystem =
         accu: system:
         let
@@ -75,7 +56,7 @@
             // (
               if system == "x86_64-linux" then
                 {
-                  ${system} = import ./checks inputs pkgs;
+                  ${system} = import ./checks flakes pkgs;
                 }
               else
                 { }
@@ -90,13 +71,13 @@
 
       universals = {
         # To fix `nix show` and FlakeHub
-        schemas = import ./maintenance/schemas { flakes = inputs; };
+        schemas = import ./maintenance/schemas { inherit flakes; };
 
         # The stars: our overlay and our modules.
-        overlays.default = import ./overlays { flakes = inputs; };
-        overlays.cache-friendly = import ./overlays/cache-friendly.nix { flakes = inputs; };
-        nixosModules = import ./modules/nixos { flakes = inputs; };
-        homeModules = import ./modules/home-manager { flakes = inputs; };
+        overlays.default = import ./overlays { inherit flakes; };
+        overlays.cache-friendly = import ./overlays/cache-friendly.nix { inherit flakes; };
+        nixosModules = import ./modules/nixos { inherit flakes; };
+        homeModules = import ./modules/home-manager { inherit flakes; };
         homeManagerModules = self.homeModules;
 
         # Dev stuff.

--- a/flake.nix
+++ b/flake.nix
@@ -29,12 +29,6 @@
           legacyPackages = (accu.legacyPackages or { }) // {
             ${system} = accu.utils.applyOverlay { inherit pkgs; };
           };
-          packages = (accu.packages or { }) // {
-            ${system} = accu.utils.applyOverlay {
-              inherit pkgs;
-              onlyDerivations = true;
-            };
-          };
 
           # Needed to build without impure
           unrestrictedPackages = (accu.unrestrictedPackages or { }) // {

--- a/maintenance/flake.nix
+++ b/maintenance/flake.nix
@@ -1,12 +1,12 @@
 {
   inputs = {
     chaotic.url = "../";
-    compare-to.url = "../";
+    compare-to.follows = "chaotic";
     systems.url = "github:nix-systems/default";
     yafas = {
       url = "github:UbiqueLambda/yafas";
       inputs.systems.follows = "systems";
-      inputs.flake-schemas.follows = "chaotic/flake-schemas";
+      inputs.flake-schemas.follows = "";
     };
   };
   outputs =

--- a/shared/utils.nix
+++ b/shared/utils.nix
@@ -10,7 +10,6 @@ rec {
       merge ? false,
       overlay ? nyxOverlay,
       nyxPkgs ? null,
-      onlyDerivations ? false,
       pkgs,
     }:
     let
@@ -19,14 +18,8 @@ rec {
         callPackage = pkgs.newScope overlayFinal;
       };
       ourPackages = if nyxPkgs != null then nyxPkgs else overlay overlayFinal pkgs;
-      preFilter = if merge then overlayFinal else ourPackages;
     in
-    if onlyDerivations then
-      pkgs.lib.attrsets.filterAttrs (
-        _k: v: (builtins.tryEval v).success && pkgs.lib.attrsets.isDerivation v
-      ) preFilter
-    else
-      preFilter;
+    if merge then overlayFinal else ourPackages;
 
   # When `removeByBaseName` and `removeByURL` can't help, use this to drop patches.
   dropN = qty: list: lib.lists.take (builtins.length list - qty) list;

--- a/vendor/default.nix
+++ b/vendor/default.nix
@@ -1,0 +1,14 @@
+let
+  fetchFlake =
+    {
+      url,
+      lock,
+      ...
+    }:
+    builtins.getFlake (builtins.unsafeDiscardStringContext "${url}${lock}");
+
+  forEachFlake =
+    name: _directory_or_regular:
+    fetchFlake (builtins.fromJSON (builtins.readFile ./flakes/${name}/version.json));
+in
+builtins.mapAttrs forEachFlake (builtins.readDir ./flakes)

--- a/vendor/flakes/jovian/version.json
+++ b/vendor/flakes/jovian/version.json
@@ -1,0 +1,4 @@
+{
+  "url": "github:Jovian-Experiments/Jovian-NixOS",
+  "lock": "/ee34630ec857335f2fb6a832f10c09724db2c467?narHash=sha256-1cz2lhRJTeodLB3fycZmMl7x6X5hiyu2MV8CixGM2qc%3D"
+}

--- a/vendor/flakes/niks3/version.json
+++ b/vendor/flakes/niks3/version.json
@@ -1,0 +1,4 @@
+{
+  "url": "github:Mic92/niks3",
+  "lock": "/c74d275536d9a38ff279b498612fae0fd68cfe85?narHash=sha256-IHIUd1/lYTaS4ilHZNV6%2Bx0fchxDpvUdMjwnnEBASu4%3D"
+}

--- a/vendor/flakes/rust-overlay/version.json
+++ b/vendor/flakes/rust-overlay/version.json
@@ -1,0 +1,4 @@
+{
+  "url": "github:oxalica/rust-overlay",
+  "lock": "/4baecb43a008cd004e5220a777e1724bd8d43e43?narHash=sha256-UL/f%2B%2B6fbg1MSC63NSynUVsww%2BDSay0N5TsbFzLZIsQ%3D"
+}

--- a/vendor/update.sh
+++ b/vendor/update.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+function eachFlake() {
+  # Define your target file
+  FILE="vendor/flakes/$1/version.json"
+
+  # Extract the base URL
+  BASE_URL=$(jq -r '.url' "$FILE")
+  OLD_LOCK=$(jq -r '.lock' "$FILE")
+
+  # Fetch the fresh metadata
+  NEW_METADATA=$(nix flake metadata --json "$BASE_URL")
+
+  # Get the new full URL from metadata
+  NEW_URL=$(printf "%s\n" "$NEW_METADATA" | jq -r '.url')
+
+  # Strip the base URL to isolate the lock string
+  NEW_LOCK="${NEW_URL#"$BASE_URL"}"
+
+  # Skip the rest when already up-to-date
+  if [ "$NEW_LOCK" = "$OLD_LOCK" ]; then
+    return 0
+  fi
+
+  # Fetch the old metadata
+  OLD_METADATA=$(nix flake metadata --json "$BASE_URL$OLD_LOCK")
+
+  # Update the JSON file
+  OLD_FILE=$(cat "$FILE")
+  printf "%s\n" "$OLD_FILE" | jq --arg lock "$NEW_LOCK" '.lock = $lock' >"$FILE"
+
+  # Commit
+  git add "$FILE"
+  git commit -m "$1: $(printf "%s\n" "$OLD_METADATA" | jq -r '.lastModified') -> $(printf "%s\n" "$NEW_METADATA" | jq -r '.lastModified')"
+}
+
+if [ -n "${1:-}" ]; then
+  eachFlake "$@"
+else
+  for f in vendor/flakes/*; do
+    [ "$f" = 'vendor/flakes/*' ] && continue
+    [ -e "$f/pin" ] && continue
+    eachFlake "$(basename "$f")"
+  done
+fi
+
+exit 0


### PR DESCRIPTION
### :fish: What?

1. Replaces https://github.com/chaotic-cx/nyx/pull/1492;
2. move third-party flakes to eval-time.

### :fishing_pole_and_fish: Why?

Reduces everyone's flake.lock.

### :fish_cake: Pending

- [x] Auto-updater.
