### PR TITLE
chore: bump pcsx2_git

### DIFF
--- a/pkgs/pcsx2-git/version.json
+++ b/pkgs/pcsx2-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260629165733-51c9951",
-  "rev": "51c995168a77384063e75cce3730e54f7f543a02",
-  "hash": "sha256-CgmKl0qHS8MNuGl5D6QOuHI6I8ztG0p3MPsTY6L9gqw="
+  "version": "unstable-20260701094037-fe3ce7f",
+  "rev": "fe3ce7f578e2dd39418ef358d84804d290e91bc1",
+  "hash": "sha256-j14MYlB5KEqi8m/lpWqkamqngA2ybhHyjRwSKNx7y3g="
 }


### PR DESCRIPTION
Automated package bump for `[
  "pcsx2_git"
]`.