### PR TITLE
chore: bump libdrm_git

### DIFF
--- a/pkgs/mesa-git/version.json
+++ b/pkgs/mesa-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260619104924-ad4e3ca",
-  "rev": "ad4e3cad54dde5fbb97483d51a325039ab18fce2",
-  "hash": "sha256-Ef0Off0biTat4TBpxlsEK8zYZ1c7vzBVub/CtNjjPrY="
+  "version": "unstable-20260620000322-27e63a9",
+  "rev": "27e63a959ee44b7b18bce07cb32d7f3c6a08fb4b",
+  "hash": "sha256-+/4felAVeroa/YqoxrllUeqa4BU5U5MfWQ7H8rkHvbM="
 }


### PR DESCRIPTION
Automated package bump for `[
  "libdrm_git",
  "wayland-protocols_git",
  "mesa_git",
  "wayland_git",
  "wlroots_git",
  "sway-unwrapped_git",
  "xdg-desktop-portal-wlr_git"
]`.