### PR TITLE
chore: bump proton-cachyos_x86_64_v3

### DIFF
--- a/pkgs/proton-bin/cachyos-v3-version.json
+++ b/pkgs/proton-bin/cachyos-v3-version.json
@@ -1,5 +1,5 @@
 {
   "base": "11.0",
-  "release": "20260602",
-  "hash": "sha256-HZmTHTziUU2nfmSTinG8qJntTweI5Xtk8SZ3BnHgpmI="
+  "release": "20260702",
+  "hash": "sha256-ETl4U+uV+PtEhTXOviZVRxMGyAw0VsRrUs1Whwik/lw="
 }


### PR DESCRIPTION
Automated package bump for `[
  "proton-cachyos_x86_64_v3"
]`.