### PR TITLE
chore: bump zed-editor_git

### DIFF
--- a/pkgs/zed-editor-git/version.json
+++ b/pkgs/zed-editor-git/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260701042540-40d2003",
-  "rev": "40d20036af34343a09f0ce6a2eb38c9e5a60e9ae",
-  "hash": "sha256-AvOypBl4wPSqyd/KeaUNM2hUTo2pl+OmALnexAAo8v8=",
-  "cargoHash": "sha256-uQhDvnkIEknJ87qftAPIgwY/FMuIz2xO+0EYNggHen8="
+  "version": "unstable-20260701225224-10b0795",
+  "rev": "10b07951838e422722e34641f4a9c0bfec9037ff",
+  "hash": "sha256-Gf8sIapuiWGqQDvTiSW4O0Yz3z8T29N2NRkDOeJyBYw=",
+  "cargoHash": "sha256-jIx3F4AD253y3w2YRafiR4aUJz1tFDoyPP16CIshQyc="
 }


### PR DESCRIPTION
Automated package bump for `[
  "zed-editor_git"
]`.