### PR TITLE
chore: bump pcsx2_git

### DIFF
--- a/pkgs/pcsx2-git/version.json
+++ b/pkgs/pcsx2-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260712041353-5e3ad28",
-  "rev": "5e3ad282a830f161ada8d0064541bb47252774de",
-  "hash": "sha256-kpjsEiePjW8BCqmzEFaNor/TixOz0Po2NeiwNL5e9Yc="
+  "version": "unstable-20260712194359-92914ce",
+  "rev": "92914cee40381e7f1fb7d0b5648390555366f56c",
+  "hash": "sha256-ZlNcIR0NRliQUswhbThye9J4pikNQU6Q8XxXXzKvYhs="
 }


### PR DESCRIPTION
Automated package bump for `[
  "pcsx2_git"
]`.