### PR TITLE
chore: bump helix_git

### DIFF
--- a/pkgs/helix-git/version.json
+++ b/pkgs/helix-git/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260622154709-3707874",
-  "rev": "37078743189f197f49563aab8f0b43badcb95897",
-  "hash": "sha256-j3KTtnnlWcCkhLsRJe5uTT8BmrX4vs6zgIakLb+wV90=",
-  "cargoHash": "sha256-iWamCgLSHCU2EVPkGzGksjFf7zNuYcTcRV6riLRPPUY="
+  "version": "unstable-20260624044028-63725a3",
+  "rev": "63725a38fc4fc665acfac39301939af60c711bbc",
+  "hash": "sha256-WHfXbw3dj+gMA9T9JlPcHinzlmPaLXCKTrJFgBUyzeU=",
+  "cargoHash": "sha256-iFuGPTsEDH4PbRrdxjhFWS+j+MMldGvT9eltXuZPzho="
 }


### PR DESCRIPTION
Automated package bump for `[
  "helix_git"
]`.