### PR TITLE
chore: bump tde2e_git

### DIFF
--- a/pkgs/tdlib-git/version.json
+++ b/pkgs/tdlib-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260715115735-1b08c83",
-  "rev": "1b08c83bc07888e4b0a6150d36c1364ff03cf930",
-  "hash": "sha256-cwBnEdFbUHdNvMzlJcutcXyDcHy+kP27nafpaIFWXr8="
+  "version": "unstable-20260716193326-d8d46df",
+  "rev": "d8d46dfab55f40e2fcf30fc5cc7cd5950abe99e2",
+  "hash": "sha256-n1EMl0Z58a+wp/gRUDKA//wRTKpO0Pb/o9bIDPPMdJ0="
 }

--- a/pkgs/telegram-desktop-git/version.json
+++ b/pkgs/telegram-desktop-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260715091147-28f5741",
-  "rev": "28f574154ea5fff940cd4c43f9d9509c430d3406",
-  "hash": "sha256-udQgYw0Vfgix64FwLETe4Hk+B5x5cIfDy6XenfzvFoE="
+  "version": "unstable-20260716173413-f7ca3c4",
+  "rev": "f7ca3c4540935771cbc96168ee297dd88d84d810",
+  "hash": "sha256-21YyUN5QaliH6upQutnij5LKeaBx6HH/lcb3n2jpWzI="
 }


### PR DESCRIPTION
Automated package bump for `[
  "tde2e_git",
  "tg-owt_git",
  "telegram-desktop-unwrapped_git",
  "telegram-desktop_git"
]`.