### PR TITLE
chore: bump zed-editor_git

### DIFF
--- a/pkgs/zed-editor-git/version.json
+++ b/pkgs/zed-editor-git/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260715232916-1a246ef",
-  "rev": "1a246efd7e1b83ab568ec5e3e6c1a43a42e1abba",
-  "hash": "sha256-Av+unZNI39dEb+zwSIU+SkEjqagHWrc7W8KehEgQ4H8=",
-  "cargoHash": "sha256-gk+wICP/Pp4jAXzxRXN3QZo/MTCRjC90xiNT4iAfe10="
+  "version": "unstable-20260716194521-058f01f",
+  "rev": "058f01fa93503491a735bfded53e77bfaa276148",
+  "hash": "sha256-EGJHz6mQJ2etErKIt4Zbd+vImA4mwAeV0SWzlnCjqdo=",
+  "cargoHash": "sha256-XQMM5iXIEaLhAh76gcyYt/1siIozvFVNXs7fQqI9HJY="
 }


### PR DESCRIPTION
Automated package bump for `[
  "zed-editor_git"
]`.