### PR TITLE
chore: bump openrgb_git

### DIFF
--- a/pkgs/openrgb-git/version.json
+++ b/pkgs/openrgb-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260716131716-1b3480b",
-  "rev": "1b3480bf8a65d68286f870527b58db64927c4a0f",
-  "hash": "sha256-mLxWp1+poaSkeZnpof1gkb6lS4dxX+JBwmUa1cfHCQo="
+  "version": "unstable-20260718000739-9d189d5",
+  "rev": "9d189d5b9be5f9af805661fbd731e871f10e8ae7",
+  "hash": "sha256-/Id/9dGqVvBMvVmNg/slweeBRmQgTz7u/WKVsUC1owA="
 }


### PR DESCRIPTION
Automated package bump for `[
  "openrgb_git"
]`.