### PR TITLE
chore: bump zed-editor_git

### DIFF
--- a/pkgs/zed-editor-git/version.json
+++ b/pkgs/zed-editor-git/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260625201031-35eaeb9",
-  "rev": "35eaeb94a7e5e9dcd7384df4bd21f01c30a38a09",
-  "hash": "sha256-KXe6iKzjgnJv3K6NKB7HuAZsf7Gpje/bzQBney2fD8k=",
-  "cargoHash": "sha256-DTzLyjwl0tSo6lIVl9zokhxqmKzMoL6kMmIXZlO7R3k="
+  "version": "unstable-20260626225641-2c346f6",
+  "rev": "2c346f60a76fe3f0367ef924927f50a6efdf5718",
+  "hash": "sha256-VCIx3H3vlZcLmw4B2an1RM4PZpMV1sKztmhKbmRt3R4=",
+  "cargoHash": "sha256-GGJVA3lj/AawvOqo1jozT+SX2Mc8F5I/WR/7+X+uXoE="
 }


### PR DESCRIPTION
Automated package bump for `[
  "zed-editor_git"
]`.