### PR TITLE
chore: bump zed-editor_git

### DIFF
--- a/pkgs/zed-editor-git/version.json
+++ b/pkgs/zed-editor-git/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260624041625-5d06fff",
-  "rev": "5d06fffd98b73cad8caa6efd08e5850345b60957",
-  "hash": "sha256-7Rgz7F/ZXuMO8aDF3ngko/DE+JTgzjRQ1UTyvXHDjtA=",
-  "cargoHash": "sha256-GHXPJ4ZoFDQnDiQqDEPZ2bHh7O/TaKU0Ir452Y2Ymf8="
+  "version": "unstable-20260625013240-17c0ebb",
+  "rev": "17c0ebb0f7b8b512d99f396e543e71c1775ff6f6",
+  "hash": "sha256-xnWV+4iQfOcHirxuQmb7yuFX1vQA1qU2/VbEoS7wVfI=",
+  "cargoHash": "sha256-sY/WXasGI/1PYgn2J6lWRu4WWHNJTiMAUtkr6+iJPZ4="
 }


### PR DESCRIPTION
Automated package bump for `[
  "zed-editor_git"
]`.