### PR TITLE
chore: bump zed-editor_git

### DIFF
--- a/pkgs/zed-editor-git/version.json
+++ b/pkgs/zed-editor-git/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260629050526-cd7f1a0",
-  "rev": "cd7f1a0fb18dd6f2474fbb84c6d6a19cce72ec76",
-  "hash": "sha256-x2kqXonm8naAbQRz7Qu50Wy3+BI2xCR8+L+NXD02s0k=",
-  "cargoHash": "sha256-K2KyaD3OWZw7heDEoE7eaQ9q8oZ02Wzfzx0PrVdmBRw="
+  "version": "unstable-20260629202146-53e4d34",
+  "rev": "53e4d34a71f61f13572919c04335e9da838623e6",
+  "hash": "sha256-O64kKdU3XRkbkT2FUFY4aLDaOoc3AKbbeBPTf5JdUJE=",
+  "cargoHash": "sha256-RgY3n8DRL0zXlrNWhPGMgKw4t5tJwLz6dinRmarkP+8="
 }


### PR DESCRIPTION
Automated package bump for `[
  "zed-editor_git"
]`.