### PR TITLE
chore: bump zed-editor_git

### DIFF
--- a/pkgs/zed-editor-git/version.json
+++ b/pkgs/zed-editor-git/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260708205451-10504e3",
-  "rev": "10504e3ce18bb1d2444baf1047fa4ea9835ff1cc",
-  "hash": "sha256-EBufTd34bbVDZquJ91VMNqhmwhFcHtdDYWgRkLKL6a4=",
+  "version": "unstable-20260709235104-76c9396",
+  "rev": "76c93968da5b8b8809bdd72e4ad9e7d0e946bad0",
+  "hash": "sha256-I6UBGHJDkaqQuErl/0GWtvCuvTqp81NZMJ21ZiKXJnE=",
   "cargoHash": "sha256-6jVJV4rMfKDILEsdSR1BapVngS1S9rzIr8ydFurhMPE="
 }


### PR DESCRIPTION
Automated package bump for `[
  "zed-editor_git"
]`.