### PR TITLE
chore: bump zed-editor_git

### DIFF
--- a/pkgs/zed-editor-git/version.json
+++ b/pkgs/zed-editor-git/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260709235104-76c9396",
-  "rev": "76c93968da5b8b8809bdd72e4ad9e7d0e946bad0",
-  "hash": "sha256-I6UBGHJDkaqQuErl/0GWtvCuvTqp81NZMJ21ZiKXJnE=",
-  "cargoHash": "sha256-6jVJV4rMfKDILEsdSR1BapVngS1S9rzIr8ydFurhMPE="
+  "version": "unstable-20260710232452-5f8a741",
+  "rev": "5f8a7413a31769e0882357f90dc424b3962ac72d",
+  "hash": "sha256-2712XNuR6dY72EysahzHDP8CopQIJGAzTZVKtNpYsY0=",
+  "cargoHash": "sha256-sy8F/4Tke5Ma7VhoTxFwpXKsTP4XzOYLOZSHIoXmWOc="
 }


### PR DESCRIPTION
Automated package bump for `[
  "zed-editor_git"
]`.