### PR TITLE
chore: bump pcsx2_git

### DIFF
--- a/pkgs/pcsx2-git/version.json
+++ b/pkgs/pcsx2-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260702174647-7a90cae",
-  "rev": "7a90caedeca6ceafc0fb748469fcae06b5ddaa97",
-  "hash": "sha256-nvmF22IwKfdTsOg17LZDKajk2/3jsZZ6TTYHlqHzeyg="
+  "version": "unstable-20260704002206-b6e9a04",
+  "rev": "b6e9a044331bed193326a912bb897ed3e9861701",
+  "hash": "sha256-D341wTINdS4BPCiYGXUhuZvXGvMlB+BviTcW5S+YNqk="
 }


### PR DESCRIPTION
Automated package bump for `[
  "pcsx2_git"
]`.