### PR TITLE
chore: bump helix_git

### DIFF
--- a/pkgs/helix-git/version.json
+++ b/pkgs/helix-git/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260706194641-14d6bc0",
-  "rev": "14d6bc0febed9c692048271a8ae2362ac969c6e0",
-  "hash": "sha256-/ibzswTrAp1yW0GStFZGyRl6KO+wb9wZIUZWH4bz3ww=",
+  "version": "unstable-20260716163018-f6f3eb1",
+  "rev": "f6f3eb1fe4a73933466f30175843059a4381a985",
+  "hash": "sha256-yfNBfV6HWAQU/xZXwrFoedsSYsDmCDIlTHRxAZI6teY=",
   "cargoHash": "sha256-oo59HhwOS3EeV/YI+NWirEkdzD9pzMot2lgphZeOxfc="
 }


### PR DESCRIPTION
Automated package bump for `[
  "helix_git"
]`.