### PR TITLE
chore: bump nix_git

### DIFF
--- a/pkgs/nix-git/version.json
+++ b/pkgs/nix-git/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260630045405-ad1507d",
-  "rev": "ad1507d6f094878e3551a47813b8406ae9569fcb",
-  "hash": "sha256-atdLW1NrCZcEk8cdd8BYUo3XrTeV+WgONCovCmmwHLo=",
-  "lastModifiedDate": "20260630045405"
+  "version": "unstable-20260701075009-fd941f6",
+  "rev": "fd941f6261ea423d52164c8c253add1a0551d10f",
+  "hash": "sha256-LLY/Ln+pe3VmNl+GUgANnetdqfcuPD5gfrScmccnNdE=",
+  "lastModifiedDate": "20260701075009"
 }


### PR DESCRIPTION
Automated package bump for `[
  "nix_git"
]`.