### PR TITLE
chore: bump openrgb_git

### DIFF
--- a/pkgs/openrgb-git/version.json
+++ b/pkgs/openrgb-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260715024518-28d73d7",
-  "rev": "28d73d74bcb0ad137107bdfff9a0f4121346c508",
-  "hash": "sha256-db8MIDgOKQHhRIHjddYqTGkAlUf8t1fTlH9hM27VTSc="
+  "version": "unstable-20260716131716-1b3480b",
+  "rev": "1b3480bf8a65d68286f870527b58db64927c4a0f",
+  "hash": "sha256-mLxWp1+poaSkeZnpof1gkb6lS4dxX+JBwmUa1cfHCQo="
 }


### PR DESCRIPTION
Automated package bump for `[
  "openrgb_git"
]`.