### PR TITLE
chore: bump nss_git

### DIFF
--- a/pkgs/firefox-nightly/version.json
+++ b/pkgs/firefox-nightly/version.json
@@ -1,6 +1,6 @@
 {
   "version": "154.0a1",
-  "rev": "d154a3eb431156b2bd63d3d5f96c82655b4e782d",
-  "buildId": "20260705204834",
-  "hash": "sha256-8Uj6SG4J8DgirEldCvBanjIsFos6y88ZcgpPx70xc9s="
+  "rev": "c86fcb7f22721f58a39455cb965da7634ecf88e6",
+  "buildId": "20260706214124",
+  "hash": "sha256-PVwhLGhjmy0mMWkchnMN4M5GSxVwLyuSN2fqybVHxAk="
 }


### PR DESCRIPTION
Automated package bump for `[
  "nss_git",
  "firefox-unwrapped_nightly"
]`.