### PR TITLE
chore: bump tde2e_git

### DIFF
--- a/pkgs/telegram-desktop-git/version.json
+++ b/pkgs/telegram-desktop-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260623025010-1520a81",
-  "rev": "1520a810ac5d665395d2dfdcaa3f17a151ea079a",
-  "hash": "sha256-5GF26vktepBw1g56ahmS0R9+O0aflgWKn42AtZzX8Pw="
+  "version": "unstable-20260623185112-9f61a9f",
+  "rev": "9f61a9fd2856621f4a996a80b7110624f9487c78",
+  "hash": "sha256-Y3SjmpHj9lJviSjA4XZvnYjmkZd2PUHckrF3mJxUxlQ="
 }


### PR DESCRIPTION
Automated package bump for `[
  "tde2e_git",
  "tg-owt_git",
  "telegram-desktop-unwrapped_git",
  "telegram-desktop_git"
]`.