### PR TITLE
chore: bump shadps4_git

### DIFF
--- a/pkgs/shadps4-git/version.json
+++ b/pkgs/shadps4-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260713205931-e9f15c3",
-  "rev": "e9f15c36a76803e5deb09864ec14afb980109575",
-  "hash": "sha256-TgpFJLexY3xeJgMSu5Xv7+Kw3IbdYBMoRH4E9h1fV5o="
+  "version": "unstable-20260714185738-2c9caf6",
+  "rev": "2c9caf6bfbe7e1dc7a1b4565af8d84c56469dd56",
+  "hash": "sha256-pa3DcXkPrsKWPFkw33UFLCWBc1GPpfCulRSxeWZLu58="
 }


### PR DESCRIPTION
Automated package bump for `[
  "shadps4_git"
]`.