### PR TITLE
chore: bump libdrm_git

### DIFF
--- a/pkgs/mesa-git/version.json
+++ b/pkgs/mesa-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260702231650-9963753",
-  "rev": "99637537e1b33afb21b21bb39290b647b7b67e59",
-  "hash": "sha256-4Nt8Ngx6xsXmbMAvOFZ0nGjX6qF4Vy077hTvoyT4elA="
+  "version": "unstable-20260704014026-4274cd9",
+  "rev": "4274cd9ca6ba528651fc60eb035e3b1154cd5b2d",
+  "hash": "sha256-YTCt8vYoE9ar9gnr93Za/uwMrPs8iL6eHPNPzCHDjkM="
 }

--- a/pkgs/wayland-git/version.json
+++ b/pkgs/wayland-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260702133454-79e3150",
-  "rev": "79e3150782b7067f4ae345305e6a4eac5930be95",
-  "hash": "sha256-pQ0UyLLs7e9waAuoMlXJo9WbzAEGtVyf2REUxaJFOHA="
+  "version": "unstable-20260703105758-67af365",
+  "rev": "67af3659fac3050b422198700643f5ee13932ebd",
+  "hash": "sha256-qflncPxliM1W77JTY0YJADj0kRuU/HNardUkHHunaos="
 }


### PR DESCRIPTION
Automated package bump for `[
  "libdrm_git",
  "wayland-protocols_git",
  "mesa_git",
  "wayland_git",
  "wlroots_git",
  "sway-unwrapped_git",
  "xdg-desktop-portal-wlr_git"
]`.