### PR TITLE
chore: bump proton-cachyos

### DIFF
--- a/pkgs/proton-bin/cachyos-version.json
+++ b/pkgs/proton-bin/cachyos-version.json
@@ -1,5 +1,5 @@
 {
   "base": "11.0",
-  "release": "20260602",
-  "hash": "sha256-qC20cEi08yTC1RMu8mCXbrIf+yl1QBUpFSKzRKzmZTg="
+  "release": "20260702",
+  "hash": "sha256-Qo16R7KVGYVuW61Q634PASPsJDHi03wxzr7ycD8k8lM="
 }


### PR DESCRIPTION
Automated package bump for `[
  "proton-cachyos"
]`.