### PR TITLE
chore: bump libdrm_git

### DIFF
--- a/pkgs/mesa-git/version.json
+++ b/pkgs/mesa-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260716023120-09180f0",
-  "rev": "09180f0eed603872b75f44b398048db06f236f54",
-  "hash": "sha256-gZtqzsHYYtOGbLYTcK+SV46+BwTnm5OpOiL48Ud+0YI="
+  "version": "unstable-20260716223651-99bf1b9",
+  "rev": "99bf1b953cba11d41dbee519ae1b53387477df9e",
+  "hash": "sha256-4URjxsXpfd6n3O4aCByQv1jo5Hw0Twp4Nf9WggN69eA="
 }

--- a/pkgs/wayland-git/version.json
+++ b/pkgs/wayland-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260709150616-c23a8be",
-  "rev": "c23a8beb1ff41428e841137175c6be738ab627be",
-  "hash": "sha256-BIK8CP/CEZjVzfmiXudwNLqp5jv/hAGexnS341Qn7Z0="
+  "version": "unstable-20260716152950-6c0a03a",
+  "rev": "6c0a03a8fade7386d202dde1b2ace76dd6897417",
+  "hash": "sha256-Y2PE11r8MyzVL9f4SB3/VKR/yXR7UrDMbiGkThEKODE="
 }

--- a/pkgs/wlroots-git/version.json
+++ b/pkgs/wlroots-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260715140625-e8c9838",
-  "rev": "e8c983808d8b98a71f991c16c24367494386958b",
-  "hash": "sha256-jmd6q7Q9pgueB2edNcg/oZJqS7iL4UbJL11PikqO0yY="
+  "version": "unstable-20260716180605-d64acff",
+  "rev": "d64acffc571643e1711361a967e399e0f1a9d5af",
+  "hash": "sha256-sYkVYiBHCTANCwyQ4r1mypFN1ZbSEdB4L1Z2DgwpPFc="
 }


### PR DESCRIPTION
Automated package bump for `[
  "libdrm_git",
  "wayland-protocols_git",
  "mesa_git",
  "wayland_git",
  "wlroots_git",
  "sway-unwrapped_git",
  "xdg-desktop-portal-wlr_git"
]`.