### PR TITLE
chore: bump libdrm_git

### DIFF
--- a/pkgs/mesa-git/version.json
+++ b/pkgs/mesa-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260624033228-7ccd70b",
-  "rev": "7ccd70b9ec3853e05dde1dcc330fbc74331a5b51",
-  "hash": "sha256-Dju57VMim4890EQP8gw76S/sGr+Mb8YT9JjWDKPvlDo="
+  "version": "unstable-20260624230203-da95960",
+  "rev": "da959603a5fe273f77bff7cf5260a0b3d9b82745",
+  "hash": "sha256-t2Z41kCTReXY8FHHVBPgnkvEpXtVX5FYWnnVvBorYk4="
 }


### PR DESCRIPTION
Automated package bump for `[
  "libdrm_git",
  "wayland-protocols_git",
  "mesa_git",
  "wayland_git",
  "wlroots_git",
  "sway-unwrapped_git",
  "xdg-desktop-portal-wlr_git"
]`.