### PR TITLE
chore: bump tde2e_git

### DIFF
--- a/pkgs/telegram-desktop-git/version.json
+++ b/pkgs/telegram-desktop-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260707193750-d359e19",
-  "rev": "d359e194eb9908d87bf00caab2a9eaebef22483d",
-  "hash": "sha256-FRfz9mGI92f5IBsiEUDfFnovb2El5YmbCPbr+ajLoXg="
+  "version": "unstable-20260708074432-27f4158",
+  "rev": "27f41580d24275da985731466200d44d9bd01dab",
+  "hash": "sha256-k02JGZUGg1blJyIBqrojcNXU4MM/O/zyBQwfo5Z14yY="
 }


### PR DESCRIPTION
Automated package bump for `[
  "tde2e_git",
  "tg-owt_git",
  "telegram-desktop-unwrapped_git",
  "telegram-desktop_git"
]`.