### PR TITLE
chore: bump openrgb_git

### DIFF
--- a/pkgs/openrgb-git/version.json
+++ b/pkgs/openrgb-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260704201048-dfe099f",
-  "rev": "dfe099fe9bd180775ed47e63fad3ca38ad42626c",
-  "hash": "sha256-uvL8SH3Ono+GzMKLcQ63+YbSducEC4PdO3GaenjRJiI="
+  "version": "unstable-20260705222039-1e1fb09",
+  "rev": "1e1fb09821ae8f3580730600cdc960472b27085b",
+  "hash": "sha256-NGcdyGoLy75lNRjlKiCWLAw/akUZNWmshXzbm4lJdnk="
 }


### PR DESCRIPTION
Automated package bump for `[
  "openrgb_git"
]`.