### PR TITLE
chore: bump openrgb_git

### DIFF
--- a/pkgs/openrgb-git/version.json
+++ b/pkgs/openrgb-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260622031749-b508818",
-  "rev": "b508818f23409c55f8460d61de811879c1fc4951",
-  "hash": "sha256-VLYfVExmUrHKasoLfwfxYNuGR45/30fGb6WcephGV0M="
+  "version": "unstable-20260623014953-39343c3",
+  "rev": "39343c3e9ed2781763618fca4f6156c99246a0cd",
+  "hash": "sha256-6zMQ2Q/guf7AcaQMl0GJ562hkh/YVFtQgUabrWq2Y4c="
 }


### PR DESCRIPTION
Automated package bump for `[
  "openrgb_git"
]`.