### PR TITLE
chore: bump tde2e_git

### DIFF
--- a/pkgs/telegram-desktop-git/version.json
+++ b/pkgs/telegram-desktop-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260708074432-27f4158",
-  "rev": "27f41580d24275da985731466200d44d9bd01dab",
-  "hash": "sha256-k02JGZUGg1blJyIBqrojcNXU4MM/O/zyBQwfo5Z14yY="
+  "version": "unstable-20260709183339-e01ee72",
+  "rev": "e01ee7256693cc4bdfa4dca0eb4f969c3f3b9227",
+  "hash": "sha256-mPgp1Hc1JDoQFkydrD0POypQqDenURsiOkh0K9nFvTI="
 }


### PR DESCRIPTION
Automated package bump for `[
  "tde2e_git",
  "tg-owt_git",
  "telegram-desktop-unwrapped_git",
  "telegram-desktop_git"
]`.