### PR TITLE
chore: bump zed-editor_git

### DIFF
--- a/pkgs/zed-editor-git/version.json
+++ b/pkgs/zed-editor-git/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260619224934-9f56a4d",
-  "rev": "9f56a4df515c9989bf0baa71c2150408cce0608e",
-  "hash": "sha256-l31Z5RRgHURaLul9KTFy1PhsR5D3FS8A9xYMjsXAZic=",
+  "version": "unstable-20260620224015-50e6411",
+  "rev": "50e6411571398f007863dfa8fc3a5e2737d7290a",
+  "hash": "sha256-RJBkwo/KFSJQ8IpTbtxbnwsjCr0yviHHw0PM1B4/C1A=",
   "cargoHash": "sha256-a1yXyXopEBh0o73ztlNa1sSY6PIZ95USKH236cGoLyg="
 }


### PR DESCRIPTION
Automated package bump for `[
  "zed-editor_git"
]`.