### PR TITLE
chore: bump mangohud_git

### DIFF
--- a/pkgs/mangohud-git/version.json
+++ b/pkgs/mangohud-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260621115141-62f9b24",
-  "rev": "62f9b24522bb095676cf9847e596f17b86d9ba2f",
-  "hash": "sha256-lUAa13hz7fO7hmXoccRVR8hgXEaiekvyfHeqw5QHD7g="
+  "version": "unstable-20260624205443-d2cef39",
+  "rev": "d2cef39d0be7af3825a6f0b5bed5074be2c42de4",
+  "hash": "sha256-1GVgO/N0l/x//OPv0AsLL1oPDlSgovxUDUBfVusAKOs="
 }


### PR DESCRIPTION
Automated package bump for `[
  "mangohud_git"
]`.