### PR TITLE
chore: bump zed-editor_git

### DIFF
--- a/pkgs/zed-editor-git/version.json
+++ b/pkgs/zed-editor-git/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260715015427-4a3e0af",
-  "rev": "4a3e0af532e4ad89baf634f4b94938b98beaa292",
-  "hash": "sha256-yG0sI08OTAwYGE76zicbRgQrYeKqBpODUCNCWxGAvaY=",
-  "cargoHash": "sha256-H0cbYIlC8wyUGfem2t4K4aaG7M3O8FN6WLnD2HAxIyk="
+  "version": "unstable-20260715232916-1a246ef",
+  "rev": "1a246efd7e1b83ab568ec5e3e6c1a43a42e1abba",
+  "hash": "sha256-Av+unZNI39dEb+zwSIU+SkEjqagHWrc7W8KehEgQ4H8=",
+  "cargoHash": "sha256-gk+wICP/Pp4jAXzxRXN3QZo/MTCRjC90xiNT4iAfe10="
 }


### PR DESCRIPTION
Automated package bump for `[
  "zed-editor_git"
]`.