### PR TITLE
chore: bump zed-editor_git

### DIFF
--- a/pkgs/zed-editor-git/version.json
+++ b/pkgs/zed-editor-git/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260703010054-552fc9f",
-  "rev": "552fc9f3c3c775276c2ce3f0fb93f1f4c2c18ba6",
-  "hash": "sha256-zZpC7OItk3e5/Jb4sJXyCiLloDTqo5zWMaW69sn1IWE=",
-  "cargoHash": "sha256-R21BK6pMgYXQXWCWVYAp72NizfzfAA2HERPzJygbQoo="
+  "version": "unstable-20260703232901-1a99eba",
+  "rev": "1a99eba1926a2776cfb39be3dca922cf08483af7",
+  "hash": "sha256-0SqG61bjFkDnmGNNKBfVYzFqG50fumLalojv6aEkydw=",
+  "cargoHash": "sha256-1l8ni8jQGlXMMFDwZ8KCSEvGSgT3etNXwttqu1mF4EQ="
 }


### PR DESCRIPTION
Automated package bump for `[
  "zed-editor_git"
]`.