### PR TITLE
chore: bump spirv-headers_git

### DIFF
--- a/pkgs/spirv-headers-git/version.json
+++ b/pkgs/spirv-headers-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260702211933-8d56066",
-  "rev": "8d56066eee52f490535afd5731d5ae2fffc85036",
-  "hash": "sha256-g22zRCv3B+tM3hxEzJ/6+JH/mjDBVBxzHLDVvKNMmvw="
+  "version": "unstable-20260703202813-02c0394",
+  "rev": "02c0394e57af6dfdda7f68973df6aa20fc3f5def",
+  "hash": "sha256-1+o9gZmMkWa0UFPvvF4OM/IZS7uWPIa/CZPPskVT7Jw="
 }


### PR DESCRIPTION
Automated package bump for `[
  "spirv-headers_git"
]`.