### PR TITLE
chore: bump nss_git

### DIFF
--- a/pkgs/firefox-nightly/version.json
+++ b/pkgs/firefox-nightly/version.json
@@ -1,6 +1,6 @@
 {
   "version": "154.0a1",
-  "rev": "2ea9edf52aa84c859a979fc0d73773ab06b6137e",
-  "buildId": "20260709205531",
-  "hash": "sha256-Eiz2W0xRVkqLbQs4iqkPZ5m2waqS4Cp5Sk1faTj7O/s="
+  "rev": "aaf0207c409c5f6479cc92bc1bf407a453d63cdc",
+  "buildId": "20260712113206",
+  "hash": "sha256-55lGbC6cRJldzNKFSDJU+xfx8Z2vHTu5A75bJierOuk="
 }


### PR DESCRIPTION
Automated package bump for `[
  "nss_git",
  "firefox-unwrapped_nightly"
]`.