### PR TITLE
chore: bump helix_git

### DIFF
--- a/pkgs/helix-git/version.json
+++ b/pkgs/helix-git/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260618151545-460d3be",
-  "rev": "460d3be574a514d327ea5e55a50dc4fea67d60fc",
-  "hash": "sha256-8fIyIlwnYzeNi0up1MXbUoVO0TGHALNtNwL1k0L/C6c=",
-  "cargoHash": "sha256-mRt05s72hjpv9GkDy1FaVPWmyEtlwRsPn3UymXCSC2c="
+  "version": "unstable-20260620161004-d2fdf3f",
+  "rev": "d2fdf3f3c788f8fb715caf6d2f94d71b984da6cd",
+  "hash": "sha256-sZ3m0vu/qNIip9S+fm/6LwvgwJNRNFzdozg95oFKfgg=",
+  "cargoHash": "sha256-iWamCgLSHCU2EVPkGzGksjFf7zNuYcTcRV6riLRPPUY="
 }


### PR DESCRIPTION
Automated package bump for `[
  "helix_git"
]`.