### PR TITLE
chore: bump swaylock-plugin_git

### DIFF
--- a/pkgs/swaylock-plugin-git/version.json
+++ b/pkgs/swaylock-plugin-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260311002056-d329aac",
-  "rev": "d329aac179e46cc2ac978a8b42d2961791a6e25d",
-  "hash": "sha256-JSFxWpSUt6ekX/owk9I6CdGBTF6F1pOTtFAls7kZrsc="
+  "version": "unstable-20260710111022-117ed3f",
+  "rev": "117ed3fe7d68a6f579cac6ce7a1bf82ceddb54d0",
+  "hash": "sha256-JWZ8aZeS8XXjRPhwyJXptwdMU2y/uFG1KlZh+v92/0c="
 }


### PR DESCRIPTION
Automated package bump for `[
  "swaylock-plugin_git"
]`.