### PR TITLE
chore: bump niri_git

### DIFF
--- a/pkgs/niri-git/version.json
+++ b/pkgs/niri-git/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260708145915-0777769",
-  "rev": "0777769e719b7c9b7c980d4ea66288bfbb4da5b3",
-  "hash": "sha256-dI0HkX1djETia7cD/Y64h8BNIsSOfTRMzfNum2J6UhE=",
+  "version": "unstable-20260719102020-f036de6",
+  "rev": "f036de655d309edc13fef545a3809330796cbe83",
+  "hash": "sha256-38yvDuO09V/GG19oJO+B5nn38NhvvZEWKRGFE4WPUi4=",
   "cargoHash": "sha256-jmYkGX4M69W16qr9kLHfnAAJWvJ87IMVBQcC2wE9Phc="
 }


### PR DESCRIPTION
Automated package bump for `[
  "niri_git"
]`.