### PR TITLE
chore: bump libportal_git

### DIFF
--- a/pkgs/libportal-git/version.json
+++ b/pkgs/libportal-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260718190043-11a6eef",
-  "rev": "11a6eef763b1491a8d4d3819c547219c0360e054",
-  "hash": "sha256-GUt59Up6zeZ6RLnnFyTIKrUSnMybxZDmErnEQDVfXT4="
+  "version": "unstable-20260719052218-646419a",
+  "rev": "646419a712ad4eca710c1e6fc12acba0a4201b06",
+  "hash": "sha256-a63PpVRaptV3kWWEQkuV/uNZGUEL11ev6x2qeP2Oyuc="
 }


### PR DESCRIPTION
Automated package bump for `[
  "libportal_git"
]`.