### PR TITLE
chore: bump nvidia_cachyos-server

### DIFF
--- a/pkgs/nvidia-cachyos/version-server.json
+++ b/pkgs/nvidia-cachyos/version-server.json
@@ -1,8 +1,8 @@
 {
-  "version": "610.43.02",
-  "hash": "sha256-MDSgVLtM33dS/43CclZMsQVROAS/9TU4lFkBsWyndGM=",
-  "aarch64Hash": "sha256-isWTnokUA/dzWocFBLalnk4+O5gSExVjs3dVpdYTU88=",
-  "openHash": "sha256-hP5NVZZ4vGsACHLmUDKq4uckpd/kn1GxCSYnnJfAuBs=",
-  "settingsHash": "sha256-0YAhufRgjDW+uR+kjaTb154fibpcDw8QowfrucoZsKE=",
-  "persistencedHash": "sha256-dObfc/suksLZr0CsU1GHtDJS2EeHO93eopkN2BLGklg="
+  "version": "610.43.03",
+  "hash": "sha256-ReLUwTSiPDXlDyU6SqY+fl6NF+PRhdSgfIpY6WEu05I=",
+  "aarch64Hash": "sha256-jSdlXo60ilXLKWKvZfgbBnVqVYuw6zhnGuiDgwxYz94=",
+  "openHash": "sha256-QCXmqo2xNyIwjGv0da2MUC8ex641Mmc5DUI+uRFVwgE=",
+  "settingsHash": "sha256-z/t+SdEQdVJPwjKIRHO02d264Kt47eWiOwwsaxmh4xQ=",
+  "persistencedHash": "sha256-pgU0ua3LJvgz8i/yG9+ZkFR1yn2CmPQ8iSmsOs6q5h8="
 }


### PR DESCRIPTION
Automated package bump for `[
  "nvidia_cachyos-server"
]`.