### PR TITLE
chore: bump tde2e_git

### DIFF
--- a/pkgs/telegram-desktop-git/version.json
+++ b/pkgs/telegram-desktop-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260623185112-9f61a9f",
-  "rev": "9f61a9fd2856621f4a996a80b7110624f9487c78",
-  "hash": "sha256-Y3SjmpHj9lJviSjA4XZvnYjmkZd2PUHckrF3mJxUxlQ="
+  "version": "unstable-20260624110952-e4cde25",
+  "rev": "e4cde250df1ea4a02f0090b0abd7d0d34c5f3671",
+  "hash": "sha256-DEB8Lq8PzXA7yCEz550ymALlpYGV93WpaagBUBSj0cw="
 }


### PR DESCRIPTION
Automated package bump for `[
  "tde2e_git",
  "tg-owt_git",
  "telegram-desktop-unwrapped_git",
  "telegram-desktop_git"
]`.