### PR TITLE
chore: bump tde2e_git

### DIFF
--- a/pkgs/telegram-desktop-git/version.json
+++ b/pkgs/telegram-desktop-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260704124646-c14efc2",
-  "rev": "c14efc268ce75e7e48e3c02327f1fcbe79d92e92",
-  "hash": "sha256-bHUnlAd6a5qw8rfjAPIZZ9IHpL79re1uuV+l3uoIjBA="
+  "version": "unstable-20260705203730-1eeea7e",
+  "rev": "1eeea7e60b4b0ff38b73e24cc42dc026e292107b",
+  "hash": "sha256-q8o7lxeKEUPadX6L/L4OAXM3Vvx8uhMOQ8ZxznnuiKY="
 }


### PR DESCRIPTION
Automated package bump for `[
  "tde2e_git",
  "tg-owt_git",
  "telegram-desktop-unwrapped_git",
  "telegram-desktop_git"
]`.