### PR TITLE
chore: bump shadps4_git

### DIFF
--- a/pkgs/shadps4-git/version.json
+++ b/pkgs/shadps4-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260717142550-0da2a58",
-  "rev": "0da2a58b84bdef01488c90c7a477dbd8a4d2c8ff",
-  "hash": "sha256-8AYLm0jNVzPhRERdDlCtaF+zbuokMRSXwJnZ69W99Jc="
+  "version": "unstable-20260718070056-bfb0122",
+  "rev": "bfb0122bbe3c1dc7c71d4973d321869c0eb5e015",
+  "hash": "sha256-qfs/MfXdrSjCm6cJkPcwy8LjVVkYrji/Qk2mQovhM5U="
 }


### PR DESCRIPTION
Automated package bump for `[
  "shadps4_git"
]`.