### PR TITLE
chore: bump libdrm_git

### DIFF
--- a/pkgs/mesa-git/version.json
+++ b/pkgs/mesa-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260623021850-475efed",
-  "rev": "475efed859b667388d60df1f4c1df2f0af7ac8c0",
-  "hash": "sha256-GQLyzkvIGRLleQwsHegzUfUaVE26od00C8gk7g2xNgk="
+  "version": "unstable-20260624033228-7ccd70b",
+  "rev": "7ccd70b9ec3853e05dde1dcc330fbc74331a5b51",
+  "hash": "sha256-Dju57VMim4890EQP8gw76S/sGr+Mb8YT9JjWDKPvlDo="
 }

--- a/pkgs/sway-unwrapped-git/version.json
+++ b/pkgs/sway-unwrapped-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260621092819-ca71b4c",
-  "rev": "ca71b4c80f609c637288303625a284f821ecc312",
-  "hash": "sha256-5bX7kMcPOINH937IEqY2sV84SSkrIYVhbVSfasd0R/Q="
+  "version": "unstable-20260623211521-ce72f66",
+  "rev": "ce72f66c58f7a6f61e8468686ba107b06d772b62",
+  "hash": "sha256-+Qn9f2N+czzA0Ck3OJnreP90PIliO2QoGXLzPRQl/Vw="
 }

--- a/pkgs/wayland-protocols-git/version.json
+++ b/pkgs/wayland-protocols-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260607130632-ee78491",
-  "rev": "ee78491a237eaff9389a0ccf8680521d074407d3",
-  "hash": "sha256-kYCbEbh4C4FnqJzwrI+6soYTm5qffEor1Rn2B2f1IKA="
+  "version": "unstable-20260623093033-afb614d",
+  "rev": "afb614d5fcbd02d261a6ae91920aa91cf3915a8a",
+  "hash": "sha256-EgUVZoH2V9suDICELRgrjNi7NqCRu9LjxDSE3VNgSz0="
 }


### PR DESCRIPTION
Automated package bump for `[
  "libdrm_git",
  "wayland-protocols_git",
  "mesa_git",
  "wayland_git",
  "wlroots_git",
  "sway-unwrapped_git",
  "xdg-desktop-portal-wlr_git"
]`.