### PR TITLE
chore: bump pcsx2_git

### DIFF
--- a/pkgs/pcsx2-git/version.json
+++ b/pkgs/pcsx2-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260624140245-a676981",
-  "rev": "a6769818fd3253315ccd8522c284713e424d66b7",
-  "hash": "sha256-nVLwOZPuYwG1tgX4Vt9jFmMQytyY2DQ5AHduMmcUTUc="
+  "version": "unstable-20260626005438-cc85cef",
+  "rev": "cc85cef17c76bffce2a412170525d4dcaf857815",
+  "hash": "sha256-mk4QvVcEz+E1ONAwtLS61JQRTVEE5p23RBXbie6Vgcw="
 }


### PR DESCRIPTION
Automated package bump for `[
  "pcsx2_git"
]`.