### PR TITLE
chore: bump openrgb_git

### DIFF
--- a/pkgs/openrgb-git/version.json
+++ b/pkgs/openrgb-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260709011638-b833a43",
-  "rev": "b833a43490a7c7c85fd6cd0fb09dd7d734504671",
-  "hash": "sha256-K1GaViybuKg+eRXcrv/Q1gdFVA1H8Tvs4y16xzfXqTk="
+  "version": "unstable-20260710225523-795616e",
+  "rev": "795616e62d664464522ff16d122939eb8adaf8b7",
+  "hash": "sha256-IZbQMvDkmEnUKYNDIpnkfEd7usD5yHZKTibXgHsD2y4="
 }


### PR DESCRIPTION
Automated package bump for `[
  "openrgb_git"
]`.