### PR TITLE
chore: bump zed-editor_git

### DIFF
--- a/pkgs/zed-editor-git/version.json
+++ b/pkgs/zed-editor-git/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260705035454-6e9ff7a",
-  "rev": "6e9ff7a4f31ad4baa467058765f5fee00e4c2bc7",
-  "hash": "sha256-jTC/uPQU/GINJDOYtraFZgtdUTKhJI31hT9iZKVWgB8=",
+  "version": "unstable-20260706031543-04de6da",
+  "rev": "04de6dab7c890d815e316f2f9554f9eeeaf8ebb2",
+  "hash": "sha256-LXP0zyEXkEh7tRnW8fkMrmkEeDJCNZOIX9m1UmzXGdY=",
   "cargoHash": "sha256-1l8ni8jQGlXMMFDwZ8KCSEvGSgT3etNXwttqu1mF4EQ="
 }


### PR DESCRIPTION
Automated package bump for `[
  "zed-editor_git"
]`.