### PR TITLE
chore: bump nss_git

### DIFF
--- a/maintenance/failures.x86_64-linux.nix
+++ b/maintenance/failures.x86_64-linux.nix
@@ -61,9 +61,6 @@
   "linuxPackages_cachyos-gcc.tt-kmd" = "/nix/store/ikzq0p1winjiaih7wyqy3fh437cgwxd9-tt-kmd-2.7.0";
   "linuxPackages_cachyos-gcc.vmm_clock" = "/nix/store/rcp98z1xifrgxf5270cv7493x7grfimv-vmm_clock-0.2.1";
   "linuxPackages_cachyos-gcc.yt6801" = "/nix/store/1bxqn16jqviq883cn3i78zdlmzhr8cwg-yt6801-1.0.30-20250430";
-  "linuxPackages_cachyos-lto.bpftrace" = "/nix/store/7rdpiid0rcm3m5gxb9pja0mzmkhzrkj6-bpftrace-x86_64-unknown-linux-gnu-0.26.1";
-  "linuxPackages_cachyos-lto.oci-seccomp-bpf-hook" = "/nix/store/s6r5jbnfx7p359k3ywdsfxl39jgrmhz0-oci-seccomp-bpf-hook-x86_64-unknown-linux-gnu-1.3.0";
-  "linuxPackages_cachyos-lto.pktgen" = "/nix/store/b7wf8alr0pw4f7r2qv1il6pav186icl6-pktgen-x86_64-unknown-linux-gnu-24.10.3";
   "mwc_git" = "/nix/store/vd49vhc9jjrwscga3m8vr3g1pc143v5l-mwc-wlr-unstable-20250316235640-33b4968";
   "sdl_git" = "/nix/store/1rjg6623idc89qb7vi5dm5zywpywsn58-sdl3-unstable-20260626183202-4bebbec-lib";
   "torzu_git" = "/nix/store/x642h0j1dbr5w2fia2bbg4q61slwz1r9-torzu-unstable-20250422-fd90833";

--- a/pkgs/firefox-nightly/version.json
+++ b/pkgs/firefox-nightly/version.json
@@ -1,6 +1,6 @@
 {
   "version": "154.0a1",
-  "rev": "0c4c351481d11be32f41af409dbc59122bef80a2",
-  "buildId": "20260628214348",
-  "hash": "sha256-UUz7P4d5haQj4HdaOb/UJy+EMYrgqoSnVcflaxy9Cy4="
+  "rev": "2b95a0a700b2173c4adb521a77098d8a53930444",
+  "buildId": "20260629214814",
+  "hash": "sha256-+x1Yuzt3hSvKOzxiuHc9ZrOjTHTaevC13b6+PbVndK4="
 }

--- a/pkgs/nss-git/version.json
+++ b/pkgs/nss-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260624031326-393acf2",
-  "rev": "393acf27284d02bc276a154ec9b6e5248ab54456",
-  "hash": "sha256-xNvAgrq+DnpElupmeE+1NcFZMSPoi7fHyj4oM2TGNlw="
+  "version": "unstable-20260630011452-1cff78a",
+  "rev": "1cff78a9cae90867a9d8ec344fb7a084c33e4c40",
+  "hash": "sha256-RCnPoelGvBsrwAuV+L+YoVWPY04RRRGCNI2H4z2TcIY="
 }


### PR DESCRIPTION
Automated package bump for `[
  "nss_git",
  "firefox-unwrapped_nightly"
]`.