### PR TITLE
chore: bump nix_git

### DIFF
--- a/pkgs/nix-git/version.json
+++ b/pkgs/nix-git/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260627163041-53f6271",
-  "rev": "53f62712aa8d66bf7198c78962cd7574e0667a92",
-  "hash": "sha256-UM4szKo3fT3jPLVFVaE4wEPbQOSYvweu+/wZv2K4scM=",
-  "lastModifiedDate": "20260627163041"
+  "version": "unstable-20260629011544-af7f2fa",
+  "rev": "af7f2fa9b832e12eb49977a112a85f426f8e4643",
+  "hash": "sha256-S9sgadbSkd0lygRK0Y54lirMtHJg24WJULbueJbHp24=",
+  "lastModifiedDate": "20260629011544"
 }


### PR DESCRIPTION
Automated package bump for `[
  "nix_git"
]`.