### PR TITLE
chore: bump shadps4_git

### DIFF
--- a/pkgs/shadps4-git/version.json
+++ b/pkgs/shadps4-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260715182326-25287fb",
-  "rev": "25287fb00bdac1a468ec14d909e6ec5e22df7b3c",
-  "hash": "sha256-DwvJgOC3vDNNoyCa5pRSOjDWk5CA+eoUdHfso0ljlM8="
+  "version": "unstable-20260716082526-bfc1a58",
+  "rev": "bfc1a588c258cc124a0d59c0e08ee9d0d984a556",
+  "hash": "sha256-sHG0oii//OqNw6VElMNNaop6YoHvaHEr3KP8ZB2eUcY="
 }


### PR DESCRIPTION
Automated package bump for `[
  "shadps4_git"
]`.