### PR TITLE
chore: bump nss_git

### DIFF
--- a/pkgs/firefox-nightly/version.json
+++ b/pkgs/firefox-nightly/version.json
@@ -1,6 +1,6 @@
 {
   "version": "154.0a1",
-  "rev": "c86fcb7f22721f58a39455cb965da7634ecf88e6",
-  "buildId": "20260706214124",
-  "hash": "sha256-PVwhLGhjmy0mMWkchnMN4M5GSxVwLyuSN2fqybVHxAk="
+  "rev": "4b550c17bb6c2c7bac7e8842c6b76f17debf643f",
+  "buildId": "20260707211043",
+  "hash": "sha256-NhgrG1NJzOayKzeevQDvOrc2dnOMAtzkfTGLaNipM9o="
 }


### PR DESCRIPTION
Automated package bump for `[
  "nss_git",
  "firefox-unwrapped_nightly"
]`.