### PR TITLE
chore: bump openrgb_git

### DIFF
--- a/pkgs/openrgb-git/version.json
+++ b/pkgs/openrgb-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260617134501-e7f8bc0",
-  "rev": "e7f8bc013694c04463266f48683324cede067b09",
-  "hash": "sha256-InPvEsXHKntEb/GDR3rwTYHYy0eJ68wHD8wOoaS3yAw="
+  "version": "unstable-20260622031749-b508818",
+  "rev": "b508818f23409c55f8460d61de811879c1fc4951",
+  "hash": "sha256-VLYfVExmUrHKasoLfwfxYNuGR45/30fGb6WcephGV0M="
 }


### PR DESCRIPTION
Automated package bump for `[
  "openrgb_git"
]`.