### PR TITLE
chore: bump openrgb_git

### DIFF
--- a/pkgs/openrgb-git/version.json
+++ b/pkgs/openrgb-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260630064920-6b8db47",
-  "rev": "6b8db478fb6038cd0602ca61d601be6a1bc6c075",
-  "hash": "sha256-HUdILRY8u+8ouuWtr33npTADAnrNLowx3FPbdECFngM="
+  "version": "unstable-20260703221225-c0a9c96",
+  "rev": "c0a9c96bea24a2ef85a6044f5cffee4135d62f67",
+  "hash": "sha256-oULKRgNR8b/Gg4TEpdDglvTKOzaw8WK+qm/NGJ8BX2Y="
 }


### PR DESCRIPTION
Automated package bump for `[
  "openrgb_git"
]`.