### PR TITLE
chore: bump libdrm_git

### DIFF
--- a/pkgs/mesa-git/version.json
+++ b/pkgs/mesa-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260704014026-4274cd9",
-  "rev": "4274cd9ca6ba528651fc60eb035e3b1154cd5b2d",
-  "hash": "sha256-YTCt8vYoE9ar9gnr93Za/uwMrPs8iL6eHPNPzCHDjkM="
+  "version": "unstable-20260705024518-58513e4",
+  "rev": "58513e4bb72e29fac2abb5e89c6ef308d7cbe658",
+  "hash": "sha256-WM7OHK4s7qWxmU6XWkvVDsOo3CNM52jlgsBMTpK6WwM="
 }

--- a/pkgs/portal-wlr-git/version.json
+++ b/pkgs/portal-wlr-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260702141355-ba6a313",
-  "rev": "ba6a313d500431799ef6ad548efa9aeec8c5c314",
-  "hash": "sha256-YmFctIm/4AZLZYatVq6iJXpUvVD0RkpU2171QpB6zVQ="
+  "version": "unstable-20260704145953-ea80500",
+  "rev": "ea80500a3b6ab381776d4bd5ee615b44dc8d7b54",
+  "hash": "sha256-A5jTJi7qqNMa/qWmqgqNTnRAcolbD7Bsm4nfXw9wSOY="
 }


### PR DESCRIPTION
Automated package bump for `[
  "libdrm_git",
  "wayland-protocols_git",
  "mesa_git",
  "wayland_git",
  "wlroots_git",
  "sway-unwrapped_git",
  "xdg-desktop-portal-wlr_git"
]`.