### PR TITLE
chore: bump zed-editor_git

### DIFF
--- a/pkgs/zed-editor-git/version.json
+++ b/pkgs/zed-editor-git/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260622235922-14f9b9d",
-  "rev": "14f9b9d077ea4de768408aa3bed285baacea13b0",
-  "hash": "sha256-oQH6WyVSj1pw6WvHc2Yebm0J1Md15xZd48DuAg7zkco=",
-  "cargoHash": "sha256-iGWiEE1nuiHZblJhTkyHUm27AQ1/a2b87oWHET9ASyk="
+  "version": "unstable-20260624041625-5d06fff",
+  "rev": "5d06fffd98b73cad8caa6efd08e5850345b60957",
+  "hash": "sha256-7Rgz7F/ZXuMO8aDF3ngko/DE+JTgzjRQ1UTyvXHDjtA=",
+  "cargoHash": "sha256-GHXPJ4ZoFDQnDiQqDEPZ2bHh7O/TaKU0Ir452Y2Ymf8="
 }


### PR DESCRIPTION
Automated package bump for `[
  "zed-editor_git"
]`.