### PR TITLE
chore: bump pcsx2_git

### DIFF
--- a/pkgs/pcsx2-git/version.json
+++ b/pkgs/pcsx2-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260626005438-cc85cef",
-  "rev": "cc85cef17c76bffce2a412170525d4dcaf857815",
-  "hash": "sha256-mk4QvVcEz+E1ONAwtLS61JQRTVEE5p23RBXbie6Vgcw="
+  "version": "unstable-20260626083551-48ca476",
+  "rev": "48ca476a2fa7de847defd63457c303a966938af0",
+  "hash": "sha256-cCF+yOPpazpfMVf791oEQ1dVT3RHlqEbmNKprVbfUCM="
 }


### PR DESCRIPTION
Automated package bump for `[
  "pcsx2_git"
]`.