### PR TITLE
chore: bump zed-editor_git

### DIFF
--- a/pkgs/zed-editor-git/version.json
+++ b/pkgs/zed-editor-git/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260717235806-9d7ab04",
-  "rev": "9d7ab044366fb266cecb30b214aea8b7b94c032d",
-  "hash": "sha256-FCK5jHcs1N9c8/T3wtIWEFDPUV7hk14dTZ+zAXIdAMw=",
-  "cargoHash": "sha256-XKdcv1VkA/Eoa5pmKwFP/h9AEXF8Dv6btlxR15eXRtI="
+  "version": "unstable-20260718224055-f032f4d",
+  "rev": "f032f4d433da3747f9d7bcc9e9cd52d6ca3fb3e4",
+  "hash": "sha256-FJLAMZSb56UVIPI8sVsK5rWFtzBt5W/e4m4tr4/w73c=",
+  "cargoHash": "sha256-SLKZNFOI0PTNbiyF9Bv7tGn5we0XpOdOg4Pp1fVz2S0="
 }


### PR DESCRIPTION
Automated package bump for `[
  "zed-editor_git"
]`.