### PR TITLE
chore: bump openrgb_git

### DIFF
--- a/pkgs/openrgb-git/version.json
+++ b/pkgs/openrgb-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260718000739-9d189d5",
-  "rev": "9d189d5b9be5f9af805661fbd731e871f10e8ae7",
-  "hash": "sha256-/Id/9dGqVvBMvVmNg/slweeBRmQgTz7u/WKVsUC1owA="
+  "version": "unstable-20260718235438-8fb7903",
+  "rev": "8fb790358f755757d9f0ac1d091c934fd8388379",
+  "hash": "sha256-Fdjwi7NWIrHwpC2HP073yDnGb8nTr3KB6eWEqxW2eE4="
 }


### PR DESCRIPTION
Automated package bump for `[
  "openrgb_git"
]`.