### PR TITLE
chore: bump openrgb_git

### DIFF
--- a/pkgs/openrgb-git/version.json
+++ b/pkgs/openrgb-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260703221225-c0a9c96",
-  "rev": "c0a9c96bea24a2ef85a6044f5cffee4135d62f67",
-  "hash": "sha256-oULKRgNR8b/Gg4TEpdDglvTKOzaw8WK+qm/NGJ8BX2Y="
+  "version": "unstable-20260704201048-dfe099f",
+  "rev": "dfe099fe9bd180775ed47e63fad3ca38ad42626c",
+  "hash": "sha256-uvL8SH3Ono+GzMKLcQ63+YbSducEC4PdO3GaenjRJiI="
 }


### PR DESCRIPTION
Automated package bump for `[
  "openrgb_git"
]`.