### PR TITLE
chore: bump zed-editor_git

### DIFF
--- a/pkgs/zed-editor-git/version.json
+++ b/pkgs/zed-editor-git/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260707013506-872ca8f",
-  "rev": "872ca8fef52fe527fc922e8bf61e93201de79878",
-  "hash": "sha256-vvd4NOFFtX/yb+pqyJM+PACuar/I8oN9m9MpeH12Rrc=",
-  "cargoHash": "sha256-1l8ni8jQGlXMMFDwZ8KCSEvGSgT3etNXwttqu1mF4EQ="
+  "version": "unstable-20260707230012-f9c9947",
+  "rev": "f9c994796ad4341649d7b8664edbdfaae8bebd5d",
+  "hash": "sha256-L6rm0G3LgbbZIWeAP92B4M4DL9sRlB4zGYSJmgK7biw=",
+  "cargoHash": "sha256-Mfsi/IW4N7V5QrBJBViCq45Wde+smldE3dGdSpQ2QmE="
 }


### PR DESCRIPTION
Automated package bump for `[
  "zed-editor_git"
]`.