### PR TITLE
chore: bump pcsx2_git

### DIFF
--- a/pkgs/pcsx2-git/version.json
+++ b/pkgs/pcsx2-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260626083551-48ca476",
-  "rev": "48ca476a2fa7de847defd63457c303a966938af0",
-  "hash": "sha256-cCF+yOPpazpfMVf791oEQ1dVT3RHlqEbmNKprVbfUCM="
+  "version": "unstable-20260627205129-7856757",
+  "rev": "78567570875dd55fcc05b0f03992a5199313c058",
+  "hash": "sha256-R9HgHw/MnGhIcz9UzQwJUrqvFSeHrDX5msy2Bwf4m50="
 }


### PR DESCRIPTION
Automated package bump for `[
  "pcsx2_git"
]`.