### PR TITLE
chore: bump zed-editor_git

### DIFF
--- a/pkgs/zed-editor-git/version.json
+++ b/pkgs/zed-editor-git/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260619110707-cc3d4d5",
-  "rev": "cc3d4d58aed840fcdd970efb6c98db80119a7e36",
-  "hash": "sha256-wmD6FKKSjIi8I6fJPVbXVzvwfbx3FRpRXKYty4mYHy0=",
-  "cargoHash": "sha256-9KzH06CzImFgy1Mj/ZB5WPHb4CBnUgPExGv8pdlIZGU="
+  "version": "unstable-20260619224934-9f56a4d",
+  "rev": "9f56a4df515c9989bf0baa71c2150408cce0608e",
+  "hash": "sha256-l31Z5RRgHURaLul9KTFy1PhsR5D3FS8A9xYMjsXAZic=",
+  "cargoHash": "sha256-a1yXyXopEBh0o73ztlNa1sSY6PIZ95USKH236cGoLyg="
 }


### PR DESCRIPTION
Automated package bump for `[
  "zed-editor_git"
]`.