### PR TITLE
chore: bump helix_git

### DIFF
--- a/pkgs/helix-git/version.json
+++ b/pkgs/helix-git/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260705191938-39b3f22",
-  "rev": "39b3f22b1bf53f64bd4256b133f4563c4d0e43b0",
-  "hash": "sha256-DREuXUJR25e5BV8nvG3cDpt/Xte9rGgMPrTHjd0KugU=",
+  "version": "unstable-20260706194641-14d6bc0",
+  "rev": "14d6bc0febed9c692048271a8ae2362ac969c6e0",
+  "hash": "sha256-/ibzswTrAp1yW0GStFZGyRl6KO+wb9wZIUZWH4bz3ww=",
   "cargoHash": "sha256-oo59HhwOS3EeV/YI+NWirEkdzD9pzMot2lgphZeOxfc="
 }


### PR DESCRIPTION
Automated package bump for `[
  "helix_git"
]`.