### PR TITLE
chore: bump zed-editor_git

### DIFF
--- a/pkgs/zed-editor-git/version.json
+++ b/pkgs/zed-editor-git/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260620224015-50e6411",
-  "rev": "50e6411571398f007863dfa8fc3a5e2737d7290a",
-  "hash": "sha256-RJBkwo/KFSJQ8IpTbtxbnwsjCr0yviHHw0PM1B4/C1A=",
+  "version": "unstable-20260622032908-c0945a8",
+  "rev": "c0945a82018c11f09bae41bbc7035f4b07568a8f",
+  "hash": "sha256-KSWfDk2G6dLU70LJw71Yi89eRfndL+w0cez9KDLRxmc=",
   "cargoHash": "sha256-a1yXyXopEBh0o73ztlNa1sSY6PIZ95USKH236cGoLyg="
 }


### PR DESCRIPTION
Automated package bump for `[
  "zed-editor_git"
]`.