### PR TITLE
chore: bump zed-editor_git

### DIFF
--- a/pkgs/zed-editor-git/version.json
+++ b/pkgs/zed-editor-git/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260701225224-10b0795",
-  "rev": "10b07951838e422722e34641f4a9c0bfec9037ff",
-  "hash": "sha256-Gf8sIapuiWGqQDvTiSW4O0Yz3z8T29N2NRkDOeJyBYw=",
-  "cargoHash": "sha256-jIx3F4AD253y3w2YRafiR4aUJz1tFDoyPP16CIshQyc="
+  "version": "unstable-20260703010054-552fc9f",
+  "rev": "552fc9f3c3c775276c2ce3f0fb93f1f4c2c18ba6",
+  "hash": "sha256-zZpC7OItk3e5/Jb4sJXyCiLloDTqo5zWMaW69sn1IWE=",
+  "cargoHash": "sha256-R21BK6pMgYXQXWCWVYAp72NizfzfAA2HERPzJygbQoo="
 }


### PR DESCRIPTION
Automated package bump for `[
  "zed-editor_git"
]`.