### PR TITLE
chore: bump pcsx2_git

### DIFF
--- a/pkgs/pcsx2-git/version.json
+++ b/pkgs/pcsx2-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260627205129-7856757",
-  "rev": "78567570875dd55fcc05b0f03992a5199313c058",
-  "hash": "sha256-R9HgHw/MnGhIcz9UzQwJUrqvFSeHrDX5msy2Bwf4m50="
+  "version": "unstable-20260629002652-f83e4ff",
+  "rev": "f83e4ff4bfbf26b80eebd7b9ecef47b4819a92e1",
+  "hash": "sha256-FkEtL2BobNM1sBl7K5vnZzHmmYUN5G7hgHmmPWyfXE4="
 }


### PR DESCRIPTION
Automated package bump for `[
  "pcsx2_git"
]`.