### PR TITLE
chore: bump zed-editor_git

### DIFF
--- a/pkgs/zed-editor-git/version.json
+++ b/pkgs/zed-editor-git/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260716194521-058f01f",
-  "rev": "058f01fa93503491a735bfded53e77bfaa276148",
-  "hash": "sha256-EGJHz6mQJ2etErKIt4Zbd+vImA4mwAeV0SWzlnCjqdo=",
-  "cargoHash": "sha256-XQMM5iXIEaLhAh76gcyYt/1siIozvFVNXs7fQqI9HJY="
+  "version": "unstable-20260717235806-9d7ab04",
+  "rev": "9d7ab044366fb266cecb30b214aea8b7b94c032d",
+  "hash": "sha256-FCK5jHcs1N9c8/T3wtIWEFDPUV7hk14dTZ+zAXIdAMw=",
+  "cargoHash": "sha256-XKdcv1VkA/Eoa5pmKwFP/h9AEXF8Dv6btlxR15eXRtI="
 }


### PR DESCRIPTION
Automated package bump for `[
  "zed-editor_git"
]`.