### PR TITLE
chore: bump pcsx2_git

### DIFF
--- a/pkgs/pcsx2-git/version.json
+++ b/pkgs/pcsx2-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260616004159-cd9530e",
-  "rev": "cd9530eec3d4733c56f394da185c64b3bb2eb294",
-  "hash": "sha256-leNzU4meb7VDgoOB1U/udgJmV+kacTvmAmXzprX0gjM="
+  "version": "unstable-20260619214042-342db51",
+  "rev": "342db51523f288c5ced20f5be3c679f46472cc45",
+  "hash": "sha256-DhFOf9nlB2NIJlRUD2UnJRYiTa7CA1ciKjF7QT1KPec="
 }


### PR DESCRIPTION
Automated package bump for `[
  "pcsx2_git"
]`.