### PR TITLE
chore: bump nss_git

### DIFF
--- a/pkgs/firefox-nightly/version.json
+++ b/pkgs/firefox-nightly/version.json
@@ -1,6 +1,6 @@
 {
   "version": "154.0a1",
-  "rev": "7d5b291d2351f7d04c504b03fa22ec3dcdf81b54",
-  "buildId": "20260713202634",
-  "hash": "sha256-OR+whAxWGQjEFPsv7073PFHJCHxBtru/0RJYykF2v84="
+  "rev": "d83a08d81de20f3b72db70f531fad19090e1db4b",
+  "buildId": "20260714213719",
+  "hash": "sha256-4K/KMI0SxNgPgKvAbNj2f7JNebuy36wvgWDJa8TASrk="
 }

--- a/pkgs/nss-git/version.json
+++ b/pkgs/nss-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260713224453-d9b3ece",
-  "rev": "d9b3ecef82ba6ed63ebc1f5e3cfbb0990dfce16e",
-  "hash": "sha256-848mGzUujZPGvXwun90Qes88R/Je6aJmUWU9A1eAHgI="
+  "version": "unstable-20260714202016-61e8b93",
+  "rev": "61e8b93902eb91963c4458511cae9c45e81f3b38",
+  "hash": "sha256-veAAm8egDINLjRt+MRkGFlZYlDUqNVq0jZRUsef32qA="
 }


### PR DESCRIPTION
Automated package bump for `[
  "nss_git",
  "firefox-unwrapped_nightly"
]`.