### PR TITLE
chore: bump pcsx2_git

### DIFF
--- a/pkgs/pcsx2-git/version.json
+++ b/pkgs/pcsx2-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260704002206-b6e9a04",
-  "rev": "b6e9a044331bed193326a912bb897ed3e9861701",
-  "hash": "sha256-D341wTINdS4BPCiYGXUhuZvXGvMlB+BviTcW5S+YNqk="
+  "version": "unstable-20260704195116-fd46054",
+  "rev": "fd46054fb77a04038d3ef9a73e1666f1031ba5b5",
+  "hash": "sha256-c3Wki/wOc+zh+w46j/urJoMxqXv4LYx4aW3nBShDJBc="
 }


### PR DESCRIPTION
Automated package bump for `[
  "pcsx2_git"
]`.