### PR TITLE
chore: bump shadps4_git

### DIFF
--- a/pkgs/shadps4-git/version.json
+++ b/pkgs/shadps4-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260716082526-bfc1a58",
-  "rev": "bfc1a588c258cc124a0d59c0e08ee9d0d984a556",
-  "hash": "sha256-sHG0oii//OqNw6VElMNNaop6YoHvaHEr3KP8ZB2eUcY="
+  "version": "unstable-20260717142550-0da2a58",
+  "rev": "0da2a58b84bdef01488c90c7a477dbd8a4d2c8ff",
+  "hash": "sha256-8AYLm0jNVzPhRERdDlCtaF+zbuokMRSXwJnZ69W99Jc="
 }


### PR DESCRIPTION
Automated package bump for `[
  "shadps4_git"
]`.