### PR TITLE
chore: bump tde2e_git

### DIFF
--- a/pkgs/telegram-desktop-git/version.json
+++ b/pkgs/telegram-desktop-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260717200000-19e221e",
-  "rev": "19e221ed51ec441c16c26e1e013c056c00018584",
-  "hash": "sha256-krXKmA/6fEe4L8X78tzeF6ieoH+1lv5CGOcw0iRBuTU="
+  "version": "unstable-20260718070540-246d0a2",
+  "rev": "246d0a21b45e5f5ed1c013678a4c1bf0fe707d0d",
+  "hash": "sha256-QH2MKHQamlPULX70x5xo+wsM2RCyXLQPTCUjWafVoYc="
 }


### PR DESCRIPTION
Automated package bump for `[
  "tde2e_git",
  "tg-owt_git",
  "telegram-desktop-unwrapped_git",
  "telegram-desktop_git"
]`.