### PR TITLE
chore: bump helix_git

### DIFF
--- a/pkgs/helix-git/version.json
+++ b/pkgs/helix-git/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260705031004-44c801d",
-  "rev": "44c801d2b5bd104f67c63d3d86174c91f38e7529",
-  "hash": "sha256-+he0R1mYFuYL+fYkU9f/20S3ygiw69a0Sv8Nmbllocs=",
+  "version": "unstable-20260705191938-39b3f22",
+  "rev": "39b3f22b1bf53f64bd4256b133f4563c4d0e43b0",
+  "hash": "sha256-DREuXUJR25e5BV8nvG3cDpt/Xte9rGgMPrTHjd0KugU=",
   "cargoHash": "sha256-oo59HhwOS3EeV/YI+NWirEkdzD9pzMot2lgphZeOxfc="
 }


### PR DESCRIPTION
Automated package bump for `[
  "helix_git"
]`.