### PR TITLE
chore: bump helix_git

### DIFF
--- a/pkgs/helix-git/version.json
+++ b/pkgs/helix-git/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260629024657-278b243",
-  "rev": "278b24389457e33791d394dd9a8a93740e2cc099",
-  "hash": "sha256-Hu9yGydALMMsNsAIKjtIvhjPNhsmZLUcaOcDFyJ8v90=",
-  "cargoHash": "sha256-iFuGPTsEDH4PbRrdxjhFWS+j+MMldGvT9eltXuZPzho="
+  "version": "unstable-20260703014245-2868367",
+  "rev": "2868367c80019d8ec54ec52b84d3e4f7a2f94814",
+  "hash": "sha256-fbgOnmm34aDiNkZdtVBR9gEWXsw0agjxbBJVDSroVZo=",
+  "cargoHash": "sha256-KbfewCYtZxFF/9dFYLZdqFnAtaqnnyt/GBC9E4xYni0="
 }


### PR DESCRIPTION
Automated package bump for `[
  "helix_git"
]`.