### PR TITLE
chore: bump libdrm_git

### DIFF
--- a/pkgs/mesa-git/version.json
+++ b/pkgs/mesa-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260705024518-58513e4",
-  "rev": "58513e4bb72e29fac2abb5e89c6ef308d7cbe658",
-  "hash": "sha256-WM7OHK4s7qWxmU6XWkvVDsOo3CNM52jlgsBMTpK6WwM="
+  "version": "unstable-20260706024817-97da377",
+  "rev": "97da3770b2a5c535cf1305e7ebbd508526e9a05f",
+  "hash": "sha256-za4rc4Mb/ezu1AJ7NJdAalt4qA0Ti7dadxqP2/jEYAw="
 }


### PR DESCRIPTION
Automated package bump for `[
  "libdrm_git",
  "wayland-protocols_git",
  "mesa_git",
  "wayland_git",
  "wlroots_git",
  "sway-unwrapped_git",
  "xdg-desktop-portal-wlr_git"
]`.