### PR TITLE
chore: bump mangohud_git

### DIFF
--- a/pkgs/mangohud-git/version.json
+++ b/pkgs/mangohud-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260629152543-c9f7b36",
-  "rev": "c9f7b36404017b74f0105f2378d638dab09c852f",
-  "hash": "sha256-2QAsNKG9l+EsxHyqZ2Jo/EMOXdy2c0thHAMhimMSu6s="
+  "version": "unstable-20260701004245-1e53419",
+  "rev": "1e53419b382162fc35e02250ad1c80986cf2f07a",
+  "hash": "sha256-2L8Wr7DJfBj0ERtu07pJiijpfuSSoX1+gUbNjO90vhI="
 }


### PR DESCRIPTION
Automated package bump for `[
  "mangohud_git"
]`.