### PR TITLE
chore: bump pcsx2_git

### DIFF
--- a/pkgs/pcsx2-git/version.json
+++ b/pkgs/pcsx2-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260629002652-f83e4ff",
-  "rev": "f83e4ff4bfbf26b80eebd7b9ecef47b4819a92e1",
-  "hash": "sha256-FkEtL2BobNM1sBl7K5vnZzHmmYUN5G7hgHmmPWyfXE4="
+  "version": "unstable-20260629165733-51c9951",
+  "rev": "51c995168a77384063e75cce3730e54f7f543a02",
+  "hash": "sha256-CgmKl0qHS8MNuGl5D6QOuHI6I8ztG0p3MPsTY6L9gqw="
 }


### PR DESCRIPTION
Automated package bump for `[
  "pcsx2_git"
]`.