### PR TITLE
chore: bump nss_git

### DIFF
--- a/pkgs/firefox-nightly/version.json
+++ b/pkgs/firefox-nightly/version.json
@@ -1,6 +1,6 @@
 {
   "version": "154.0a1",
-  "rev": "aaf0207c409c5f6479cc92bc1bf407a453d63cdc",
-  "buildId": "20260712113206",
-  "hash": "sha256-55lGbC6cRJldzNKFSDJU+xfx8Z2vHTu5A75bJierOuk="
+  "rev": "4408fe95bc97ecf93cc5d9a1e0b5381f98bf656f",
+  "buildId": "20260712214442",
+  "hash": "sha256-yrts67xaNYo6NZGCo11HZwieE1dlz5vuZfyOTSdM4gw="
 }


### PR DESCRIPTION
Automated package bump for `[
  "nss_git",
  "firefox-unwrapped_nightly"
]`.