### PR TITLE
chore: bump zed-editor_git

### DIFF
--- a/pkgs/zed-editor-git/version.json
+++ b/pkgs/zed-editor-git/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260626225641-2c346f6",
-  "rev": "2c346f60a76fe3f0367ef924927f50a6efdf5718",
-  "hash": "sha256-VCIx3H3vlZcLmw4B2an1RM4PZpMV1sKztmhKbmRt3R4=",
+  "version": "unstable-20260627211949-5837e7e",
+  "rev": "5837e7ef50f65d6e041d19ba6543532a1d596e6b",
+  "hash": "sha256-i2JXcieQyBKz/OlgyWXfUNQ1zHADsYpGnPlEZVqJxfc=",
   "cargoHash": "sha256-GGJVA3lj/AawvOqo1jozT+SX2Mc8F5I/WR/7+X+uXoE="
 }


### PR DESCRIPTION
Automated package bump for `[
  "zed-editor_git"
]`.