### PR TITLE
chore: bump pcsx2_git

### DIFF
--- a/pkgs/pcsx2-git/version.json
+++ b/pkgs/pcsx2-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260710081651-eb5e3fc",
-  "rev": "eb5e3fcd13cfb687800ba1c16727077f93fb2a79",
-  "hash": "sha256-Sza78zqyyS18+kBBQ0HXd92CJu5dMPmSzzLa0hvLbm8="
+  "version": "unstable-20260712041353-5e3ad28",
+  "rev": "5e3ad282a830f161ada8d0064541bb47252774de",
+  "hash": "sha256-kpjsEiePjW8BCqmzEFaNor/TixOz0Po2NeiwNL5e9Yc="
 }


### PR DESCRIPTION
Automated package bump for `[
  "pcsx2_git"
]`.