### PR TITLE
chore: bump nix_git

### DIFF
--- a/pkgs/nix-git/version.json
+++ b/pkgs/nix-git/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260705202710-0e27c67",
-  "rev": "0e27c6740ed2dbf8bd1ec9e9faa80ed7ef39960b",
-  "hash": "sha256-MFotaCFDYeT/OFk7o9ItWpB/ag3csOKSPKIi0ry+JV0=",
-  "lastModifiedDate": "20260705202710"
+  "version": "unstable-20260706203159-9a06fdc",
+  "rev": "9a06fdc75f0b5c20e11276824b5cc3b034829e8a",
+  "hash": "sha256-n06XChnmO2Dukk8vjBQNmNI3tEc4ugTD+6Gv1erBE6w=",
+  "lastModifiedDate": "20260706203159"
 }


### PR DESCRIPTION
Automated package bump for `[
  "nix_git"
]`.