### PR TITLE
chore: bump openrgb_git

### DIFF
--- a/pkgs/openrgb-git/version.json
+++ b/pkgs/openrgb-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260714024918-19112cd",
-  "rev": "19112cdeff94086fa994c4a9cf45ec5786a599bf",
-  "hash": "sha256-5vJ0Z0u7LZigGixLafbTqVCl1ZpGeQfDw3qvYWE15gc="
+  "version": "unstable-20260715024518-28d73d7",
+  "rev": "28d73d74bcb0ad137107bdfff9a0f4121346c508",
+  "hash": "sha256-db8MIDgOKQHhRIHjddYqTGkAlUf8t1fTlH9hM27VTSc="
 }


### PR DESCRIPTION
Automated package bump for `[
  "openrgb_git"
]`.