### PR TITLE
chore: bump libdrm_git

### DIFF
--- a/pkgs/mesa-git/version.json
+++ b/pkgs/mesa-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260712210718-f768c98",
-  "rev": "f768c98f3181f1255ed0315391435501b9839e72",
-  "hash": "sha256-ndaJgaqrdoDFzw9D+2GyJzOmmQOo+MvqzKtR71NgK1k="
+  "version": "unstable-20260714002631-4def7fb",
+  "rev": "4def7fb90a9b39367f819275ff9af93965679dd1",
+  "hash": "sha256-OeAUvESeO+89eFPhA9ukv6S1Za9U1bbYtjdcJiSDLVw="
 }

--- a/pkgs/wlroots-git/version.json
+++ b/pkgs/wlroots-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260709160821-a4ccad9",
-  "rev": "a4ccad96c7e3a67d216098f3669f8bed4e6ac10e",
-  "hash": "sha256-7so2HHFolMTtZNr9n9eSrXNME16cWDwTp3RPubvD/2M="
+  "version": "unstable-20260713134939-6e06fb2",
+  "rev": "6e06fb2f89348155c439e7137ebabcc266523174",
+  "hash": "sha256-PeT1JEntLv6jrQ+KMRhvVTaLE80+ArM4QbwKkOjkYjU="
 }


### PR DESCRIPTION
Automated package bump for `[
  "libdrm_git",
  "wayland-protocols_git",
  "mesa_git",
  "wayland_git",
  "wlroots_git",
  "sway-unwrapped_git",
  "xdg-desktop-portal-wlr_git"
]`.