### PR TITLE
chore: bump openrgb_git

### DIFF
--- a/pkgs/openrgb-git/version.json
+++ b/pkgs/openrgb-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260707063416-3818398",
-  "rev": "3818398d86e59584c5b6e96e7271cc08ba494b74",
-  "hash": "sha256-D1Iz8EzTiPjpCO5zpqqsAd333Uncug6bh0SM+CBwwTg="
+  "version": "unstable-20260709011638-b833a43",
+  "rev": "b833a43490a7c7c85fd6cd0fb09dd7d734504671",
+  "hash": "sha256-K1GaViybuKg+eRXcrv/Q1gdFVA1H8Tvs4y16xzfXqTk="
 }


### PR DESCRIPTION
Automated package bump for `[
  "openrgb_git"
]`.