### PR TITLE
chore: bump spirv-headers_git

### DIFF
--- a/pkgs/spirv-headers-git/version.json
+++ b/pkgs/spirv-headers-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260617153853-c63848e",
-  "rev": "c63848ecf2200425511319fd8bf2c17b751e501e",
-  "hash": "sha256-SLysXcE16JYuHkv5vq2+mfu6A/K6JbcfKz5/CMzfkmA="
+  "version": "unstable-20260624153924-daa093d",
+  "rev": "daa093dd29aab8cbb6562b808370562f56e399fb",
+  "hash": "sha256-2xYphq6uMRlPaaaVSiwqPrWRkCfyOMjeJcWewRja/WY="
 }


### PR DESCRIPTION
Automated package bump for `[
  "spirv-headers_git"
]`.