### PR TITLE
chore: bump libdrm_git

### DIFF
--- a/pkgs/mesa-git/version.json
+++ b/pkgs/mesa-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260620000322-27e63a9",
-  "rev": "27e63a959ee44b7b18bce07cb32d7f3c6a08fb4b",
-  "hash": "sha256-+/4felAVeroa/YqoxrllUeqa4BU5U5MfWQ7H8rkHvbM="
+  "version": "unstable-20260621015354-4a6f6dd",
+  "rev": "4a6f6dd266cce89912d1eb093f141753626ef795",
+  "hash": "sha256-yae1fFl1oKouVG0sI18yv2a3/FF7bWzbnush25va9nk="
 }

--- a/pkgs/wlroots-git/version.json
+++ b/pkgs/wlroots-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260613095946-f141edc",
-  "rev": "f141edcd0233d86d9e9aab605b2b6f0803be5e98",
-  "hash": "sha256-sDKLKhYKUFxL6TlaWIVo3GVCNy3zJewFjkxbCBCqUgc="
+  "version": "unstable-20260620180532-c3f7587",
+  "rev": "c3f75870689ce577f5bf405f9c372eca448b5c36",
+  "hash": "sha256-y426IIIcok5p4eXo7eHDetYrKGXvGWeP7ASBctAgC9I="
 }


### PR DESCRIPTION
Automated package bump for `[
  "libdrm_git",
  "wayland-protocols_git",
  "mesa_git",
  "wayland_git",
  "wlroots_git",
  "sway-unwrapped_git",
  "xdg-desktop-portal-wlr_git"
]`.