### PR TITLE
chore: bump tde2e_git

### DIFF
--- a/pkgs/tdlib-git/version.json
+++ b/pkgs/tdlib-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260716193326-d8d46df",
-  "rev": "d8d46dfab55f40e2fcf30fc5cc7cd5950abe99e2",
-  "hash": "sha256-n1EMl0Z58a+wp/gRUDKA//wRTKpO0Pb/o9bIDPPMdJ0="
+  "version": "unstable-20260717141848-022d602",
+  "rev": "022d60202e446ad1287b9fb68e687c8a0760788b",
+  "hash": "sha256-jO/9S3G0F25AInn9H3sw6KrLOKVmTQV+AxIPo5dzpBg="
 }

--- a/pkgs/telegram-desktop-git/version.json
+++ b/pkgs/telegram-desktop-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260716173413-f7ca3c4",
-  "rev": "f7ca3c4540935771cbc96168ee297dd88d84d810",
-  "hash": "sha256-21YyUN5QaliH6upQutnij5LKeaBx6HH/lcb3n2jpWzI="
+  "version": "unstable-20260717200000-19e221e",
+  "rev": "19e221ed51ec441c16c26e1e013c056c00018584",
+  "hash": "sha256-krXKmA/6fEe4L8X78tzeF6ieoH+1lv5CGOcw0iRBuTU="
 }


### PR DESCRIPTION
Automated package bump for `[
  "tde2e_git",
  "tg-owt_git",
  "telegram-desktop-unwrapped_git",
  "telegram-desktop_git"
]`.