### PR TITLE
chore: bump nss_git

### DIFF
--- a/pkgs/firefox-nightly/version.json
+++ b/pkgs/firefox-nightly/version.json
@@ -1,6 +1,6 @@
 {
   "version": "154.0a1",
-  "rev": "a07b2cb8ff33387a81968a7ed9d59ebdc4dad607",
-  "buildId": "20260708220003",
-  "hash": "sha256-yxTVlNkQpRT9H3Lah78e5PjLhZ+6svSlvt5LyaqQf5o="
+  "rev": "2ea9edf52aa84c859a979fc0d73773ab06b6137e",
+  "buildId": "20260709205531",
+  "hash": "sha256-Eiz2W0xRVkqLbQs4iqkPZ5m2waqS4Cp5Sk1faTj7O/s="
 }

--- a/pkgs/nss-git/version.json
+++ b/pkgs/nss-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260703171325-7c0c73d",
-  "rev": "7c0c73d30e9c140bc24e8faf545b6a77a1dd9d39",
-  "hash": "sha256-itnLsR8bvyH5lFtxd+yUcO+mMRYAP76jqJVJHA9JTjE="
+  "version": "unstable-20260709153214-3c8c04e",
+  "rev": "3c8c04efdb7458aefb10ea06f93d5b515fd4cded",
+  "hash": "sha256-evcQbPv6/SIRqcl4QGoEB0BqIdil+zfzMNEMDWzvnk8="
 }


### PR DESCRIPTION
Automated package bump for `[
  "nss_git",
  "firefox-unwrapped_nightly"
]`.