### PR TITLE
chore: bump libdrm_git

### DIFF
--- a/pkgs/mesa-git/version.json
+++ b/pkgs/mesa-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260715022606-0f90865",
-  "rev": "0f9086520f0ed1ba8fdd81548e6b4e1a6dc2ad65",
-  "hash": "sha256-A/FCXi/qMks6SFnGSp9Hjx7upGXOnUgdTEd1Z8l1jF0="
+  "version": "unstable-20260716023120-09180f0",
+  "rev": "09180f0eed603872b75f44b398048db06f236f54",
+  "hash": "sha256-gZtqzsHYYtOGbLYTcK+SV46+BwTnm5OpOiL48Ud+0YI="
 }

--- a/pkgs/wlroots-git/version.json
+++ b/pkgs/wlroots-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260714191211-e04f8f4",
-  "rev": "e04f8f4f373624f2e6eaade6ff3cac54c72ed266",
-  "hash": "sha256-zxjg2pxosyqeYHvemnXzQfvp/8mRaT8TewVkUqrtUJI="
+  "version": "unstable-20260715140625-e8c9838",
+  "rev": "e8c983808d8b98a71f991c16c24367494386958b",
+  "hash": "sha256-jmd6q7Q9pgueB2edNcg/oZJqS7iL4UbJL11PikqO0yY="
 }


### PR DESCRIPTION
Automated package bump for `[
  "libdrm_git",
  "wayland-protocols_git",
  "mesa_git",
  "wayland_git",
  "wlroots_git",
  "sway-unwrapped_git",
  "xdg-desktop-portal-wlr_git"
]`.