### PR TITLE
chore: bump tde2e_git

### DIFF
--- a/pkgs/telegram-desktop-git/version.json
+++ b/pkgs/telegram-desktop-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260625191211-228934b",
-  "rev": "228934b6c38e52deadb2d0dfe03f8a6980b003b3",
-  "hash": "sha256-IKwQI2CQcNroTVYGCVgYP9o1gNUaCeLCXALilSvEh54="
+  "version": "unstable-20260626131125-1c1a538",
+  "rev": "1c1a5386eeb1f647d6d478d3a36732d48c4deecf",
+  "hash": "sha256-lqtLpF66SqWCuwpIGyS9H7okWpLShO6TtjgIiOUt0/4="
 }


### PR DESCRIPTION
Automated package bump for `[
  "tde2e_git",
  "tg-owt_git",
  "telegram-desktop-unwrapped_git",
  "telegram-desktop_git"
]`.