### PR TITLE
chore: bump libdrm_git

### DIFF
--- a/pkgs/mesa-git/version.json
+++ b/pkgs/mesa-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260624230203-da95960",
-  "rev": "da959603a5fe273f77bff7cf5260a0b3d9b82745",
-  "hash": "sha256-t2Z41kCTReXY8FHHVBPgnkvEpXtVX5FYWnnVvBorYk4="
+  "version": "unstable-20260626043159-2ce9bc6",
+  "rev": "2ce9bc68585af69cd8e46d38139f82b0efdc4ecc",
+  "hash": "sha256-KytoonSbIz2Ul1KETqVpcr5o54xgMMVO/1EukEkzKFM="
 }


### PR DESCRIPTION
Automated package bump for `[
  "libdrm_git",
  "wayland-protocols_git",
  "mesa_git",
  "wayland_git",
  "wlroots_git",
  "sway-unwrapped_git",
  "xdg-desktop-portal-wlr_git"
]`.