### PR TITLE
chore: bump zed-editor_git

### DIFF
--- a/pkgs/zed-editor-git/version.json
+++ b/pkgs/zed-editor-git/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260703232901-1a99eba",
-  "rev": "1a99eba1926a2776cfb39be3dca922cf08483af7",
-  "hash": "sha256-0SqG61bjFkDnmGNNKBfVYzFqG50fumLalojv6aEkydw=",
+  "version": "unstable-20260705035454-6e9ff7a",
+  "rev": "6e9ff7a4f31ad4baa467058765f5fee00e4c2bc7",
+  "hash": "sha256-jTC/uPQU/GINJDOYtraFZgtdUTKhJI31hT9iZKVWgB8=",
   "cargoHash": "sha256-1l8ni8jQGlXMMFDwZ8KCSEvGSgT3etNXwttqu1mF4EQ="
 }


### PR DESCRIPTION
Automated package bump for `[
  "zed-editor_git"
]`.