### PR TITLE
chore: bump openrgb_git

### DIFF
--- a/pkgs/openrgb-git/version.json
+++ b/pkgs/openrgb-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260626011618-9404237",
-  "rev": "94042375a7b78cd2eb76418590b70096a0d7a362",
-  "hash": "sha256-XRWW+k8aE1iSPTjQ+kWMTq62/EH0PW98y3oX2krZyfU="
+  "version": "unstable-20260626151706-75bac1f",
+  "rev": "75bac1fd4e711305bcaadfea125d635d9c27b4a5",
+  "hash": "sha256-mw3xFWOgbVy0vOs9FyeT1XzvKNHHqVuCHkuakizYjlg="
 }


### PR DESCRIPTION
Automated package bump for `[
  "openrgb_git"
]`.