### PR TITLE
chore: bump nix_git

### DIFF
--- a/pkgs/nix-git/version.json
+++ b/pkgs/nix-git/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260713231953-40f375f",
-  "rev": "40f375fac1af1a432cbf48dfd15468b1921d458c",
-  "hash": "sha256-AwPBTkXn3+Ost+HnDxJ3z0J/sZKZd3Kq1PmKCnl8JR8=",
-  "lastModifiedDate": "20260713231953"
+  "version": "unstable-20260716021834-035f34f",
+  "rev": "035f34f13f969cf72ca4ea60369d907972402956",
+  "hash": "sha256-GVlCnL2/fkvFKj09Yn95KUxNANloc59/K4SqnkhrRD8=",
+  "lastModifiedDate": "20260716021834"
 }


### PR DESCRIPTION
Automated package bump for `[
  "nix_git"
]`.