### PR TITLE
fix(nvidia-cachyos): correct openHash computation using fetchFromGitHub NAR hash

### DIFF
--- a/pkgs/nvidia-cachyos/update.nix
+++ b/pkgs/nvidia-cachyos/update.nix
@@ -51,7 +51,7 @@ writeShellScript "update-nvidia-cachyos-${variant}" ''
 
   mainHash=$(fetch_hash "https://download.nvidia.com/XFree86/Linux-x86_64/$latestVer/NVIDIA-Linux-x86_64-$latestVer.run")
   aarch64Hash=$(fetch_hash "https://download.nvidia.com/XFree86/Linux-aarch64/$latestVer/NVIDIA-Linux-aarch64-$latestVer.run")
-  openHash=$(fetch_hash "https://github.com/NVIDIA/open-gpu-kernel-modules/archive/$latestVer.tar.gz")
+  openHash=$(fetch_hash_unpack "https://github.com/NVIDIA/open-gpu-kernel-modules/archive/$latestVer.tar.gz")
   settingsHash=$(fetch_hash_unpack "https://github.com/NVIDIA/nvidia-settings/archive/$latestVer.tar.gz")
   persistencedHash=$(fetch_hash "https://download.nvidia.com/XFree86/nvidia-persistenced/nvidia-persistenced-$latestVer.tar.bz2")
 

--- a/pkgs/nvidia-cachyos/version-hardened.json
+++ b/pkgs/nvidia-cachyos/version-hardened.json
@@ -2,7 +2,7 @@
   "version": "610.43.03",
   "hash": "sha256-ReLUwTSiPDXlDyU6SqY+fl6NF+PRhdSgfIpY6WEu05I=",
   "aarch64Hash": "sha256-jSdlXo60ilXLKWKvZfgbBnVqVYuw6zhnGuiDgwxYz94=",
-  "openHash": "sha256-nfh9dTzZwFqg7txGKvmzXeu1SaZXE26GMoL5TJbuJkA=",
+  "openHash": "sha256-QCXmqo2xNyIwjGv0da2MUC8ex641Mmc5DUI+uRFVwgE=",
   "settingsHash": "sha256-z/t+SdEQdVJPwjKIRHO02d264Kt47eWiOwwsaxmh4xQ=",
   "persistencedHash": "sha256-pgU0ua3LJvgz8i/yG9+ZkFR1yn2CmPQ8iSmsOs6q5h8="
 }

--- a/pkgs/nvidia-cachyos/version-lts.json
+++ b/pkgs/nvidia-cachyos/version-lts.json
@@ -2,7 +2,7 @@
   "version": "610.43.03",
   "hash": "sha256-ReLUwTSiPDXlDyU6SqY+fl6NF+PRhdSgfIpY6WEu05I=",
   "aarch64Hash": "sha256-jSdlXo60ilXLKWKvZfgbBnVqVYuw6zhnGuiDgwxYz94=",
-  "openHash": "sha256-nfh9dTzZwFqg7txGKvmzXeu1SaZXE26GMoL5TJbuJkA=",
+  "openHash": "sha256-QCXmqo2xNyIwjGv0da2MUC8ex641Mmc5DUI+uRFVwgE=",
   "settingsHash": "sha256-z/t+SdEQdVJPwjKIRHO02d264Kt47eWiOwwsaxmh4xQ=",
   "persistencedHash": "sha256-pgU0ua3LJvgz8i/yG9+ZkFR1yn2CmPQ8iSmsOs6q5h8="
 }

--- a/pkgs/nvidia-cachyos/version-rc.json
+++ b/pkgs/nvidia-cachyos/version-rc.json
@@ -2,7 +2,7 @@
   "version": "610.43.03",
   "hash": "sha256-ReLUwTSiPDXlDyU6SqY+fl6NF+PRhdSgfIpY6WEu05I=",
   "aarch64Hash": "sha256-jSdlXo60ilXLKWKvZfgbBnVqVYuw6zhnGuiDgwxYz94=",
-  "openHash": "sha256-nfh9dTzZwFqg7txGKvmzXeu1SaZXE26GMoL5TJbuJkA=",
+  "openHash": "sha256-QCXmqo2xNyIwjGv0da2MUC8ex641Mmc5DUI+uRFVwgE=",
   "settingsHash": "sha256-z/t+SdEQdVJPwjKIRHO02d264Kt47eWiOwwsaxmh4xQ=",
   "persistencedHash": "sha256-pgU0ua3LJvgz8i/yG9+ZkFR1yn2CmPQ8iSmsOs6q5h8="
 }

--- a/pkgs/nvidia-cachyos/version-server.json
+++ b/pkgs/nvidia-cachyos/version-server.json
@@ -2,7 +2,7 @@
   "version": "610.43.02",
   "hash": "sha256-MDSgVLtM33dS/43CclZMsQVROAS/9TU4lFkBsWyndGM=",
   "aarch64Hash": "sha256-isWTnokUA/dzWocFBLalnk4+O5gSExVjs3dVpdYTU88=",
-  "openHash": "sha256-Yvu+KVJ+ML4yyzizDfrS6U2xyof3elgJDlY8dmmFfmA=",
+  "openHash": "sha256-hP5NVZZ4vGsACHLmUDKq4uckpd/kn1GxCSYnnJfAuBs=",
   "settingsHash": "sha256-0YAhufRgjDW+uR+kjaTb154fibpcDw8QowfrucoZsKE=",
   "persistencedHash": "sha256-dObfc/suksLZr0CsU1GHtDJS2EeHO93eopkN2BLGklg="
 }

--- a/pkgs/nvidia-cachyos/version.json
+++ b/pkgs/nvidia-cachyos/version.json
@@ -2,7 +2,7 @@
   "version": "610.43.03",
   "hash": "sha256-ReLUwTSiPDXlDyU6SqY+fl6NF+PRhdSgfIpY6WEu05I=",
   "aarch64Hash": "sha256-jSdlXo60ilXLKWKvZfgbBnVqVYuw6zhnGuiDgwxYz94=",
-  "openHash": "sha256-nfh9dTzZwFqg7txGKvmzXeu1SaZXE26GMoL5TJbuJkA=",
+  "openHash": "sha256-QCXmqo2xNyIwjGv0da2MUC8ex641Mmc5DUI+uRFVwgE=",
   "settingsHash": "sha256-z/t+SdEQdVJPwjKIRHO02d264Kt47eWiOwwsaxmh4xQ=",
   "persistencedHash": "sha256-pgU0ua3LJvgz8i/yG9+ZkFR1yn2CmPQ8iSmsOs6q5h8="
 }


### PR DESCRIPTION
Fixed openHash in `pkgs/nvidia-cachyos/update.nix` for `nvidia_cachyos.open`:  `fetch_hash` to `fetch_hash_unpack`.