### PR TITLE
chore: bump nix_git

### DIFF
--- a/pkgs/nix-git/version.json
+++ b/pkgs/nix-git/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260708213004-ac94798",
-  "rev": "ac94798c753e48fd0b36128a029ed8aecebe9b56",
-  "hash": "sha256-lMvyBFy7jl8cnUI8efQuW8lxgIiwUhw6CHEmDpK0mfw=",
-  "lastModifiedDate": "20260708213004"
+  "version": "unstable-20260712081304-79b58eb",
+  "rev": "79b58eb9d976e131cdcee919e448c79132250c91",
+  "hash": "sha256-zY8qGFDkyHY2iT//fljCRQOwquJKN9MQp6+GxnPBkdc=",
+  "lastModifiedDate": "20260712081304"
 }


### PR DESCRIPTION
Automated package bump for `[
  "nix_git"
]`.