### PR TITLE
chore: bump tde2e_git

### DIFF
--- a/pkgs/tdlib-git/version.json
+++ b/pkgs/tdlib-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260613094822-a17f87c",
-  "rev": "a17f87c4cff7b90b278d12b91ba0614383aaee82",
-  "hash": "sha256-xNAC9DpbLH4Fsl83We13PaXX9WjY8MUSZ3kA5bUo2s8="
+  "version": "unstable-20260714202703-07d3a09",
+  "rev": "07d3a0973f5113b0827a04d54a93aaaa9e288348",
+  "hash": "sha256-4N7QTO9NbW9M6HdY5gbimCAE/fAIARRLhjJasZpC/lQ="
 }

--- a/pkgs/telegram-desktop-git/version.json
+++ b/pkgs/telegram-desktop-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260711180300-ed73b49",
-  "rev": "ed73b49d0110a8e949e7fe06a8a90bd7e7b421a8",
-  "hash": "sha256-2VB04WrcsnWjKGhVxNrosMq2vV5CMcO1vLCWCmJXFlo="
+  "version": "unstable-20260714114100-a6209e3",
+  "rev": "a6209e3993ab63d8c02d2dfae6677469867b249b",
+  "hash": "sha256-zvJEfqMD4q2DI434dP6WfHU5TXAwpspdpgV959+A/0U="
 }


### PR DESCRIPTION
Automated package bump for `[
  "tde2e_git",
  "tg-owt_git",
  "telegram-desktop-unwrapped_git",
  "telegram-desktop_git"
]`.