### PR TITLE
chore: bump nix_git

### DIFF
--- a/pkgs/nix-git/version.json
+++ b/pkgs/nix-git/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260622225014-0fe449f",
-  "rev": "0fe449f99d6bd164514ed2ca1ab81fde4a31032e",
-  "hash": "sha256-3oMtSrhOv3so3WrIs8k3CLpg6FEB5OYGvT9i/wGJQd8=",
-  "lastModifiedDate": "20260622225014"
+  "version": "unstable-20260623185625-cb35ae6",
+  "rev": "cb35ae61cf12bd156158a4bf3ab18e7d8d49c271",
+  "hash": "sha256-0V3ha3q58lctYp/rvgYwSLq/QTSU2mf8QjohTAZlEHw=",
+  "lastModifiedDate": "20260623185625"
 }


### PR DESCRIPTION
Automated package bump for `[
  "nix_git"
]`.