### PR TITLE
chore: bump nss_git

### DIFF
--- a/pkgs/firefox-nightly/version.json
+++ b/pkgs/firefox-nightly/version.json
@@ -1,6 +1,6 @@
 {
   "version": "154.0a1",
-  "rev": "6a252a86c5bb0fdd7a197d1c244f8a28e0827b3a",
-  "buildId": "20260626040954",
-  "hash": "sha256-EW3zlZiDeXzrz2fxpL8e8Wquu0VMElqLxg/AvxTRHYE="
+  "rev": "0c4c351481d11be32f41af409dbc59122bef80a2",
+  "buildId": "20260628214348",
+  "hash": "sha256-UUz7P4d5haQj4HdaOb/UJy+EMYrgqoSnVcflaxy9Cy4="
 }


### PR DESCRIPTION
Automated package bump for `[
  "nss_git",
  "firefox-unwrapped_nightly"
]`.