### PR TITLE
chore: bump libdrm_git

### DIFF
--- a/pkgs/mesa-git/version.json
+++ b/pkgs/mesa-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260712122154-584a099",
-  "rev": "584a0997c8e4e93cfd517abe7db41c369642460a",
-  "hash": "sha256-wSRR80sMPsfWIvn9qeVyxxH8VWzyziGDHdeT+G+JBsM="
+  "version": "unstable-20260712210718-f768c98",
+  "rev": "f768c98f3181f1255ed0315391435501b9839e72",
+  "hash": "sha256-ndaJgaqrdoDFzw9D+2GyJzOmmQOo+MvqzKtR71NgK1k="
 }


### PR DESCRIPTION
Automated package bump for `[
  "libdrm_git",
  "wayland-protocols_git",
  "mesa_git",
  "wayland_git",
  "wlroots_git",
  "sway-unwrapped_git",
  "xdg-desktop-portal-wlr_git"
]`.