### PR TITLE
chore: bump vulkanPackages_latest.vulkan-headers

### DIFF
--- a/pkgs/vulkan-versioned/default.nix
+++ b/pkgs/vulkan-versioned/default.nix
@@ -101,6 +101,16 @@ final.lib.makeScope final.newScope (self: {
 
     # updated by validation-layer
     withUpdateScript = false;
+
+    extraAttrs = prevAttrs: {
+      patches = builtins.filter (
+        patch:
+        !(
+          final.lib.hasInfix "1a22b167081842915a1c78a0b5b5a353a23284aa" (toString patch)
+          || final.lib.hasInfix "b8a32968473ce852a809b9de5f04f02a5a9dfa78" (toString patch)
+        )
+      ) (prevAttrs.patches or [ ]);
+    };
   };
 
   spirv-tools = genericOverride {
@@ -111,6 +121,12 @@ final.lib.makeScope final.newScope (self: {
 
     # updated by validation-layer
     withUpdateScript = false;
+
+    extraAttrs = prevAttrs: {
+      patches = builtins.filter (
+        patch: !final.lib.hasInfix "2ec8457ab33d539b6f1fecc998360c0b8b05ed4f" (toString patch)
+      ) (prevAttrs.patches or [ ]);
+    };
   };
 
   vulkan-extension-layer = genericOverride {

--- a/pkgs/vulkan-versioned/latest.json
+++ b/pkgs/vulkan-versioned/latest.json
@@ -30,9 +30,9 @@
     "hash": "sha256-+llJlEdzFcmqGBAdKHjYhkwBuH19ZngavmF1TQgejsI="
   },
   "Vulkan-Loader": {
-    "version": "1.4.352",
+    "version": "1.4.356",
     "rev": "v#{version}",
-    "hash": "sha256-AORBz48AAt88xUJVppgy0VeLhubYBNYUsRptxCyxZfA="
+    "hash": "sha256-tITPfUj/ory0Xo+dHccML4JB9aqGn6v91OLCOCoH3N8="
   },
   "Vulkan-Tools": {
     "version": "1.4.352",

--- a/pkgs/vulkan-versioned/latest.json
+++ b/pkgs/vulkan-versioned/latest.json
@@ -35,9 +35,9 @@
     "hash": "sha256-tITPfUj/ory0Xo+dHccML4JB9aqGn6v91OLCOCoH3N8="
   },
   "Vulkan-Tools": {
-    "version": "1.4.352",
+    "version": "1.4.356",
     "rev": "v#{version}",
-    "hash": "sha256-EZXlQDVy3ubXdXX1z/HLF/w3y1E/givIE8cQCUdtYMA=",
+    "hash": "sha256-lKeiATnxcIV0XfFGG1dWJyZX8bWvnIdlRurlVNsVSpY=",
     "badTag": "vulkan-sdk-1.3.280.0"
   },
   "LunarG-Tools": {

--- a/pkgs/vulkan-versioned/latest.json
+++ b/pkgs/vulkan-versioned/latest.json
@@ -1,6 +1,6 @@
 {
   "gfxreconstruct": {
-    "version": "1.4.350.0",
+    "version": "1.4.350.1",
     "rev": "vulkan-sdk-#{version}",
     "hash": "sha256-Qp4msQ8yzbOQIk9tFEDZ47+u/8yFiKPZ5H/oqyy+qZw="
   },

--- a/pkgs/vulkan-versioned/latest.json
+++ b/pkgs/vulkan-versioned/latest.json
@@ -51,9 +51,9 @@
     "hash": "sha256-6ZtPp6OqzzppmijIU1/77qcUvwCck/eMZOUh5pSwVc8="
   },
   "Vulkan-Utility-Libraries": {
-    "version": "1.4.352",
+    "version": "1.4.356",
     "rev": "v#{version}",
-    "hash": "sha256-eHQVpU2ibiWtixgf6TR9YJ6VJy/IjA4dRHuSxTQkiwc="
+    "hash": "sha256-To20WFEMluJNCOXDdOy3li0g0D4bKElkgmqMeYksHNY="
   },
   "Vulkan-ValidationLayers": {
     "version": "1.4.352",

--- a/pkgs/vulkan-versioned/latest.json
+++ b/pkgs/vulkan-versioned/latest.json
@@ -41,7 +41,7 @@
     "badTag": "vulkan-sdk-1.3.280.0"
   },
   "LunarG-Tools": {
-    "version": "1.4.350.0",
+    "version": "1.4.350.1",
     "rev": "vulkan-sdk-#{version}",
     "hash": "sha256-tKt/OrGIVfg2/aK9dYPuOB4+05ayUheP9T7Ny5MfWTk="
   },

--- a/pkgs/vulkan-versioned/latest.json
+++ b/pkgs/vulkan-versioned/latest.json
@@ -46,7 +46,7 @@
     "hash": "sha256-tKt/OrGIVfg2/aK9dYPuOB4+05ayUheP9T7Ny5MfWTk="
   },
   "Vulkan-ExtensionLayer": {
-    "version": "1.4.350.0",
+    "version": "1.4.350.1",
     "rev": "vulkan-sdk-#{version}",
     "hash": "sha256-6ZtPp6OqzzppmijIU1/77qcUvwCck/eMZOUh5pSwVc8="
   },

--- a/pkgs/vulkan-versioned/latest.json
+++ b/pkgs/vulkan-versioned/latest.json
@@ -25,9 +25,9 @@
     "hash": "sha256-tEbqXBuv5wFvODTETRor06Szj1LyCU/PEMgrY4/eEVE="
   },
   "Vulkan-Headers": {
-    "version": "1.4.352",
+    "version": "1.4.356",
     "rev": "v#{version}",
-    "hash": "sha256-pUxPwFGbOzP8ymTooeA1slFWEFsRoqUROSnndVtLiY8="
+    "hash": "sha256-+llJlEdzFcmqGBAdKHjYhkwBuH19ZngavmF1TQgejsI="
   },
   "Vulkan-Loader": {
     "version": "1.4.352",


### PR DESCRIPTION
Automated package bump for `[
  "vulkanPackages_latest.vulkan-headers",
  "vulkanPackages_latest.vulkan-loader",
  "vulkanPackages_latest.gfxreconstruct",
  "vulkanPackages_latest.vulkan-utility-libraries",
  "vulkanPackages_latest.vulkan-extension-layer",
  "vulkanPackages_latest.vulkan-volk",
  "vulkanPackages_latest.vulkan-tools",
  "vulkanPackages_latest.vulkan-tools-lunarg"
]`.