### PR TITLE
chore: bump nix_git

### DIFF
--- a/pkgs/nix-git/version.json
+++ b/pkgs/nix-git/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260712081304-79b58eb",
-  "rev": "79b58eb9d976e131cdcee919e448c79132250c91",
-  "hash": "sha256-zY8qGFDkyHY2iT//fljCRQOwquJKN9MQp6+GxnPBkdc=",
-  "lastModifiedDate": "20260712081304"
+  "version": "unstable-20260713231953-40f375f",
+  "rev": "40f375fac1af1a432cbf48dfd15468b1921d458c",
+  "hash": "sha256-AwPBTkXn3+Ost+HnDxJ3z0J/sZKZd3Kq1PmKCnl8JR8=",
+  "lastModifiedDate": "20260713231953"
 }


### PR DESCRIPTION
Automated package bump for `[
  "nix_git"
]`.