### PR TITLE
chore: bump tde2e_git

### DIFF
--- a/pkgs/telegram-desktop-git/version.json
+++ b/pkgs/telegram-desktop-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260703030051-0eb071f",
-  "rev": "0eb071fcede9a4706b65318f133a02f03d9b9885",
-  "hash": "sha256-iy5C4Y3fjL9775Sx3/yZXZYaRlXzu0klMBnpLpk0hBo="
+  "version": "unstable-20260703193701-54d4d8a",
+  "rev": "54d4d8a03e074b69bbd2b9350cca202c8e5acb5b",
+  "hash": "sha256-Zi1xxgXIzwUE91ZRg1Tn5KZacVcfzlqU/suNQJ7BEo4="
 }


### PR DESCRIPTION
Automated package bump for `[
  "tde2e_git",
  "tg-owt_git",
  "telegram-desktop-unwrapped_git",
  "telegram-desktop_git"
]`.