### PR TITLE
chore: bump pcsx2_git

### DIFF
--- a/pkgs/pcsx2-git/version.json
+++ b/pkgs/pcsx2-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260709004848-cb000a5",
-  "rev": "cb000a510180770036cc907978b3f05e704ff9ab",
-  "hash": "sha256-yf5ppW+psqnH9mhsQDesDwpTk9OpYxflWJX+BWT42sM="
+  "version": "unstable-20260709224047-8f8968c",
+  "rev": "8f8968cbb1c545e64a515109624f46ae9e3d3c8a",
+  "hash": "sha256-Rz23z4bfeXLXZ1VNBjGDfHsK6ZujyHK20/TAzXTkwOk="
 }


### PR DESCRIPTION
Automated package bump for `[
  "pcsx2_git"
]`.