### PR TITLE
chore: bump openrgb_git

### DIFF
--- a/pkgs/openrgb-git/version.json
+++ b/pkgs/openrgb-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260628010350-6fc68f4",
-  "rev": "6fc68f4e628223e7bbc4b7eda19de163d91d4c67",
-  "hash": "sha256-jd+pTJAd4WoTIlwNpzw+7T9M9HCZWH938RWonqvQ+d0="
+  "version": "unstable-20260629044310-d130e64",
+  "rev": "d130e64f691e4cb6383075c1e2d31ddc2a7a6eef",
+  "hash": "sha256-BVHSycQgcJpPT9fZfiTPVntddfQ9Gd2wOEbj9lwOWNU="
 }


### PR DESCRIPTION
Automated package bump for `[
  "openrgb_git"
]`.