### PR TITLE
chore: bump niri_git

### DIFF
--- a/pkgs/niri-git/version.json
+++ b/pkgs/niri-git/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260705105541-a30ca79",
-  "rev": "a30ca7983b2f1fc3ddeb209b3fe18fa78e0dbd25",
-  "hash": "sha256-citgYJbvR1iUKXpiWlFq3NO+fw6hXGL3Qk1ampU7lhA=",
-  "cargoHash": "sha256-jGORNwJ/F9UrajObXdGLbOTGEpCv919puUuWojbuVwo="
+  "version": "unstable-20260708145915-0777769",
+  "rev": "0777769e719b7c9b7c980d4ea66288bfbb4da5b3",
+  "hash": "sha256-dI0HkX1djETia7cD/Y64h8BNIsSOfTRMzfNum2J6UhE=",
+  "cargoHash": "sha256-jmYkGX4M69W16qr9kLHfnAAJWvJ87IMVBQcC2wE9Phc="
 }


### PR DESCRIPTION
Automated package bump for `[
  "niri_git"
]`.