### PR TITLE
chore: bump openrgb_git

### DIFF
--- a/pkgs/openrgb-git/version.json
+++ b/pkgs/openrgb-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260623014953-39343c3",
-  "rev": "39343c3e9ed2781763618fca4f6156c99246a0cd",
-  "hash": "sha256-6zMQ2Q/guf7AcaQMl0GJ562hkh/YVFtQgUabrWq2Y4c="
+  "version": "unstable-20260624045018-a6a07ba",
+  "rev": "a6a07ba0d7beb8c5cfcbf6fae7bf213b4a81460f",
+  "hash": "sha256-m/qm2A7c7l/iXt397dFkbCI/gLlv2JXeSy8XDDvcW10="
 }


### PR DESCRIPTION
Automated package bump for `[
  "openrgb_git"
]`.