### PR TITLE
chore: bump openrgb_git

### DIFF
--- a/pkgs/openrgb-git/version.json
+++ b/pkgs/openrgb-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260718235438-8fb7903",
-  "rev": "8fb790358f755757d9f0ac1d091c934fd8388379",
-  "hash": "sha256-Fdjwi7NWIrHwpC2HP073yDnGb8nTr3KB6eWEqxW2eE4="
+  "version": "unstable-20260719070446-b35e119",
+  "rev": "b35e11932563e91f24e8dc092e37fd4f58fbc515",
+  "hash": "sha256-OJXMMcvb7wrZ7XS6geLsnBX170g4WSoCE+MAHwph+0o="
 }


### PR DESCRIPTION
Automated package bump for `[
  "openrgb_git"
]`.