### PR TITLE
chore: bump libdrm_git

### DIFF
--- a/pkgs/mesa-git/version.json
+++ b/pkgs/mesa-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260710031411-a1b50db",
-  "rev": "a1b50dbcd751bbb24ac717927c627a30e5969657",
-  "hash": "sha256-eBBbpwxUPd5VsbVle2wU3mZbBnPpOtKwxoCe0cvkbc0="
+  "version": "unstable-20260712122154-584a099",
+  "rev": "584a0997c8e4e93cfd517abe7db41c369642460a",
+  "hash": "sha256-wSRR80sMPsfWIvn9qeVyxxH8VWzyziGDHdeT+G+JBsM="
 }


### PR DESCRIPTION
Automated package bump for `[
  "libdrm_git",
  "wayland-protocols_git",
  "mesa_git",
  "wayland_git",
  "wlroots_git",
  "sway-unwrapped_git",
  "xdg-desktop-portal-wlr_git"
]`.