### PR TITLE
chore: bump nix_git

### DIFF
--- a/pkgs/nix-git/version.json
+++ b/pkgs/nix-git/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260622043203-4e882f2",
-  "rev": "4e882f28706af52a4925bc9c25c54dab62f4deb7",
-  "hash": "sha256-AkebrMdFatWh0K7vWWSnv+qEwgsv+QdpS+XHp7PhAik=",
-  "lastModifiedDate": "20260622043203"
+  "version": "unstable-20260622225014-0fe449f",
+  "rev": "0fe449f99d6bd164514ed2ca1ab81fde4a31032e",
+  "hash": "sha256-3oMtSrhOv3so3WrIs8k3CLpg6FEB5OYGvT9i/wGJQd8=",
+  "lastModifiedDate": "20260622225014"
 }


### PR DESCRIPTION
Automated package bump for `[
  "nix_git"
]`.