### PR TITLE
chore: bump nix_git

### DIFF
--- a/pkgs/nix-git/version.json
+++ b/pkgs/nix-git/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260716021834-035f34f",
-  "rev": "035f34f13f969cf72ca4ea60369d907972402956",
-  "hash": "sha256-GVlCnL2/fkvFKj09Yn95KUxNANloc59/K4SqnkhrRD8=",
-  "lastModifiedDate": "20260716021834"
+  "version": "unstable-20260716234557-214570a",
+  "rev": "214570a1939dff12bc0c2fca5f63ea5a32c90a1f",
+  "hash": "sha256-TXWVj4hqfAfuTpJxjl2Yqqa1oL/ULDKoPjgt66IXpNc=",
+  "lastModifiedDate": "20260716234557"
 }


### PR DESCRIPTION
Automated package bump for `[
  "nix_git"
]`.