### PR TITLE
chore: bump beautyline-icons

### DIFF
--- a/pkgs/beautyline-icons/version.json
+++ b/pkgs/beautyline-icons/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260520221037-cb19ed8",
-  "rev": "cb19ed82a10c49e035a68000860c9a49fea79ff2",
-  "hash": "sha256-pjpT0zJZ03RAH4mz5gJgJRzSAJ2mI23mMlx45JQiOnY="
+  "version": "unstable-20260718161308-07e3736",
+  "rev": "07e3736f8be38f9f48cf015d992f56f06e455002",
+  "hash": "sha256-8ER5BnrFtVggWB3B9GaMoTZdHDtrmOU1hlMROTuBQ7U="
 }


### PR DESCRIPTION
Automated package bump for `[
  "beautyline-icons",
  "dr460nized-kde-theme"
]`.