### PR TITLE
chore: bump proton-ge-custom

### DIFF
--- a/pkgs/proton-bin/ge-version.json
+++ b/pkgs/proton-bin/ge-version.json
@@ -1,5 +1,5 @@
 {
-  "base": "10",
-  "release": "34",
-  "hash": "sha256-UcWAtmqDPHOZj+APBxfurFcZdlQECi8u1RiePuaNdz0="
+  "base": "11",
+  "release": "1",
+  "hash": "sha256-zm3WY+oBcloxgF7VwWVyOiU83wlFpmQpBzMHQq4t5eQ="
 }


### PR DESCRIPTION
Automated package bump for `[
  "proton-ge-custom"
]`.