### PR TITLE
chore: bump pcsx2_git

### DIFF
--- a/pkgs/pcsx2-git/version.json
+++ b/pkgs/pcsx2-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260715003545-a80b314",
-  "rev": "a80b3144bb95fc949208c1fdc0a5ef6cf631433d",
-  "hash": "sha256-lWbIcrUYc4PJ0jpEpHL0nawZE7ukemuwmnt038CP4RU="
+  "version": "unstable-20260716002909-2d62078",
+  "rev": "2d62078b043017581f89ad35d1f2a90481d05311",
+  "hash": "sha256-1TD3Zil7yH1JHeeS3K6WR8CY8ocRgxAU1Wbdw7h0CMI="
 }


### PR DESCRIPTION
Automated package bump for `[
  "pcsx2_git"
]`.