### PR TITLE
chore: bump nss_git

### DIFF
--- a/pkgs/firefox-nightly/version.json
+++ b/pkgs/firefox-nightly/version.json
@@ -1,6 +1,6 @@
 {
   "version": "154.0a1",
-  "rev": "d83a08d81de20f3b72db70f531fad19090e1db4b",
-  "buildId": "20260714213719",
-  "hash": "sha256-4K/KMI0SxNgPgKvAbNj2f7JNebuy36wvgWDJa8TASrk="
+  "rev": "c0dff85fa67e5ab148ce20d4298c13f13ceec342",
+  "buildId": "20260715200402",
+  "hash": "sha256-iDzGkrAscohNWAu1REdY8wjW8cx3S0v2KvMi+LwgrTw="
 }

--- a/pkgs/nss-git/version.json
+++ b/pkgs/nss-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260714202016-61e8b93",
-  "rev": "61e8b93902eb91963c4458511cae9c45e81f3b38",
-  "hash": "sha256-veAAm8egDINLjRt+MRkGFlZYlDUqNVq0jZRUsef32qA="
+  "version": "unstable-20260715202725-d92d229",
+  "rev": "d92d22962d985f0d8ce457a5fe36bba42dc6a491",
+  "hash": "sha256-WfLekTZ0W1jmkkVN76jS+0rB4Ft/nmSxjE+M2l7pXgg="
 }


### PR DESCRIPTION
Automated package bump for `[
  "nss_git",
  "firefox-unwrapped_nightly"
]`.