### PR TITLE
chore: bump libdrm_git

### DIFF
--- a/pkgs/mesa-git/version.json
+++ b/pkgs/mesa-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260702032829-5d4b3d6",
-  "rev": "5d4b3d64982c42614873880764d3ae392cf1ca0d",
-  "hash": "sha256-opqNCEy3shAI5sIWlpEM3eBdtcmJ9uTLvFjbP5OL0GU="
+  "version": "unstable-20260702231650-9963753",
+  "rev": "99637537e1b33afb21b21bb39290b647b7b67e59",
+  "hash": "sha256-4Nt8Ngx6xsXmbMAvOFZ0nGjX6qF4Vy077hTvoyT4elA="
 }

--- a/pkgs/portal-wlr-git/version.json
+++ b/pkgs/portal-wlr-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260618151856-a2e0d1e",
-  "rev": "a2e0d1e735bafefe115359de3505f51d814cd09a",
-  "hash": "sha256-T7iV0lIZO8rY36iafAtt1Ias44QkNZd1+GRLE6frYDo="
+  "version": "unstable-20260702141355-ba6a313",
+  "rev": "ba6a313d500431799ef6ad548efa9aeec8c5c314",
+  "hash": "sha256-YmFctIm/4AZLZYatVq6iJXpUvVD0RkpU2171QpB6zVQ="
 }

--- a/pkgs/sway-unwrapped-git/version.json
+++ b/pkgs/sway-unwrapped-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260630165511-edcc4b0",
-  "rev": "edcc4b0ed0b8a478f469409ef4b67917256388ec",
-  "hash": "sha256-VgZ+Gd+I5voHdPif+AT3eNBBAnmAlkMbq5uCNUx7Gvg="
+  "version": "unstable-20260702124137-f3b6431",
+  "rev": "f3b64311045c3241ac6be3fd293dff8bfd55b6d4",
+  "hash": "sha256-cCVhLvVKX3GqQ+5H9j2wQy2zSqzheM0Fw8uReUJzb2I="
 }

--- a/pkgs/wayland-git/version.json
+++ b/pkgs/wayland-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260608102928-165504a",
-  "rev": "165504a90edd7d6e51dd42d11f9dd0e8c9384609",
-  "hash": "sha256-ptyff8wTlBP5XaOG4+sBgOwq8IcFMbuwzzBzQxbb7FU="
+  "version": "unstable-20260702133454-79e3150",
+  "rev": "79e3150782b7067f4ae345305e6a4eac5930be95",
+  "hash": "sha256-pQ0UyLLs7e9waAuoMlXJo9WbzAEGtVyf2REUxaJFOHA="
 }


### PR DESCRIPTION
Automated package bump for `[
  "libdrm_git",
  "wayland-protocols_git",
  "mesa_git",
  "wayland_git",
  "wlroots_git",
  "sway-unwrapped_git",
  "xdg-desktop-portal-wlr_git"
]`.