### PR TITLE
chore: bump nix_git

### DIFF
--- a/pkgs/nix-git/version.json
+++ b/pkgs/nix-git/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260702220848-b41781e",
-  "rev": "b41781ed09cc718773b19c04b322601e2c00db1a",
-  "hash": "sha256-WfRmwMYdnzwhMrbAy8dGIshMUd/u2UzyiyZrhLKDZig=",
-  "lastModifiedDate": "20260702220848"
+  "version": "unstable-20260705202710-0e27c67",
+  "rev": "0e27c6740ed2dbf8bd1ec9e9faa80ed7ef39960b",
+  "hash": "sha256-MFotaCFDYeT/OFk7o9ItWpB/ag3csOKSPKIi0ry+JV0=",
+  "lastModifiedDate": "20260705202710"
 }


### PR DESCRIPTION
Automated package bump for `[
  "nix_git"
]`.