### PR TITLE
chore: bump helix_git

### DIFF
--- a/pkgs/helix-git/version.json
+++ b/pkgs/helix-git/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260620161004-d2fdf3f",
-  "rev": "d2fdf3f3c788f8fb715caf6d2f94d71b984da6cd",
-  "hash": "sha256-sZ3m0vu/qNIip9S+fm/6LwvgwJNRNFzdozg95oFKfgg=",
+  "version": "unstable-20260621215730-9a07a82",
+  "rev": "9a07a8267975be5c6fa579244d8b4119d48d8977",
+  "hash": "sha256-Du+gsn1qldac2+x5+NWPsiwZaMUZ4G2Ux0tjk/x8bew=",
   "cargoHash": "sha256-iWamCgLSHCU2EVPkGzGksjFf7zNuYcTcRV6riLRPPUY="
 }


### PR DESCRIPTION
Automated package bump for `[
  "helix_git"
]`.