### PR TITLE
chore: bump nss_git

### DIFF
--- a/pkgs/firefox-nightly/version.json
+++ b/pkgs/firefox-nightly/version.json
@@ -1,5 +1,5 @@
 {
   "version": "154.0a1",
-  "rev": "c280a3de79038960073359b0b4777c676320b76a",
-  "hash": "sha256-m/XjVXgOGw4FkOZLb+0hgdq+Pp4gVJK44FquIGRzWmM="
+  "rev": "850e4be1127e6854cfef5be7beeaf4c054ec69a4",
+  "hash": "sha256-4tJg6NECObiyg/lnyhsy4gLkHV2otuN+PUpcxVsMncY="
 }

--- a/pkgs/nss-git/version.json
+++ b/pkgs/nss-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260622164427-fb89ecd",
-  "rev": "fb89ecd780f6ea48f6200932239892eee1d0decd",
-  "hash": "sha256-klQy76SDMphIKjElCdWPIj0Y6uUq1Ihnr6zpX3eK1Po="
+  "version": "unstable-20260624031326-393acf2",
+  "rev": "393acf27284d02bc276a154ec9b6e5248ab54456",
+  "hash": "sha256-xNvAgrq+DnpElupmeE+1NcFZMSPoi7fHyj4oM2TGNlw="
 }


### PR DESCRIPTION
Automated package bump for `[
  "nss_git",
  "firefox-unwrapped_nightly"
]`.