### PR TITLE
chore: bump pcsx2_git

### DIFF
--- a/pkgs/pcsx2-git/version.json
+++ b/pkgs/pcsx2-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260713214530-5df1662",
-  "rev": "5df1662c1bf2db832d6b8b3c4ace80421f3eb096",
-  "hash": "sha256-lKmuPa9ZX5eJ2IfHDRokgGG9l0BUNOb4p6bzqCIbJMA="
+  "version": "unstable-20260715003545-a80b314",
+  "rev": "a80b3144bb95fc949208c1fdc0a5ef6cf631433d",
+  "hash": "sha256-lWbIcrUYc4PJ0jpEpHL0nawZE7ukemuwmnt038CP4RU="
 }


### PR DESCRIPTION
Automated package bump for `[
  "pcsx2_git"
]`.