### PR TITLE
chore: bump pcsx2_git

### DIFF
--- a/pkgs/pcsx2-git/version.json
+++ b/pkgs/pcsx2-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260620231752-8e73dea",
-  "rev": "8e73dea7e26079171cdebe6985a77a2d39132e6f",
-  "hash": "sha256-VzAGyyLLfVerS+Y1utQMQcYPPQW99xoKHzx5RFEtczE="
+  "version": "unstable-20260623011335-9553521",
+  "rev": "95535215aa8be77ee0bb1556d940a761d895abb6",
+  "hash": "sha256-e6M88/GEds6epknV6jg9sKq8j649m1WIQ+t4Eg6FSO0="
 }


### PR DESCRIPTION
Automated package bump for `[
  "pcsx2_git"
]`.