### PR TITLE
chore: bump nss_git

### DIFF
--- a/pkgs/firefox-nightly/version.json
+++ b/pkgs/firefox-nightly/version.json
@@ -1,6 +1,6 @@
 {
   "version": "154.0a1",
-  "rev": "24cab6a0399d3dd76568e424d9a720b2be4f56df",
-  "buildId": "20260703214104",
-  "hash": "sha256-qHvn3SDv/BKlnGij+V2dyVjjx1LULyOemzlPmVBJCF8="
+  "rev": "609faad611b33bee94f2fcb455a6b840093bab89",
+  "buildId": "20260704213149",
+  "hash": "sha256-VzTkDwllfErZIh/epq4OrB9ex/mDRQ/tvTiRdzV7D34="
 }


### PR DESCRIPTION
Automated package bump for `[
  "nss_git",
  "firefox-unwrapped_nightly"
]`.