### PR TITLE
chore: bump tde2e_git

### DIFF
--- a/pkgs/telegram-desktop-git/version.json
+++ b/pkgs/telegram-desktop-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260626131125-1c1a538",
-  "rev": "1c1a5386eeb1f647d6d478d3a36732d48c4deecf",
-  "hash": "sha256-lqtLpF66SqWCuwpIGyS9H7okWpLShO6TtjgIiOUt0/4="
+  "version": "unstable-20260703030051-0eb071f",
+  "rev": "0eb071fcede9a4706b65318f133a02f03d9b9885",
+  "hash": "sha256-iy5C4Y3fjL9775Sx3/yZXZYaRlXzu0klMBnpLpk0hBo="
 }


### PR DESCRIPTION
Automated package bump for `[
  "tde2e_git",
  "tg-owt_git",
  "telegram-desktop-unwrapped_git",
  "telegram-desktop_git"
]`.