### PR TITLE
chore: bump openrgb_git

### DIFF
--- a/pkgs/openrgb-git/version.json
+++ b/pkgs/openrgb-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260624045018-a6a07ba",
-  "rev": "a6a07ba0d7beb8c5cfcbf6fae7bf213b4a81460f",
-  "hash": "sha256-m/qm2A7c7l/iXt397dFkbCI/gLlv2JXeSy8XDDvcW10="
+  "version": "unstable-20260625043323-5c931a6",
+  "rev": "5c931a61b455f7e6580e3694574952ca1ab5d470",
+  "hash": "sha256-vJURg8UJPeIXtlmY0ZoZJhE7WFCKgMjGiz5rgG6WsUk="
 }


### PR DESCRIPTION
Automated package bump for `[
  "openrgb_git"
]`.