### PR TITLE
chore: bump tde2e_git

### DIFF
--- a/pkgs/telegram-desktop-git/version.json
+++ b/pkgs/telegram-desktop-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260705203730-1eeea7e",
-  "rev": "1eeea7e60b4b0ff38b73e24cc42dc026e292107b",
-  "hash": "sha256-q8o7lxeKEUPadX6L/L4OAXM3Vvx8uhMOQ8ZxznnuiKY="
+  "version": "unstable-20260707193750-d359e19",
+  "rev": "d359e194eb9908d87bf00caab2a9eaebef22483d",
+  "hash": "sha256-FRfz9mGI92f5IBsiEUDfFnovb2El5YmbCPbr+ajLoXg="
 }


### PR DESCRIPTION
Automated package bump for `[
  "tde2e_git",
  "tg-owt_git",
  "telegram-desktop-unwrapped_git",
  "telegram-desktop_git"
]`.