### PR TITLE
chore: bump pcsx2_git

### DIFF
--- a/pkgs/pcsx2-git/version.json
+++ b/pkgs/pcsx2-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260716002909-2d62078",
-  "rev": "2d62078b043017581f89ad35d1f2a90481d05311",
-  "hash": "sha256-1TD3Zil7yH1JHeeS3K6WR8CY8ocRgxAU1Wbdw7h0CMI="
+  "version": "unstable-20260716144538-86d76bb",
+  "rev": "86d76bbf590566d9ea74d381eeff3acd9856503a",
+  "hash": "sha256-m1GZ6s3iYX3KSKFIfTi1jWLWtI4NG0YzJ+/UaFVd5t4="
 }


### PR DESCRIPTION
Automated package bump for `[
  "pcsx2_git"
]`.