### PR TITLE
chore: bump helix_git

### DIFF
--- a/pkgs/helix-git/version.json
+++ b/pkgs/helix-git/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260621215730-9a07a82",
-  "rev": "9a07a8267975be5c6fa579244d8b4119d48d8977",
-  "hash": "sha256-Du+gsn1qldac2+x5+NWPsiwZaMUZ4G2Ux0tjk/x8bew=",
+  "version": "unstable-20260622154709-3707874",
+  "rev": "37078743189f197f49563aab8f0b43badcb95897",
+  "hash": "sha256-j3KTtnnlWcCkhLsRJe5uTT8BmrX4vs6zgIakLb+wV90=",
   "cargoHash": "sha256-iWamCgLSHCU2EVPkGzGksjFf7zNuYcTcRV6riLRPPUY="
 }


### PR DESCRIPTION
Automated package bump for `[
  "helix_git"
]`.