### PR TITLE
chore: bump nix_git

### DIFF
--- a/pkgs/nix-git/version.json
+++ b/pkgs/nix-git/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260619055048-f8bb823",
-  "rev": "f8bb823a23bf6d62f4c8feb792a77702d7a49fe1",
-  "hash": "sha256-eWBQ01zjUjTF6VyWzmt6fN6jI+vlCDtqYaJG1McIKpc=",
-  "lastModifiedDate": "20260619055048"
+  "version": "unstable-20260622043203-4e882f2",
+  "rev": "4e882f28706af52a4925bc9c25c54dab62f4deb7",
+  "hash": "sha256-AkebrMdFatWh0K7vWWSnv+qEwgsv+QdpS+XHp7PhAik=",
+  "lastModifiedDate": "20260622043203"
 }


### PR DESCRIPTION
Automated package bump for `[
  "nix_git"
]`.