### PR TITLE
chore: bump tde2e_git

### DIFF
--- a/pkgs/telegram-desktop-git/version.json
+++ b/pkgs/telegram-desktop-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260718070540-246d0a2",
-  "rev": "246d0a21b45e5f5ed1c013678a4c1bf0fe707d0d",
-  "hash": "sha256-QH2MKHQamlPULX70x5xo+wsM2RCyXLQPTCUjWafVoYc="
+  "version": "unstable-20260719084025-1601247",
+  "rev": "1601247ea611eb41f79b1cbf4a34e3bf982a193a",
+  "hash": "sha256-cX/8D5/BjJHnB8FxRR9IFztzVEjxN0glmq56j1nFHX0="
 }


### PR DESCRIPTION
Automated package bump for `[
  "tde2e_git",
  "tg-owt_git",
  "telegram-desktop-unwrapped_git",
  "telegram-desktop_git"
]`.