### PR TITLE
chore: bump zed-editor_git

### DIFF
--- a/pkgs/zed-editor-git/version.json
+++ b/pkgs/zed-editor-git/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260712230226-aeeacf5",
-  "rev": "aeeacf5439b2d30d01e38d65d767e6f31b255ecc",
-  "hash": "sha256-wtxKMDX5g4tX27IQWbTfmBwRTysZ7DpT2jrkhNU3u5U=",
-  "cargoHash": "sha256-sy8F/4Tke5Ma7VhoTxFwpXKsTP4XzOYLOZSHIoXmWOc="
+  "version": "unstable-20260714012138-97110fd",
+  "rev": "97110fd5a119eb5fad49524dc04d7c042193e8ab",
+  "hash": "sha256-+yx42PEy5exI1y6gYtVdggeQCSoMNlu4qCZlpTgM2rA=",
+  "cargoHash": "sha256-w70KAoFiEB8AUj0wYoNtJpMsuvOzA9IVM0zsIm5w0vQ="
 }


### PR DESCRIPTION
Automated package bump for `[
  "zed-editor_git"
]`.