### PR TITLE
chore: bump libdrm_git

### DIFF
--- a/pkgs/mesa-git/version.json
+++ b/pkgs/mesa-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260707024323-eaa4b57",
-  "rev": "eaa4b57774d1f8825dcdfc280ceb8adbecfd19d3",
-  "hash": "sha256-MNP5JWiRbR8fU3odJxcAX0atyVq2qJiArC8jnjX/xCE="
+  "version": "unstable-20260708022412-2451cb6",
+  "rev": "2451cb698eafa8df57f62e935f09c34feabeef97",
+  "hash": "sha256-2WpwT0dBE60b+F6aettcDdzFQDd6hHYweP/EhFyscZQ="
 }

--- a/pkgs/wayland-git/version.json
+++ b/pkgs/wayland-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260706083425-7e2118f",
-  "rev": "7e2118f3c271203e0ea25b982517777d32f525ad",
-  "hash": "sha256-P6Xv1O42jUar3C8rL5XETa4nQEbfCGIjsXBxqhUYmDE="
+  "version": "unstable-20260707115522-c28d941",
+  "rev": "c28d941787c47f7e21a39638340086ad74939014",
+  "hash": "sha256-J/qH076HfeZ/XabEB7gAhN6owv6LfJryX0EzHZnveJo="
 }

--- a/pkgs/wlroots-git/version.json
+++ b/pkgs/wlroots-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260706132502-327f000",
-  "rev": "327f000532e96329280e06eb12af2d98071ac023",
-  "hash": "sha256-QQUsnzNo6uzhwDCnadZQpfxGmhihUZjjuSsSn0+9SuQ="
+  "version": "unstable-20260707154543-d70c84b",
+  "rev": "d70c84b5717dafd922f434b022873b7f1b276543",
+  "hash": "sha256-ftdw0GpkjLFAg97jHYoK5911g/NDY/V+p2stqiU+Yy0="
 }


### PR DESCRIPTION
Automated package bump for `[
  "libdrm_git",
  "wayland-protocols_git",
  "mesa_git",
  "wayland_git",
  "wlroots_git",
  "sway-unwrapped_git",
  "xdg-desktop-portal-wlr_git"
]`.