### PR TITLE
chore: bump libdrm_git

### DIFF
--- a/pkgs/mesa-git/version.json
+++ b/pkgs/mesa-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260701041352-a6bb4bb",
-  "rev": "a6bb4bbd1eaa8b1b8ba9e5df98ed2c9958393e40",
-  "hash": "sha256-EgLIEnqpApLlyNwwMSF5ph1MpHPbqW+mV/Fk2iMKE6c="
+  "version": "unstable-20260702032829-5d4b3d6",
+  "rev": "5d4b3d64982c42614873880764d3ae392cf1ca0d",
+  "hash": "sha256-opqNCEy3shAI5sIWlpEM3eBdtcmJ9uTLvFjbP5OL0GU="
 }


### PR DESCRIPTION
Automated package bump for `[
  "libdrm_git",
  "wayland-protocols_git",
  "mesa_git",
  "wayland_git",
  "wlroots_git",
  "sway-unwrapped_git",
  "xdg-desktop-portal-wlr_git"
]`.