### PR TITLE
chore: bump zed-editor_git

### DIFF
--- a/pkgs/zed-editor-git/version.json
+++ b/pkgs/zed-editor-git/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260629202146-53e4d34",
-  "rev": "53e4d34a71f61f13572919c04335e9da838623e6",
-  "hash": "sha256-O64kKdU3XRkbkT2FUFY4aLDaOoc3AKbbeBPTf5JdUJE=",
-  "cargoHash": "sha256-RgY3n8DRL0zXlrNWhPGMgKw4t5tJwLz6dinRmarkP+8="
+  "version": "unstable-20260701042540-40d2003",
+  "rev": "40d20036af34343a09f0ce6a2eb38c9e5a60e9ae",
+  "hash": "sha256-AvOypBl4wPSqyd/KeaUNM2hUTo2pl+OmALnexAAo8v8=",
+  "cargoHash": "sha256-uQhDvnkIEknJ87qftAPIgwY/FMuIz2xO+0EYNggHen8="
 }


### PR DESCRIPTION
Automated package bump for `[
  "zed-editor_git"
]`.