### PR TITLE
chore: bump pcsx2_git

### DIFF
--- a/pkgs/pcsx2-git/version.json
+++ b/pkgs/pcsx2-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260717155027-470e995",
-  "rev": "470e995c6c1404dfa76c9efff60d7f47acb63562",
-  "hash": "sha256-aXAHS4ahjpAIS2D4sYycphVidOn5r0uEUNo/azJu7PY="
+  "version": "unstable-20260719001707-899a487",
+  "rev": "899a4873d4a6bc472d87e163261598d4d552fd0c",
+  "hash": "sha256-/B7HXi3/XHdXnTcSOZvd2EEwqQY5hGqDMMnHu59Mucc="
 }


### PR DESCRIPTION
Automated package bump for `[
  "pcsx2_git"
]`.