### PR TITLE
chore: bump libdrm_git

### DIFF
--- a/pkgs/mesa-git/version.json
+++ b/pkgs/mesa-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260629205956-9710884",
-  "rev": "97108842afd4a56885e51e596024514a880928a2",
-  "hash": "sha256-+yhL5aen99o3jDwwebpzizBYOXrA6b76BmFHkkm8nLM="
+  "version": "unstable-20260701041352-a6bb4bb",
+  "rev": "a6bb4bbd1eaa8b1b8ba9e5df98ed2c9958393e40",
+  "hash": "sha256-EgLIEnqpApLlyNwwMSF5ph1MpHPbqW+mV/Fk2iMKE6c="
 }

--- a/pkgs/sway-unwrapped-git/version.json
+++ b/pkgs/sway-unwrapped-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260628135434-512d64b",
-  "rev": "512d64b70fac64a55ba16222a2a8ca1fe5ce42ba",
-  "hash": "sha256-LcLgKIw2qhc/DefMCwWpbUhma+exlhibIiVzQYwpu+o="
+  "version": "unstable-20260630165511-edcc4b0",
+  "rev": "edcc4b0ed0b8a478f469409ef4b67917256388ec",
+  "hash": "sha256-VgZ+Gd+I5voHdPif+AT3eNBBAnmAlkMbq5uCNUx7Gvg="
 }


### PR DESCRIPTION
Automated package bump for `[
  "libdrm_git",
  "wayland-protocols_git",
  "mesa_git",
  "wayland_git",
  "wlroots_git",
  "sway-unwrapped_git",
  "xdg-desktop-portal-wlr_git"
]`.