### PR TITLE
chore: bump nix_git

### DIFF
--- a/pkgs/nix-git/version.json
+++ b/pkgs/nix-git/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260629011544-af7f2fa",
-  "rev": "af7f2fa9b832e12eb49977a112a85f426f8e4643",
-  "hash": "sha256-S9sgadbSkd0lygRK0Y54lirMtHJg24WJULbueJbHp24=",
-  "lastModifiedDate": "20260629011544"
+  "version": "unstable-20260629190923-adc8ada",
+  "rev": "adc8ada9ad605361e15439cd8c2325c3262e717d",
+  "hash": "sha256-G4K92GydXZx73ZFUAOCoI2KlE3ApQCJp+Rw2FrPAl/U=",
+  "lastModifiedDate": "20260629190923"
 }


### PR DESCRIPTION
Automated package bump for `[
  "nix_git"
]`.