### PR TITLE
chore: bump libdrm_git

### DIFF
--- a/pkgs/mesa-git/version.json
+++ b/pkgs/mesa-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260716223651-99bf1b9",
-  "rev": "99bf1b953cba11d41dbee519ae1b53387477df9e",
-  "hash": "sha256-4URjxsXpfd6n3O4aCByQv1jo5Hw0Twp4Nf9WggN69eA="
+  "version": "unstable-20260718015151-4b9c74d",
+  "rev": "4b9c74d0af56b7a9cea3384965934a20ce95bfc4",
+  "hash": "sha256-DOak3+afVeidauokowcoBd9Zkkebi9SvTcziDEDQL20="
 }


### PR DESCRIPTION
Automated package bump for `[
  "libdrm_git",
  "wayland-protocols_git",
  "mesa_git",
  "wayland_git",
  "wlroots_git",
  "sway-unwrapped_git",
  "xdg-desktop-portal-wlr_git"
]`.