### PR TITLE
chore: bump zed-editor_git

### DIFF
--- a/pkgs/zed-editor-git/version.json
+++ b/pkgs/zed-editor-git/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260712133909-60099a0",
-  "rev": "60099a06df5a9d035274577815d78e0f10a5d9bf",
-  "hash": "sha256-O6NHWUqIDIXYUfu3Ry/7i7oyIazTEIRHJO/VILGxhBQ=",
+  "version": "unstable-20260712230226-aeeacf5",
+  "rev": "aeeacf5439b2d30d01e38d65d767e6f31b255ecc",
+  "hash": "sha256-wtxKMDX5g4tX27IQWbTfmBwRTysZ7DpT2jrkhNU3u5U=",
   "cargoHash": "sha256-sy8F/4Tke5Ma7VhoTxFwpXKsTP4XzOYLOZSHIoXmWOc="
 }


### PR DESCRIPTION
Automated package bump for `[
  "zed-editor_git"
]`.