### PR TITLE
chore: bump spirv-headers_git

### DIFF
--- a/pkgs/spirv-headers-git/version.json
+++ b/pkgs/spirv-headers-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260624153924-daa093d",
-  "rev": "daa093dd29aab8cbb6562b808370562f56e399fb",
-  "hash": "sha256-2xYphq6uMRlPaaaVSiwqPrWRkCfyOMjeJcWewRja/WY="
+  "version": "unstable-20260702211933-8d56066",
+  "rev": "8d56066eee52f490535afd5731d5ae2fffc85036",
+  "hash": "sha256-g22zRCv3B+tM3hxEzJ/6+JH/mjDBVBxzHLDVvKNMmvw="
 }


### PR DESCRIPTION
Automated package bump for `[
  "spirv-headers_git"
]`.