### PR TITLE
chore: bump niri_git

### DIFF
--- a/pkgs/niri-git/version.json
+++ b/pkgs/niri-git/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260618111104-49fc611",
-  "rev": "49fc6117fd6c043adaa2ead316b82db5ed735d36",
-  "hash": "sha256-Ii/koEm/sRyg65qbAQWqEgboSEIhdH0EL4KglAc14p0=",
+  "version": "unstable-20260705105541-a30ca79",
+  "rev": "a30ca7983b2f1fc3ddeb209b3fe18fa78e0dbd25",
+  "hash": "sha256-citgYJbvR1iUKXpiWlFq3NO+fw6hXGL3Qk1ampU7lhA=",
   "cargoHash": "sha256-jGORNwJ/F9UrajObXdGLbOTGEpCv919puUuWojbuVwo="
 }


### PR DESCRIPTION
Automated package bump for `[
  "niri_git"
]`.