### PR TITLE
chore: bump pcsx2_git

### DIFF
--- a/pkgs/pcsx2-git/version.json
+++ b/pkgs/pcsx2-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260701094037-fe3ce7f",
-  "rev": "fe3ce7f578e2dd39418ef358d84804d290e91bc1",
-  "hash": "sha256-j14MYlB5KEqi8m/lpWqkamqngA2ybhHyjRwSKNx7y3g="
+  "version": "unstable-20260702174647-7a90cae",
+  "rev": "7a90caedeca6ceafc0fb748469fcae06b5ddaa97",
+  "hash": "sha256-nvmF22IwKfdTsOg17LZDKajk2/3jsZZ6TTYHlqHzeyg="
 }


### PR DESCRIPTION
Automated package bump for `[
  "pcsx2_git"
]`.