### PR TITLE
chore: bump zed-editor_git

### DIFF
--- a/pkgs/zed-editor-git/version.json
+++ b/pkgs/zed-editor-git/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260627211949-5837e7e",
-  "rev": "5837e7ef50f65d6e041d19ba6543532a1d596e6b",
-  "hash": "sha256-i2JXcieQyBKz/OlgyWXfUNQ1zHADsYpGnPlEZVqJxfc=",
-  "cargoHash": "sha256-GGJVA3lj/AawvOqo1jozT+SX2Mc8F5I/WR/7+X+uXoE="
+  "version": "unstable-20260629050526-cd7f1a0",
+  "rev": "cd7f1a0fb18dd6f2474fbb84c6d6a19cce72ec76",
+  "hash": "sha256-x2kqXonm8naAbQRz7Qu50Wy3+BI2xCR8+L+NXD02s0k=",
+  "cargoHash": "sha256-K2KyaD3OWZw7heDEoE7eaQ9q8oZ02Wzfzx0PrVdmBRw="
 }


### PR DESCRIPTION
Automated package bump for `[
  "zed-editor_git"
]`.