### PR TITLE
chore: bump libdrm_git

### DIFF
--- a/pkgs/mesa-git/version.json
+++ b/pkgs/mesa-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260621015354-4a6f6dd",
-  "rev": "4a6f6dd266cce89912d1eb093f141753626ef795",
-  "hash": "sha256-yae1fFl1oKouVG0sI18yv2a3/FF7bWzbnush25va9nk="
+  "version": "unstable-20260621233608-dc1db53",
+  "rev": "dc1db5367ef1245498d2d0fc74637a9e56e22f0d",
+  "hash": "sha256-MdCapJ0WOPCICeBzOqx4uKsF2U/+TQ9nvOa/ZZvIUmI="
 }

--- a/pkgs/sway-unwrapped-git/version.json
+++ b/pkgs/sway-unwrapped-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260618155929-9727113",
-  "rev": "9727113c60b8b17efe63095349c7d38c59d450ab",
-  "hash": "sha256-lQ6yJfVdGEawMqMlyEIdHaD3brFHVi12kEnoJuCBk6A="
+  "version": "unstable-20260621092819-ca71b4c",
+  "rev": "ca71b4c80f609c637288303625a284f821ecc312",
+  "hash": "sha256-5bX7kMcPOINH937IEqY2sV84SSkrIYVhbVSfasd0R/Q="
 }

--- a/pkgs/wlroots-git/version.json
+++ b/pkgs/wlroots-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260620180532-c3f7587",
-  "rev": "c3f75870689ce577f5bf405f9c372eca448b5c36",
-  "hash": "sha256-y426IIIcok5p4eXo7eHDetYrKGXvGWeP7ASBctAgC9I="
+  "version": "unstable-20260621091723-6dcc061",
+  "rev": "6dcc061a7946430428c82cdb2609aeb1956eafa8",
+  "hash": "sha256-POJnZYG1Vu1Vi+Lc9qlSpz6HHJ5U4g1cqJhJsnoXNVs="
 }


### PR DESCRIPTION
Automated package bump for `[
  "libdrm_git",
  "wayland-protocols_git",
  "mesa_git",
  "wayland_git",
  "wlroots_git",
  "sway-unwrapped_git",
  "xdg-desktop-portal-wlr_git"
]`.