### PR TITLE
chore: bump nss_git

### DIFF
--- a/pkgs/firefox-nightly/version.json
+++ b/pkgs/firefox-nightly/version.json
@@ -1,6 +1,6 @@
 {
   "version": "154.0a1",
-  "rev": "446c6e609dbd7c355c2fb27209dfe4833211991f",
-  "buildId": "20260716213609",
-  "hash": "sha256-/o3TEaS1EngGZvl8QsUooa0sI9h7twTJ4szznd0x37c="
+  "rev": "7f94689f2c228a96f6c271e30880e72778b7ab15",
+  "buildId": "20260717161234",
+  "hash": "sha256-GS9zcT67jtwZup//oRG91Qq0UPB1RYg4WqYBNd6SMA0="
 }

--- a/pkgs/nss-git/version.json
+++ b/pkgs/nss-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260716230651-737bda2",
-  "rev": "737bda25215afc5b8ab43d053e251421826f51fe",
-  "hash": "sha256-O9IP5ijBb3xT55GGs6genlTfXkhbpkLhnNFXHBp8TJc="
+  "version": "unstable-20260717230157-1d6469a",
+  "rev": "1d6469a80ed9a48310c703c5e6d3b3f09a97a77b",
+  "hash": "sha256-bDayz2HFW5nL32YUilW0MIO3RRTwDkpF8qQ/OxkEW2I="
 }


### PR DESCRIPTION
Automated package bump for `[
  "nss_git",
  "firefox-unwrapped_nightly"
]`.