### PR TITLE
chore: bump shadps4_git

### DIFF
--- a/pkgs/shadps4-git/version.json
+++ b/pkgs/shadps4-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260714185738-2c9caf6",
-  "rev": "2c9caf6bfbe7e1dc7a1b4565af8d84c56469dd56",
-  "hash": "sha256-pa3DcXkPrsKWPFkw33UFLCWBc1GPpfCulRSxeWZLu58="
+  "version": "unstable-20260715182326-25287fb",
+  "rev": "25287fb00bdac1a468ec14d909e6ec5e22df7b3c",
+  "hash": "sha256-DwvJgOC3vDNNoyCa5pRSOjDWk5CA+eoUdHfso0ljlM8="
 }


### PR DESCRIPTION
Automated package bump for `[
  "shadps4_git"
]`.