### PR TITLE
chore: bump openrgb_git

### DIFF
--- a/pkgs/openrgb-git/version.json
+++ b/pkgs/openrgb-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260626151706-75bac1f",
-  "rev": "75bac1fd4e711305bcaadfea125d635d9c27b4a5",
-  "hash": "sha256-mw3xFWOgbVy0vOs9FyeT1XzvKNHHqVuCHkuakizYjlg="
+  "version": "unstable-20260628010350-6fc68f4",
+  "rev": "6fc68f4e628223e7bbc4b7eda19de163d91d4c67",
+  "hash": "sha256-jd+pTJAd4WoTIlwNpzw+7T9M9HCZWH938RWonqvQ+d0="
 }


### PR DESCRIPTION
Automated package bump for `[
  "openrgb_git"
]`.