### PR TITLE
chore: bump pcsx2_git

### DIFF
--- a/pkgs/pcsx2-git/version.json
+++ b/pkgs/pcsx2-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260619214042-342db51",
-  "rev": "342db51523f288c5ced20f5be3c679f46472cc45",
-  "hash": "sha256-DhFOf9nlB2NIJlRUD2UnJRYiTa7CA1ciKjF7QT1KPec="
+  "version": "unstable-20260620231752-8e73dea",
+  "rev": "8e73dea7e26079171cdebe6985a77a2d39132e6f",
+  "hash": "sha256-VzAGyyLLfVerS+Y1utQMQcYPPQW99xoKHzx5RFEtczE="
 }


### PR DESCRIPTION
Automated package bump for `[
  "pcsx2_git"
]`.