### PR TITLE
chore: bump nss_git

### DIFF
--- a/pkgs/firefox-nightly/version.json
+++ b/pkgs/firefox-nightly/version.json
@@ -1,6 +1,6 @@
 {
   "version": "154.0a1",
-  "rev": "4408fe95bc97ecf93cc5d9a1e0b5381f98bf656f",
-  "buildId": "20260712214442",
-  "hash": "sha256-yrts67xaNYo6NZGCo11HZwieE1dlz5vuZfyOTSdM4gw="
+  "rev": "7d5b291d2351f7d04c504b03fa22ec3dcdf81b54",
+  "buildId": "20260713202634",
+  "hash": "sha256-OR+whAxWGQjEFPsv7073PFHJCHxBtru/0RJYykF2v84="
 }

--- a/pkgs/nss-git/version.json
+++ b/pkgs/nss-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260709153214-3c8c04e",
-  "rev": "3c8c04efdb7458aefb10ea06f93d5b515fd4cded",
-  "hash": "sha256-evcQbPv6/SIRqcl4QGoEB0BqIdil+zfzMNEMDWzvnk8="
+  "version": "unstable-20260713224453-d9b3ece",
+  "rev": "d9b3ecef82ba6ed63ebc1f5e3cfbb0990dfce16e",
+  "hash": "sha256-848mGzUujZPGvXwun90Qes88R/Je6aJmUWU9A1eAHgI="
 }


### PR DESCRIPTION
Automated package bump for `[
  "nss_git",
  "firefox-unwrapped_nightly"
]`.