### PR TITLE
chore: bump openrgb_git

### DIFF
--- a/pkgs/openrgb-git/version.json
+++ b/pkgs/openrgb-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260629044310-d130e64",
-  "rev": "d130e64f691e4cb6383075c1e2d31ddc2a7a6eef",
-  "hash": "sha256-BVHSycQgcJpPT9fZfiTPVntddfQ9Gd2wOEbj9lwOWNU="
+  "version": "unstable-20260629230848-3932a96",
+  "rev": "3932a9614cec40b06c4492329991adf4ee3705df",
+  "hash": "sha256-sBZJIXxEZ0ernTxsDiPZfCwks1c7IPoOV2NC/HhI5jM="
 }


### PR DESCRIPTION
Automated package bump for `[
  "openrgb_git"
]`.