### PR TITLE
chore: bump nix_git

### DIFF
--- a/pkgs/nix-git/version.json
+++ b/pkgs/nix-git/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260716234557-214570a",
-  "rev": "214570a1939dff12bc0c2fca5f63ea5a32c90a1f",
-  "hash": "sha256-TXWVj4hqfAfuTpJxjl2Yqqa1oL/ULDKoPjgt66IXpNc=",
-  "lastModifiedDate": "20260716234557"
+  "version": "unstable-20260717185627-d2c75b6",
+  "rev": "d2c75b6a0ac3334cab6d520cd9c4313ad2ff0385",
+  "hash": "sha256-4vpJ/vvELkQ76+woKNNvLbsMxZUqesIgvFTJiIPTJyQ=",
+  "lastModifiedDate": "20260717185627"
 }


### PR DESCRIPTION
Automated package bump for `[
  "nix_git"
]`.