### PR TITLE
chore: bump tde2e_git

### DIFF
--- a/pkgs/tdlib-git/version.json
+++ b/pkgs/tdlib-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260714202703-07d3a09",
-  "rev": "07d3a0973f5113b0827a04d54a93aaaa9e288348",
-  "hash": "sha256-4N7QTO9NbW9M6HdY5gbimCAE/fAIARRLhjJasZpC/lQ="
+  "version": "unstable-20260715115735-1b08c83",
+  "rev": "1b08c83bc07888e4b0a6150d36c1364ff03cf930",
+  "hash": "sha256-cwBnEdFbUHdNvMzlJcutcXyDcHy+kP27nafpaIFWXr8="
 }

--- a/pkgs/telegram-desktop-git/version.json
+++ b/pkgs/telegram-desktop-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260714114100-a6209e3",
-  "rev": "a6209e3993ab63d8c02d2dfae6677469867b249b",
-  "hash": "sha256-zvJEfqMD4q2DI434dP6WfHU5TXAwpspdpgV959+A/0U="
+  "version": "unstable-20260715091147-28f5741",
+  "rev": "28f574154ea5fff940cd4c43f9d9509c430d3406",
+  "hash": "sha256-udQgYw0Vfgix64FwLETe4Hk+B5x5cIfDy6XenfzvFoE="
 }


### PR DESCRIPTION
Automated package bump for `[
  "tde2e_git",
  "tg-owt_git",
  "telegram-desktop-unwrapped_git",
  "telegram-desktop_git"
]`.