### PR TITLE
chore: bump helix_git

### DIFF
--- a/pkgs/helix-git/version.json
+++ b/pkgs/helix-git/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260624060629-6b7c7c6",
-  "rev": "6b7c7c6e0784d7c34295c24064deb36418c0b4b5",
-  "hash": "sha256-pr0uoMp72SkUkh6VQtQd+OVTqxAaat+3FN+o5yMJvQE=",
+  "version": "unstable-20260629024657-278b243",
+  "rev": "278b24389457e33791d394dd9a8a93740e2cc099",
+  "hash": "sha256-Hu9yGydALMMsNsAIKjtIvhjPNhsmZLUcaOcDFyJ8v90=",
   "cargoHash": "sha256-iFuGPTsEDH4PbRrdxjhFWS+j+MMldGvT9eltXuZPzho="
 }


### PR DESCRIPTION
Automated package bump for `[
  "helix_git"
]`.