### PR TITLE
chore: bump nix_git

### DIFF
--- a/pkgs/nix-git/version.json
+++ b/pkgs/nix-git/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260717185627-d2c75b6",
-  "rev": "d2c75b6a0ac3334cab6d520cd9c4313ad2ff0385",
-  "hash": "sha256-4vpJ/vvELkQ76+woKNNvLbsMxZUqesIgvFTJiIPTJyQ=",
-  "lastModifiedDate": "20260717185627"
+  "version": "unstable-20260718115020-bebd2f8",
+  "rev": "bebd2f851a304e9fb2e143ce0cbeff577c6a37ac",
+  "hash": "sha256-dt1zVj4MRpmffhsgQk+3tx1m/pFTXbtVWrn5KZ1y+8Q=",
+  "lastModifiedDate": "20260718115020"
 }


### PR DESCRIPTION
Automated package bump for `[
  "nix_git"
]`.