### PR TITLE
chore: bump tde2e_git

### DIFF
--- a/pkgs/telegram-desktop-git/version.json
+++ b/pkgs/telegram-desktop-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260619082145-cb97504",
-  "rev": "cb9750427f57e5518ddb8a0fda9f0bb2291c487f",
-  "hash": "sha256-zKIazcb/DSw+NrMpQIcTG7z+Kt9y1GnSU2sjfCThVOE="
+  "version": "unstable-20260623025010-1520a81",
+  "rev": "1520a810ac5d665395d2dfdcaa3f17a151ea079a",
+  "hash": "sha256-5GF26vktepBw1g56ahmS0R9+O0aflgWKn42AtZzX8Pw="
 }


### PR DESCRIPTION
Automated package bump for `[
  "tde2e_git",
  "tg-owt_git",
  "telegram-desktop-unwrapped_git",
  "telegram-desktop_git"
]`.