### PR TITLE
chore: bump libportal_git

### DIFF
--- a/pkgs/libportal-git/version.json
+++ b/pkgs/libportal-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260617013325-9489e1d",
-  "rev": "9489e1dfb8d14adf28b75db172d7ce47a3f0349b",
-  "hash": "sha256-F0JOhlQr0ajOiQdzIhpDcxSJNLhc4wSCo1Y3mWM49uU="
+  "version": "unstable-20260718190043-11a6eef",
+  "rev": "11a6eef763b1491a8d4d3819c547219c0360e054",
+  "hash": "sha256-GUt59Up6zeZ6RLnnFyTIKrUSnMybxZDmErnEQDVfXT4="
 }


### PR DESCRIPTION
Automated package bump for `[
  "libportal_git"
]`.