### PR TITLE
chore: bump libdrm_git

### DIFF
--- a/pkgs/mesa-git/version.json
+++ b/pkgs/mesa-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260628044937-a7d8f5d",
-  "rev": "a7d8f5d5b305e876f871a6965036053f16fb414c",
-  "hash": "sha256-ZnWXclqUbN49xL4M8yqsvDpuiqaWXcXwrW7mSkOI+Tg="
+  "version": "unstable-20260628180211-2f5aee0",
+  "rev": "2f5aee03ceeb7c9ac38c06d0799380232ed3e693",
+  "hash": "sha256-HRJVtk3PyyoHnwX1b3cnMojNIKEAuq8u9f+7VAl5fI0="
 }

--- a/pkgs/sway-unwrapped-git/version.json
+++ b/pkgs/sway-unwrapped-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260623211521-ce72f66",
-  "rev": "ce72f66c58f7a6f61e8468686ba107b06d772b62",
-  "hash": "sha256-+Qn9f2N+czzA0Ck3OJnreP90PIliO2QoGXLzPRQl/Vw="
+  "version": "unstable-20260628135434-512d64b",
+  "rev": "512d64b70fac64a55ba16222a2a8ca1fe5ce42ba",
+  "hash": "sha256-LcLgKIw2qhc/DefMCwWpbUhma+exlhibIiVzQYwpu+o="
 }


### PR DESCRIPTION
Automated package bump for `[
  "libdrm_git",
  "wayland-protocols_git",
  "mesa_git",
  "wayland_git",
  "wlroots_git",
  "sway-unwrapped_git",
  "xdg-desktop-portal-wlr_git"
]`.