### PR TITLE
chore: bump libdrm_git

### DIFF
--- a/pkgs/libdrm-git/version.json
+++ b/pkgs/libdrm-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260611152330-35c7c53",
-  "rev": "35c7c536d5d1c0124a416a531df4432508d7d2f1",
-  "hash": "sha256-7+PoH4c98Hf30wxX2mooD9OMTGpSqjJueMrVrmF6w98="
+  "version": "unstable-20260714195949-f9816a4",
+  "rev": "f9816a42b0d6138851cbe5eb7a33ee1a2f2a15ca",
+  "hash": "sha256-jljFpM2GMXLBY5bDibk6bIobSNfxhW8duRNacSvXK7M="
 }

--- a/pkgs/mesa-git/version.json
+++ b/pkgs/mesa-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260714002631-4def7fb",
-  "rev": "4def7fb90a9b39367f819275ff9af93965679dd1",
-  "hash": "sha256-OeAUvESeO+89eFPhA9ukv6S1Za9U1bbYtjdcJiSDLVw="
+  "version": "unstable-20260715022606-0f90865",
+  "rev": "0f9086520f0ed1ba8fdd81548e6b4e1a6dc2ad65",
+  "hash": "sha256-A/FCXi/qMks6SFnGSp9Hjx7upGXOnUgdTEd1Z8l1jF0="
 }

--- a/pkgs/wlroots-git/version.json
+++ b/pkgs/wlroots-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260713134939-6e06fb2",
-  "rev": "6e06fb2f89348155c439e7137ebabcc266523174",
-  "hash": "sha256-PeT1JEntLv6jrQ+KMRhvVTaLE80+ArM4QbwKkOjkYjU="
+  "version": "unstable-20260714191211-e04f8f4",
+  "rev": "e04f8f4f373624f2e6eaade6ff3cac54c72ed266",
+  "hash": "sha256-zxjg2pxosyqeYHvemnXzQfvp/8mRaT8TewVkUqrtUJI="
 }


### PR DESCRIPTION
Automated package bump for `[
  "libdrm_git",
  "wayland-protocols_git",
  "mesa_git",
  "wayland_git",
  "wlroots_git",
  "sway-unwrapped_git",
  "xdg-desktop-portal-wlr_git"
]`.