### PR TITLE
chore: bump pcsx2_git

### DIFF
--- a/pkgs/pcsx2-git/version.json
+++ b/pkgs/pcsx2-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260716144538-86d76bb",
-  "rev": "86d76bbf590566d9ea74d381eeff3acd9856503a",
-  "hash": "sha256-m1GZ6s3iYX3KSKFIfTi1jWLWtI4NG0YzJ+/UaFVd5t4="
+  "version": "unstable-20260717155027-470e995",
+  "rev": "470e995c6c1404dfa76c9efff60d7f47acb63562",
+  "hash": "sha256-aXAHS4ahjpAIS2D4sYycphVidOn5r0uEUNo/azJu7PY="
 }


### PR DESCRIPTION
Automated package bump for `[
  "pcsx2_git"
]`.