### PR TITLE
chore: bump tde2e_git

### DIFF
--- a/pkgs/telegram-desktop-git/version.json
+++ b/pkgs/telegram-desktop-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260624110952-e4cde25",
-  "rev": "e4cde250df1ea4a02f0090b0abd7d0d34c5f3671",
-  "hash": "sha256-DEB8Lq8PzXA7yCEz550ymALlpYGV93WpaagBUBSj0cw="
+  "version": "unstable-20260625191211-228934b",
+  "rev": "228934b6c38e52deadb2d0dfe03f8a6980b003b3",
+  "hash": "sha256-IKwQI2CQcNroTVYGCVgYP9o1gNUaCeLCXALilSvEh54="
 }


### PR DESCRIPTION
Automated package bump for `[
  "tde2e_git",
  "tg-owt_git",
  "telegram-desktop-unwrapped_git",
  "telegram-desktop_git"
]`.