### PR TITLE
chore: bump nss_git

### DIFF
--- a/pkgs/firefox-nightly/version.json
+++ b/pkgs/firefox-nightly/version.json
@@ -1,6 +1,6 @@
 {
   "version": "154.0a1",
-  "rev": "4b550c17bb6c2c7bac7e8842c6b76f17debf643f",
-  "buildId": "20260707211043",
-  "hash": "sha256-NhgrG1NJzOayKzeevQDvOrc2dnOMAtzkfTGLaNipM9o="
+  "rev": "a07b2cb8ff33387a81968a7ed9d59ebdc4dad607",
+  "buildId": "20260708220003",
+  "hash": "sha256-yxTVlNkQpRT9H3Lah78e5PjLhZ+6svSlvt5LyaqQf5o="
 }


### PR DESCRIPTION
Automated package bump for `[
  "nss_git",
  "firefox-unwrapped_nightly"
]`.