### PR TITLE
chore: bump zed-editor_git

### DIFF
--- a/pkgs/zed-editor-git/version.json
+++ b/pkgs/zed-editor-git/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260707230012-f9c9947",
-  "rev": "f9c994796ad4341649d7b8664edbdfaae8bebd5d",
-  "hash": "sha256-L6rm0G3LgbbZIWeAP92B4M4DL9sRlB4zGYSJmgK7biw=",
-  "cargoHash": "sha256-Mfsi/IW4N7V5QrBJBViCq45Wde+smldE3dGdSpQ2QmE="
+  "version": "unstable-20260708205451-10504e3",
+  "rev": "10504e3ce18bb1d2444baf1047fa4ea9835ff1cc",
+  "hash": "sha256-EBufTd34bbVDZquJ91VMNqhmwhFcHtdDYWgRkLKL6a4=",
+  "cargoHash": "sha256-6jVJV4rMfKDILEsdSR1BapVngS1S9rzIr8ydFurhMPE="
 }


### PR DESCRIPTION
Automated package bump for `[
  "zed-editor_git"
]`.