### PR TITLE
chore: bump libdrm_git

### DIFF
--- a/pkgs/mesa-git/version.json
+++ b/pkgs/mesa-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260706024817-97da377",
-  "rev": "97da3770b2a5c535cf1305e7ebbd508526e9a05f",
-  "hash": "sha256-za4rc4Mb/ezu1AJ7NJdAalt4qA0Ti7dadxqP2/jEYAw="
+  "version": "unstable-20260707024323-eaa4b57",
+  "rev": "eaa4b57774d1f8825dcdfc280ceb8adbecfd19d3",
+  "hash": "sha256-MNP5JWiRbR8fU3odJxcAX0atyVq2qJiArC8jnjX/xCE="
 }

--- a/pkgs/wayland-git/version.json
+++ b/pkgs/wayland-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260703105758-67af365",
-  "rev": "67af3659fac3050b422198700643f5ee13932ebd",
-  "hash": "sha256-qflncPxliM1W77JTY0YJADj0kRuU/HNardUkHHunaos="
+  "version": "unstable-20260706083425-7e2118f",
+  "rev": "7e2118f3c271203e0ea25b982517777d32f525ad",
+  "hash": "sha256-P6Xv1O42jUar3C8rL5XETa4nQEbfCGIjsXBxqhUYmDE="
 }

--- a/pkgs/wlroots-git/version.json
+++ b/pkgs/wlroots-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260622151852-29fc556",
-  "rev": "29fc556f4cd70896e464b3402b510d9759707cf8",
-  "hash": "sha256-hn2gbw+QMHQ1lpJp9xxleHEmD+w8FRHnQAwlCu+U8Go="
+  "version": "unstable-20260706132502-327f000",
+  "rev": "327f000532e96329280e06eb12af2d98071ac023",
+  "hash": "sha256-QQUsnzNo6uzhwDCnadZQpfxGmhihUZjjuSsSn0+9SuQ="
 }


### PR DESCRIPTION
Automated package bump for `[
  "libdrm_git",
  "wayland-protocols_git",
  "mesa_git",
  "wayland_git",
  "wlroots_git",
  "sway-unwrapped_git",
  "xdg-desktop-portal-wlr_git"
]`.