### PR TITLE
chore: bump nss_git

### DIFF
--- a/pkgs/firefox-nightly/version.json
+++ b/pkgs/firefox-nightly/version.json
@@ -1,6 +1,6 @@
 {
   "version": "154.0a1",
-  "rev": "472cf81a7946ede9e3e6c44eb038d4cd9168d5fc",
-  "buildId": "20260624063255",
-  "hash": "sha256-31WmWk2Fsz1n9KvNzpHA4wuy9qvdN238YWgA3Jv0mf8="
+  "rev": "d5171e9e0f4729494423b0524f289073e0f0cb6c",
+  "buildId": "20260625094708",
+  "hash": "sha256-StZfBSd2BKFBo8t/27KvH442LZ7G5Xg2aysgmdWACVU="
 }


### PR DESCRIPTION
Automated package bump for `[
  "nss_git",
  "firefox-unwrapped_nightly"
]`.