### PR TITLE
chore: bump nix_git

### DIFF
--- a/pkgs/nix-git/version.json
+++ b/pkgs/nix-git/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260706203159-9a06fdc",
-  "rev": "9a06fdc75f0b5c20e11276824b5cc3b034829e8a",
-  "hash": "sha256-n06XChnmO2Dukk8vjBQNmNI3tEc4ugTD+6Gv1erBE6w=",
-  "lastModifiedDate": "20260706203159"
+  "version": "unstable-20260708213004-ac94798",
+  "rev": "ac94798c753e48fd0b36128a029ed8aecebe9b56",
+  "hash": "sha256-lMvyBFy7jl8cnUI8efQuW8lxgIiwUhw6CHEmDpK0mfw=",
+  "lastModifiedDate": "20260708213004"
 }


### PR DESCRIPTION
Automated package bump for `[
  "nix_git"
]`.