### PR TITLE
chore: bump nss_git

### DIFF
--- a/pkgs/firefox-nightly/version.json
+++ b/pkgs/firefox-nightly/version.json
@@ -1,6 +1,6 @@
 {
   "version": "154.0a1",
-  "rev": "609faad611b33bee94f2fcb455a6b840093bab89",
-  "buildId": "20260704213149",
-  "hash": "sha256-VzTkDwllfErZIh/epq4OrB9ex/mDRQ/tvTiRdzV7D34="
+  "rev": "d154a3eb431156b2bd63d3d5f96c82655b4e782d",
+  "buildId": "20260705204834",
+  "hash": "sha256-8Uj6SG4J8DgirEldCvBanjIsFos6y88ZcgpPx70xc9s="
 }


### PR DESCRIPTION
Automated package bump for `[
  "nss_git",
  "firefox-unwrapped_nightly"
]`.