### PR TITLE
chore: bump zed-editor_git

### DIFF
--- a/pkgs/zed-editor-git/version.json
+++ b/pkgs/zed-editor-git/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260714012138-97110fd",
-  "rev": "97110fd5a119eb5fad49524dc04d7c042193e8ab",
-  "hash": "sha256-+yx42PEy5exI1y6gYtVdggeQCSoMNlu4qCZlpTgM2rA=",
-  "cargoHash": "sha256-w70KAoFiEB8AUj0wYoNtJpMsuvOzA9IVM0zsIm5w0vQ="
+  "version": "unstable-20260715015427-4a3e0af",
+  "rev": "4a3e0af532e4ad89baf634f4b94938b98beaa292",
+  "hash": "sha256-yG0sI08OTAwYGE76zicbRgQrYeKqBpODUCNCWxGAvaY=",
+  "cargoHash": "sha256-H0cbYIlC8wyUGfem2t4K4aaG7M3O8FN6WLnD2HAxIyk="
 }


### PR DESCRIPTION
Automated package bump for `[
  "zed-editor_git"
]`.