### PR TITLE
chore: bump zed-editor_git

### DIFF
--- a/pkgs/zed-editor-git/version.json
+++ b/pkgs/zed-editor-git/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260622032908-c0945a8",
-  "rev": "c0945a82018c11f09bae41bbc7035f4b07568a8f",
-  "hash": "sha256-KSWfDk2G6dLU70LJw71Yi89eRfndL+w0cez9KDLRxmc=",
-  "cargoHash": "sha256-a1yXyXopEBh0o73ztlNa1sSY6PIZ95USKH236cGoLyg="
+  "version": "unstable-20260622235922-14f9b9d",
+  "rev": "14f9b9d077ea4de768408aa3bed285baacea13b0",
+  "hash": "sha256-oQH6WyVSj1pw6WvHc2Yebm0J1Md15xZd48DuAg7zkco=",
+  "cargoHash": "sha256-iGWiEE1nuiHZblJhTkyHUm27AQ1/a2b87oWHET9ASyk="
 }


### PR DESCRIPTION
Automated package bump for `[
  "zed-editor_git"
]`.