### PR TITLE
chore: bump libdrm_git

### DIFF
--- a/pkgs/mesa-git/version.json
+++ b/pkgs/mesa-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260621233608-dc1db53",
-  "rev": "dc1db5367ef1245498d2d0fc74637a9e56e22f0d",
-  "hash": "sha256-MdCapJ0WOPCICeBzOqx4uKsF2U/+TQ9nvOa/ZZvIUmI="
+  "version": "unstable-20260623021850-475efed",
+  "rev": "475efed859b667388d60df1f4c1df2f0af7ac8c0",
+  "hash": "sha256-GQLyzkvIGRLleQwsHegzUfUaVE26od00C8gk7g2xNgk="
 }

--- a/pkgs/wlroots-git/version.json
+++ b/pkgs/wlroots-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260621091723-6dcc061",
-  "rev": "6dcc061a7946430428c82cdb2609aeb1956eafa8",
-  "hash": "sha256-POJnZYG1Vu1Vi+Lc9qlSpz6HHJ5U4g1cqJhJsnoXNVs="
+  "version": "unstable-20260622151852-29fc556",
+  "rev": "29fc556f4cd70896e464b3402b510d9759707cf8",
+  "hash": "sha256-hn2gbw+QMHQ1lpJp9xxleHEmD+w8FRHnQAwlCu+U8Go="
 }


### PR DESCRIPTION
Automated package bump for `[
  "libdrm_git",
  "wayland-protocols_git",
  "mesa_git",
  "wayland_git",
  "wlroots_git",
  "sway-unwrapped_git",
  "xdg-desktop-portal-wlr_git"
]`.