### PR TITLE
chore: bump mangohud_git

### DIFF
--- a/pkgs/mangohud-git/version.json
+++ b/pkgs/mangohud-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260702225450-e921cbf",
-  "rev": "e921cbfb9d25280303263ccebea9ef5d4d71dd02",
-  "hash": "sha256-/WwQOMQqXX1BJoDmUoRy6TkRP2cqPrNGdLkFtPM/T/A="
+  "version": "unstable-20260704042421-b76a1aa",
+  "rev": "b76a1aa25a9fbd1697fd83c0dee4bc751cdb631d",
+  "hash": "sha256-nRj9PKyu3Rc43XWZ2jAi1ahABjfW/bu7rM/T9TjtkWA="
 }


### PR DESCRIPTION
Automated package bump for `[
  "mangohud_git"
]`.