### PR TITLE
chore: bump nix_git

### DIFF
--- a/pkgs/nix-git/version.json
+++ b/pkgs/nix-git/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260629190923-adc8ada",
-  "rev": "adc8ada9ad605361e15439cd8c2325c3262e717d",
-  "hash": "sha256-G4K92GydXZx73ZFUAOCoI2KlE3ApQCJp+Rw2FrPAl/U=",
-  "lastModifiedDate": "20260629190923"
+  "version": "unstable-20260630045405-ad1507d",
+  "rev": "ad1507d6f094878e3551a47813b8406ae9569fcb",
+  "hash": "sha256-atdLW1NrCZcEk8cdd8BYUo3XrTeV+WgONCovCmmwHLo=",
+  "lastModifiedDate": "20260630045405"
 }


### PR DESCRIPTION
Automated package bump for `[
  "nix_git"
]`.