### PR TITLE
chore: bump pcsx2_git

### DIFF
--- a/pkgs/pcsx2-git/version.json
+++ b/pkgs/pcsx2-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260623011335-9553521",
-  "rev": "95535215aa8be77ee0bb1556d940a761d895abb6",
-  "hash": "sha256-e6M88/GEds6epknV6jg9sKq8j649m1WIQ+t4Eg6FSO0="
+  "version": "unstable-20260624140245-a676981",
+  "rev": "a6769818fd3253315ccd8522c284713e424d66b7",
+  "hash": "sha256-nVLwOZPuYwG1tgX4Vt9jFmMQytyY2DQ5AHduMmcUTUc="
 }


### PR DESCRIPTION
Automated package bump for `[
  "pcsx2_git"
]`.