### PR TITLE
chore: bump openrgb_git

### DIFF
--- a/pkgs/openrgb-git/version.json
+++ b/pkgs/openrgb-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260710225523-795616e",
-  "rev": "795616e62d664464522ff16d122939eb8adaf8b7",
-  "hash": "sha256-IZbQMvDkmEnUKYNDIpnkfEd7usD5yHZKTibXgHsD2y4="
+  "version": "unstable-20260711192043-21009cd",
+  "rev": "21009cdc45611ae3e0fd29b198f87bbe45f71a94",
+  "hash": "sha256-kUg0diOhJi0ZVNMOpWI1o2G/0zIOLnS+2uU0dbJSZ9E="
 }


### PR DESCRIPTION
Automated package bump for `[
  "openrgb_git"
]`.