### PR TITLE
chore: bump openrgb_git

### DIFF
--- a/pkgs/openrgb-git/version.json
+++ b/pkgs/openrgb-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260705222039-1e1fb09",
-  "rev": "1e1fb09821ae8f3580730600cdc960472b27085b",
-  "hash": "sha256-NGcdyGoLy75lNRjlKiCWLAw/akUZNWmshXzbm4lJdnk="
+  "version": "unstable-20260707063416-3818398",
+  "rev": "3818398d86e59584c5b6e96e7271cc08ba494b74",
+  "hash": "sha256-D1Iz8EzTiPjpCO5zpqqsAd333Uncug6bh0SM+CBwwTg="
 }


### PR DESCRIPTION
Automated package bump for `[
  "openrgb_git"
]`.