### PR TITLE
chore: bump shadps4_git

### DIFF
--- a/pkgs/shadps4-git/version.json
+++ b/pkgs/shadps4-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260710135426-cf3bb34",
-  "rev": "cf3bb346bf9d73471e7bb64a8bcafd52f36c3685",
-  "hash": "sha256-fc/eAe1JdSG2M2r5izERsFTBOSxcofuZqkY0Rp5lOZk="
+  "version": "unstable-20260713205931-e9f15c3",
+  "rev": "e9f15c36a76803e5deb09864ec14afb980109575",
+  "hash": "sha256-TgpFJLexY3xeJgMSu5Xv7+Kw3IbdYBMoRH4E9h1fV5o="
 }


### PR DESCRIPTION
Automated package bump for `[
  "shadps4_git"
]`.