### PR TITLE
chore: bump zed-editor_git

### DIFF
--- a/pkgs/zed-editor-git/version.json
+++ b/pkgs/zed-editor-git/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260625013240-17c0ebb",
-  "rev": "17c0ebb0f7b8b512d99f396e543e71c1775ff6f6",
-  "hash": "sha256-xnWV+4iQfOcHirxuQmb7yuFX1vQA1qU2/VbEoS7wVfI=",
-  "cargoHash": "sha256-sY/WXasGI/1PYgn2J6lWRu4WWHNJTiMAUtkr6+iJPZ4="
+  "version": "unstable-20260625201031-35eaeb9",
+  "rev": "35eaeb94a7e5e9dcd7384df4bd21f01c30a38a09",
+  "hash": "sha256-KXe6iKzjgnJv3K6NKB7HuAZsf7Gpje/bzQBney2fD8k=",
+  "cargoHash": "sha256-DTzLyjwl0tSo6lIVl9zokhxqmKzMoL6kMmIXZlO7R3k="
 }


### PR DESCRIPTION
Automated package bump for `[
  "zed-editor_git"
]`.