### PR TITLE
chore: bump nss_git

### DIFF
--- a/pkgs/firefox-nightly/version.json
+++ b/pkgs/firefox-nightly/version.json
@@ -1,6 +1,6 @@
 {
   "version": "154.0a1",
-  "rev": "c0dff85fa67e5ab148ce20d4298c13f13ceec342",
-  "buildId": "20260715200402",
-  "hash": "sha256-iDzGkrAscohNWAu1REdY8wjW8cx3S0v2KvMi+LwgrTw="
+  "rev": "446c6e609dbd7c355c2fb27209dfe4833211991f",
+  "buildId": "20260716213609",
+  "hash": "sha256-/o3TEaS1EngGZvl8QsUooa0sI9h7twTJ4szznd0x37c="
 }

--- a/pkgs/nss-git/version.json
+++ b/pkgs/nss-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260715202725-d92d229",
-  "rev": "d92d22962d985f0d8ce457a5fe36bba42dc6a491",
-  "hash": "sha256-WfLekTZ0W1jmkkVN76jS+0rB4Ft/nmSxjE+M2l7pXgg="
+  "version": "unstable-20260716230651-737bda2",
+  "rev": "737bda25215afc5b8ab43d053e251421826f51fe",
+  "hash": "sha256-O9IP5ijBb3xT55GGs6genlTfXkhbpkLhnNFXHBp8TJc="
 }


### PR DESCRIPTION
Automated package bump for `[
  "nss_git",
  "firefox-unwrapped_nightly"
]`.