### PR TITLE
chore: bump libdrm_git

### DIFF
--- a/pkgs/mesa-git/version.json
+++ b/pkgs/mesa-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260718015151-4b9c74d",
-  "rev": "4b9c74d0af56b7a9cea3384965934a20ce95bfc4",
-  "hash": "sha256-DOak3+afVeidauokowcoBd9Zkkebi9SvTcziDEDQL20="
+  "version": "unstable-20260719005348-a11215b",
+  "rev": "a11215b318f6208cca39b49315a3856d4870210b",
+  "hash": "sha256-xOCvvFqGTd9Fxby39Haocl7dIHJzSp5hw0brvuJ0Ugw="
 }

--- a/pkgs/sway-unwrapped-git/version.json
+++ b/pkgs/sway-unwrapped-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260702124137-f3b6431",
-  "rev": "f3b64311045c3241ac6be3fd293dff8bfd55b6d4",
-  "hash": "sha256-cCVhLvVKX3GqQ+5H9j2wQy2zSqzheM0Fw8uReUJzb2I="
+  "version": "unstable-20260718130434-d6227fe",
+  "rev": "d6227fe978484e080937b18fbd731fc1456561f7",
+  "hash": "sha256-5IQBRQiEQPixflxbcPj9RHMwvK8eQH0y728LqY623F4="
 }


### PR DESCRIPTION
Automated package bump for `[
  "libdrm_git",
  "wayland-protocols_git",
  "mesa_git",
  "wayland_git",
  "wlroots_git",
  "sway-unwrapped_git",
  "xdg-desktop-portal-wlr_git"
]`.