### PR TITLE
chore: bump libdrm_git

### DIFF
--- a/pkgs/mesa-git/version.json
+++ b/pkgs/mesa-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260628180211-2f5aee0",
-  "rev": "2f5aee03ceeb7c9ac38c06d0799380232ed3e693",
-  "hash": "sha256-HRJVtk3PyyoHnwX1b3cnMojNIKEAuq8u9f+7VAl5fI0="
+  "version": "unstable-20260629205956-9710884",
+  "rev": "97108842afd4a56885e51e596024514a880928a2",
+  "hash": "sha256-+yhL5aen99o3jDwwebpzizBYOXrA6b76BmFHkkm8nLM="
 }


### PR DESCRIPTION
Automated package bump for `[
  "libdrm_git",
  "wayland-protocols_git",
  "mesa_git",
  "wayland_git",
  "wlroots_git",
  "sway-unwrapped_git",
  "xdg-desktop-portal-wlr_git"
]`.