### PR TITLE
chore: bump zed-editor_git

### DIFF
--- a/pkgs/zed-editor-git/version.json
+++ b/pkgs/zed-editor-git/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260710232452-5f8a741",
-  "rev": "5f8a7413a31769e0882357f90dc424b3962ac72d",
-  "hash": "sha256-2712XNuR6dY72EysahzHDP8CopQIJGAzTZVKtNpYsY0=",
+  "version": "unstable-20260712133909-60099a0",
+  "rev": "60099a06df5a9d035274577815d78e0f10a5d9bf",
+  "hash": "sha256-O6NHWUqIDIXYUfu3Ry/7i7oyIazTEIRHJO/VILGxhBQ=",
   "cargoHash": "sha256-sy8F/4Tke5Ma7VhoTxFwpXKsTP4XzOYLOZSHIoXmWOc="
 }


### PR DESCRIPTION
Automated package bump for `[
  "zed-editor_git"
]`.