### PR TITLE
chore: bump pcsx2_git

### DIFF
--- a/pkgs/pcsx2-git/version.json
+++ b/pkgs/pcsx2-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260709224047-8f8968c",
-  "rev": "8f8968cbb1c545e64a515109624f46ae9e3d3c8a",
-  "hash": "sha256-Rz23z4bfeXLXZ1VNBjGDfHsK6ZujyHK20/TAzXTkwOk="
+  "version": "unstable-20260710081651-eb5e3fc",
+  "rev": "eb5e3fcd13cfb687800ba1c16727077f93fb2a79",
+  "hash": "sha256-Sza78zqyyS18+kBBQ0HXd92CJu5dMPmSzzLa0hvLbm8="
 }


### PR DESCRIPTION
Automated package bump for `[
  "pcsx2_git"
]`.