### PR TITLE
chore: bump nss_git

### DIFF
--- a/maintenance/failures.x86_64-linux.nix
+++ b/maintenance/failures.x86_64-linux.nix
@@ -1,4 +1,6 @@
 {
+  "firefox-unwrapped_nightly" = "/nix/store/mf05hfianp54z2lw8p8fajkzfhk7cxmn-firefox-nightly-unwrapped-154.0a1-20260718090721-7ae92e6";
+  "firefox_nightly" = "/nix/store/j93m7jr2q0187ahi6ag874ahf60sdg72-firefox-nightly-154.0a1-20260718090721-7ae92e6";
   "linuxPackages_cachyos.amdgpu-i2c" = "/nix/store/7ygsfxv5shk5sdqp8ky0fyzd08rgnh60-amdgpu-i2c-x86_64-unknown-linux-gnu-0-unstable-2024-12-16";
   "linuxPackages_cachyos.amneziawg" = "/nix/store/nxsdyj98pp0b5y45dr48l2chz22ha4gp-amneziawg-x86_64-unknown-linux-gnu-1.0.20260611";
   "linuxPackages_cachyos.bcachefs" = "/nix/store/0iz7f4lx7qzr9cpjx5w302vdxkpjksna-bcachefs-x86_64-unknown-linux-gnu-7.1.3-1.38.8";

--- a/pkgs/firefox-nightly/version.json
+++ b/pkgs/firefox-nightly/version.json
@@ -1,6 +1,6 @@
 {
   "version": "154.0a1",
-  "rev": "7f94689f2c228a96f6c271e30880e72778b7ab15",
-  "buildId": "20260717161234",
-  "hash": "sha256-GS9zcT67jtwZup//oRG91Qq0UPB1RYg4WqYBNd6SMA0="
+  "rev": "7ae92e67d094086cd3e09918ec94b6278a948535",
+  "buildId": "20260718090721",
+  "hash": "sha256-Jcg++wMWimAc/zfbZhppVi8MrI9JXew+Uk8b9bMF78A="
 }


### PR DESCRIPTION
Automated package bump for `[
  "nss_git",
  "firefox-unwrapped_nightly"
]`.