### PR TITLE
chore: bump libdrm_git

### DIFF
--- a/pkgs/mesa-git/version.json
+++ b/pkgs/mesa-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260627010155-d3c2dab",
-  "rev": "d3c2dab2073a8604e2fec1367165fba54edad5fa",
-  "hash": "sha256-ESuWTr9zk314ZmZ+FgC3JMRCxa7E2P3PgfU5Jq7uRFI="
+  "version": "unstable-20260628044937-a7d8f5d",
+  "rev": "a7d8f5d5b305e876f871a6965036053f16fb414c",
+  "hash": "sha256-ZnWXclqUbN49xL4M8yqsvDpuiqaWXcXwrW7mSkOI+Tg="
 }


### PR DESCRIPTION
Automated package bump for `[
  "libdrm_git",
  "wayland-protocols_git",
  "mesa_git",
  "wayland_git",
  "wlroots_git",
  "sway-unwrapped_git",
  "xdg-desktop-portal-wlr_git"
]`.