### PR TITLE
chore: bump openrgb_git

### DIFF
--- a/pkgs/openrgb-git/version.json
+++ b/pkgs/openrgb-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260712212507-285a7bc",
-  "rev": "285a7bce4e316e516376e6e8066cc3c04eff5e54",
-  "hash": "sha256-N5+lR9SSnvhZcT2h+mIv5jdYIKFJ4mpG53/DuGOBDcY="
+  "version": "unstable-20260714024918-19112cd",
+  "rev": "19112cdeff94086fa994c4a9cf45ec5786a599bf",
+  "hash": "sha256-5vJ0Z0u7LZigGixLafbTqVCl1ZpGeQfDw3qvYWE15gc="
 }


### PR DESCRIPTION
Automated package bump for `[
  "openrgb_git"
]`.