### PR TITLE
chore: bump nss_git

### DIFF
--- a/pkgs/firefox-nightly/version.json
+++ b/pkgs/firefox-nightly/version.json
@@ -1,6 +1,6 @@
 {
   "version": "154.0a1",
-  "rev": "0a7f146ccac85b8f413264042dcd764028d419ec",
-  "buildId": "20260701192917",
-  "hash": "sha256-HiuBJjQDYwfgikLC2F/KPhVBzpkzmkUO0r2SF49qwUU="
+  "rev": "4eb5d723d627edec42ca3e5d606e1227c656dfca",
+  "buildId": "20260702212026",
+  "hash": "sha256-MEi6106vgrV5Ay650LlfWthu8TTWTCglD6xtYT1nWvE="
 }

--- a/pkgs/nss-git/version.json
+++ b/pkgs/nss-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260701222603-192f7e9",
-  "rev": "192f7e96397038c6caf0534cf9fb926307278d3f",
-  "hash": "sha256-wLofZlSErmL0hQvhDNa0I5QQYMc8akhQa6hf2YIY1Bw="
+  "version": "unstable-20260702213647-9e86123",
+  "rev": "9e861234be33b0778930541d02d7504b1a0b3f45",
+  "hash": "sha256-FANROG7QC+6W3ssEZU9g4yVr8xTDPp9ghmKEqVTo9Ds="
 }


### PR DESCRIPTION
Automated package bump for `[
  "nss_git",
  "firefox-unwrapped_nightly"
]`.