### PR TITLE
chore: bump zed-editor_git

### DIFF
--- a/pkgs/zed-editor-git/version.json
+++ b/pkgs/zed-editor-git/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260706031543-04de6da",
-  "rev": "04de6dab7c890d815e316f2f9554f9eeeaf8ebb2",
-  "hash": "sha256-LXP0zyEXkEh7tRnW8fkMrmkEeDJCNZOIX9m1UmzXGdY=",
+  "version": "unstable-20260707013506-872ca8f",
+  "rev": "872ca8fef52fe527fc922e8bf61e93201de79878",
+  "hash": "sha256-vvd4NOFFtX/yb+pqyJM+PACuar/I8oN9m9MpeH12Rrc=",
   "cargoHash": "sha256-1l8ni8jQGlXMMFDwZ8KCSEvGSgT3etNXwttqu1mF4EQ="
 }


### PR DESCRIPTION
Automated package bump for `[
  "zed-editor_git"
]`.