### PR TITLE
chore: bump pcsx2_git

### DIFF
--- a/pkgs/pcsx2-git/version.json
+++ b/pkgs/pcsx2-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260704195116-fd46054",
-  "rev": "fd46054fb77a04038d3ef9a73e1666f1031ba5b5",
-  "hash": "sha256-c3Wki/wOc+zh+w46j/urJoMxqXv4LYx4aW3nBShDJBc="
+  "version": "unstable-20260709004848-cb000a5",
+  "rev": "cb000a510180770036cc907978b3f05e704ff9ab",
+  "hash": "sha256-yf5ppW+psqnH9mhsQDesDwpTk9OpYxflWJX+BWT42sM="
 }


### PR DESCRIPTION
Automated package bump for `[
  "pcsx2_git"
]`.