### PR TITLE
chore: bump nss_git

### DIFF
--- a/pkgs/firefox-nightly/version.json
+++ b/pkgs/firefox-nightly/version.json
@@ -1,6 +1,6 @@
 {
   "version": "154.0a1",
-  "rev": "2b95a0a700b2173c4adb521a77098d8a53930444",
-  "buildId": "20260629214814",
-  "hash": "sha256-+x1Yuzt3hSvKOzxiuHc9ZrOjTHTaevC13b6+PbVndK4="
+  "rev": "0a7f146ccac85b8f413264042dcd764028d419ec",
+  "buildId": "20260701192917",
+  "hash": "sha256-HiuBJjQDYwfgikLC2F/KPhVBzpkzmkUO0r2SF49qwUU="
 }

--- a/pkgs/nss-git/version.json
+++ b/pkgs/nss-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260630011452-1cff78a",
-  "rev": "1cff78a9cae90867a9d8ec344fb7a084c33e4c40",
-  "hash": "sha256-RCnPoelGvBsrwAuV+L+YoVWPY04RRRGCNI2H4z2TcIY="
+  "version": "unstable-20260701222603-192f7e9",
+  "rev": "192f7e96397038c6caf0534cf9fb926307278d3f",
+  "hash": "sha256-wLofZlSErmL0hQvhDNa0I5QQYMc8akhQa6hf2YIY1Bw="
 }


### PR DESCRIPTION
Automated package bump for `[
  "nss_git",
  "firefox-unwrapped_nightly"
]`.