### PR TITLE
chore: bump nix_git

### DIFF
--- a/pkgs/nix-git/version.json
+++ b/pkgs/nix-git/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260701075009-fd941f6",
-  "rev": "fd941f6261ea423d52164c8c253add1a0551d10f",
-  "hash": "sha256-LLY/Ln+pe3VmNl+GUgANnetdqfcuPD5gfrScmccnNdE=",
-  "lastModifiedDate": "20260701075009"
+  "version": "unstable-20260702220848-b41781e",
+  "rev": "b41781ed09cc718773b19c04b322601e2c00db1a",
+  "hash": "sha256-WfRmwMYdnzwhMrbAy8dGIshMUd/u2UzyiyZrhLKDZig=",
+  "lastModifiedDate": "20260702220848"
 }


### PR DESCRIPTION
Automated package bump for `[
  "nix_git"
]`.