### PR TITLE
chore: bump nix_git

### DIFF
--- a/pkgs/nix-git/version.json
+++ b/pkgs/nix-git/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260623185625-cb35ae6",
-  "rev": "cb35ae61cf12bd156158a4bf3ab18e7d8d49c271",
-  "hash": "sha256-0V3ha3q58lctYp/rvgYwSLq/QTSU2mf8QjohTAZlEHw=",
-  "lastModifiedDate": "20260623185625"
+  "version": "unstable-20260624215139-3887a90",
+  "rev": "3887a906b178836818a62e8eba666ad652e8a388",
+  "hash": "sha256-Imevyelg3r2N5iDonnGdOKGRiB56m3HgVFAljTB3CLU=",
+  "lastModifiedDate": "20260624215139"
 }


### PR DESCRIPTION
Automated package bump for `[
  "nix_git"
]`.