### PR TITLE
chore: bump openrgb_git

### DIFF
--- a/pkgs/openrgb-git/version.json
+++ b/pkgs/openrgb-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260711192043-21009cd",
-  "rev": "21009cdc45611ae3e0fd29b198f87bbe45f71a94",
-  "hash": "sha256-kUg0diOhJi0ZVNMOpWI1o2G/0zIOLnS+2uU0dbJSZ9E="
+  "version": "unstable-20260712212507-285a7bc",
+  "rev": "285a7bce4e316e516376e6e8066cc3c04eff5e54",
+  "hash": "sha256-N5+lR9SSnvhZcT2h+mIv5jdYIKFJ4mpG53/DuGOBDcY="
 }


### PR DESCRIPTION
Automated package bump for `[
  "openrgb_git"
]`.