### PR TITLE
chore: bump libdrm_git

### DIFF
--- a/pkgs/mesa-git/version.json
+++ b/pkgs/mesa-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260708022412-2451cb6",
-  "rev": "2451cb698eafa8df57f62e935f09c34feabeef97",
-  "hash": "sha256-2WpwT0dBE60b+F6aettcDdzFQDd6hHYweP/EhFyscZQ="
+  "version": "unstable-20260710031411-a1b50db",
+  "rev": "a1b50dbcd751bbb24ac717927c627a30e5969657",
+  "hash": "sha256-eBBbpwxUPd5VsbVle2wU3mZbBnPpOtKwxoCe0cvkbc0="
 }

--- a/pkgs/portal-wlr-git/version.json
+++ b/pkgs/portal-wlr-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260704145953-ea80500",
-  "rev": "ea80500a3b6ab381776d4bd5ee615b44dc8d7b54",
-  "hash": "sha256-A5jTJi7qqNMa/qWmqgqNTnRAcolbD7Bsm4nfXw9wSOY="
+  "version": "unstable-20260709161103-544e114",
+  "rev": "544e11481338a3784a11cb30561f06982fc0a158",
+  "hash": "sha256-qDL67snP2DFPp7Fgpru9MtC4iujWaz1A3c6ZALIoXnk="
 }

--- a/pkgs/wayland-git/version.json
+++ b/pkgs/wayland-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260707115522-c28d941",
-  "rev": "c28d941787c47f7e21a39638340086ad74939014",
-  "hash": "sha256-J/qH076HfeZ/XabEB7gAhN6owv6LfJryX0EzHZnveJo="
+  "version": "unstable-20260709150616-c23a8be",
+  "rev": "c23a8beb1ff41428e841137175c6be738ab627be",
+  "hash": "sha256-BIK8CP/CEZjVzfmiXudwNLqp5jv/hAGexnS341Qn7Z0="
 }

--- a/pkgs/wlroots-git/version.json
+++ b/pkgs/wlroots-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260707154543-d70c84b",
-  "rev": "d70c84b5717dafd922f434b022873b7f1b276543",
-  "hash": "sha256-ftdw0GpkjLFAg97jHYoK5911g/NDY/V+p2stqiU+Yy0="
+  "version": "unstable-20260709160821-a4ccad9",
+  "rev": "a4ccad96c7e3a67d216098f3669f8bed4e6ac10e",
+  "hash": "sha256-7so2HHFolMTtZNr9n9eSrXNME16cWDwTp3RPubvD/2M="
 }


### PR DESCRIPTION
Automated package bump for `[
  "libdrm_git",
  "wayland-protocols_git",
  "mesa_git",
  "wayland_git",
  "wlroots_git",
  "sway-unwrapped_git",
  "xdg-desktop-portal-wlr_git"
]`.