### PR TITLE
chore: bump libdrm_git

### DIFF
--- a/pkgs/mesa-git/version.json
+++ b/pkgs/mesa-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260626043159-2ce9bc6",
-  "rev": "2ce9bc68585af69cd8e46d38139f82b0efdc4ecc",
-  "hash": "sha256-KytoonSbIz2Ul1KETqVpcr5o54xgMMVO/1EukEkzKFM="
+  "version": "unstable-20260627010155-d3c2dab",
+  "rev": "d3c2dab2073a8604e2fec1367165fba54edad5fa",
+  "hash": "sha256-ESuWTr9zk314ZmZ+FgC3JMRCxa7E2P3PgfU5Jq7uRFI="
 }


### PR DESCRIPTION
Automated package bump for `[
  "libdrm_git",
  "wayland-protocols_git",
  "mesa_git",
  "wayland_git",
  "wlroots_git",
  "sway-unwrapped_git",
  "xdg-desktop-portal-wlr_git"
]`.