### PR TITLE
chore: bump tde2e_git

### DIFF
--- a/pkgs/telegram-desktop-git/version.json
+++ b/pkgs/telegram-desktop-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260703193701-54d4d8a",
-  "rev": "54d4d8a03e074b69bbd2b9350cca202c8e5acb5b",
-  "hash": "sha256-Zi1xxgXIzwUE91ZRg1Tn5KZacVcfzlqU/suNQJ7BEo4="
+  "version": "unstable-20260704124646-c14efc2",
+  "rev": "c14efc268ce75e7e48e3c02327f1fcbe79d92e92",
+  "hash": "sha256-bHUnlAd6a5qw8rfjAPIZZ9IHpL79re1uuV+l3uoIjBA="
 }


### PR DESCRIPTION
Automated package bump for `[
  "tde2e_git",
  "tg-owt_git",
  "telegram-desktop-unwrapped_git",
  "telegram-desktop_git"
]`.