### PR TITLE
chore: bump spirv-headers_git

### DIFF
--- a/pkgs/spirv-headers-git/version.json
+++ b/pkgs/spirv-headers-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260703202813-02c0394",
-  "rev": "02c0394e57af6dfdda7f68973df6aa20fc3f5def",
-  "hash": "sha256-1+o9gZmMkWa0UFPvvF4OM/IZS7uWPIa/CZPPskVT7Jw="
+  "version": "unstable-20260708154953-29981f6",
+  "rev": "29981f65241605e08b0ede4cfeb999fe3b723c6a",
+  "hash": "sha256-tGY4H3+5p9M5LBK/xxRdMT9CX+qq3e7fPkaftnpjU9I="
 }


### PR DESCRIPTION
Automated package bump for `[
  "spirv-headers_git"
]`.