### PR TITLE
chore: bump nss_git

### DIFF
--- a/pkgs/firefox-nightly/version.json
+++ b/pkgs/firefox-nightly/version.json
@@ -1,6 +1,6 @@
 {
   "version": "154.0a1",
-  "rev": "4eb5d723d627edec42ca3e5d606e1227c656dfca",
-  "buildId": "20260702212026",
-  "hash": "sha256-MEi6106vgrV5Ay650LlfWthu8TTWTCglD6xtYT1nWvE="
+  "rev": "24cab6a0399d3dd76568e424d9a720b2be4f56df",
+  "buildId": "20260703214104",
+  "hash": "sha256-qHvn3SDv/BKlnGij+V2dyVjjx1LULyOemzlPmVBJCF8="
 }

--- a/pkgs/nss-git/version.json
+++ b/pkgs/nss-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260702213647-9e86123",
-  "rev": "9e861234be33b0778930541d02d7504b1a0b3f45",
-  "hash": "sha256-FANROG7QC+6W3ssEZU9g4yVr8xTDPp9ghmKEqVTo9Ds="
+  "version": "unstable-20260703171325-7c0c73d",
+  "rev": "7c0c73d30e9c140bc24e8faf545b6a77a1dd9d39",
+  "hash": "sha256-itnLsR8bvyH5lFtxd+yUcO+mMRYAP76jqJVJHA9JTjE="
 }


### PR DESCRIPTION
Automated package bump for `[
  "nss_git",
  "firefox-unwrapped_nightly"
]`.