### PR TITLE
chore: bump nix_git

### DIFF
--- a/pkgs/nix-git/version.json
+++ b/pkgs/nix-git/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260624215139-3887a90",
-  "rev": "3887a906b178836818a62e8eba666ad652e8a388",
-  "hash": "sha256-Imevyelg3r2N5iDonnGdOKGRiB56m3HgVFAljTB3CLU=",
-  "lastModifiedDate": "20260624215139"
+  "version": "unstable-20260627163041-53f6271",
+  "rev": "53f62712aa8d66bf7198c78962cd7574e0667a92",
+  "hash": "sha256-UM4szKo3fT3jPLVFVaE4wEPbQOSYvweu+/wZv2K4scM=",
+  "lastModifiedDate": "20260627163041"
 }


### PR DESCRIPTION
Automated package bump for `[
  "nix_git"
]`.