### PR TITLE
chore: bump openrgb_git

### DIFF
--- a/pkgs/openrgb-git/version.json
+++ b/pkgs/openrgb-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260625043323-5c931a6",
-  "rev": "5c931a61b455f7e6580e3694574952ca1ab5d470",
-  "hash": "sha256-vJURg8UJPeIXtlmY0ZoZJhE7WFCKgMjGiz5rgG6WsUk="
+  "version": "unstable-20260626011618-9404237",
+  "rev": "94042375a7b78cd2eb76418590b70096a0d7a362",
+  "hash": "sha256-XRWW+k8aE1iSPTjQ+kWMTq62/EH0PW98y3oX2krZyfU="
 }


### PR DESCRIPTION
Automated package bump for `[
  "openrgb_git"
]`.