### PR TITLE
chore: bump openrgb_git

### DIFF
--- a/pkgs/openrgb-git/version.json
+++ b/pkgs/openrgb-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260629230848-3932a96",
-  "rev": "3932a9614cec40b06c4492329991adf4ee3705df",
-  "hash": "sha256-sBZJIXxEZ0ernTxsDiPZfCwks1c7IPoOV2NC/HhI5jM="
+  "version": "unstable-20260630064920-6b8db47",
+  "rev": "6b8db478fb6038cd0602ca61d601be6a1bc6c075",
+  "hash": "sha256-HUdILRY8u+8ouuWtr33npTADAnrNLowx3FPbdECFngM="
 }


### PR DESCRIPTION
Automated package bump for `[
  "openrgb_git"
]`.