### PR TITLE
chore: bump pcsx2_git

### DIFF
--- a/pkgs/pcsx2-git/version.json
+++ b/pkgs/pcsx2-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260712194359-92914ce",
-  "rev": "92914cee40381e7f1fb7d0b5648390555366f56c",
-  "hash": "sha256-ZlNcIR0NRliQUswhbThye9J4pikNQU6Q8XxXXzKvYhs="
+  "version": "unstable-20260713214530-5df1662",
+  "rev": "5df1662c1bf2db832d6b8b3c4ace80421f3eb096",
+  "hash": "sha256-lKmuPa9ZX5eJ2IfHDRokgGG9l0BUNOb4p6bzqCIbJMA="
 }


### PR DESCRIPTION
Automated package bump for `[
  "pcsx2_git"
]`.