### PR TITLE
chore: bump pcsx2_git

### DIFF
--- a/pkgs/pcsx2-git/version.json
+++ b/pkgs/pcsx2-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260719001707-899a487",
-  "rev": "899a4873d4a6bc472d87e163261598d4d552fd0c",
-  "hash": "sha256-/B7HXi3/XHdXnTcSOZvd2EEwqQY5hGqDMMnHu59Mucc="
+  "version": "unstable-20260719130544-30962c8",
+  "rev": "30962c8d088793d847a5287d4ab5691a90187fce",
+  "hash": "sha256-LlG+D3LKgTNSP5FDE8tFOGJRAQHPR7mu1PvvUwwcnPQ="
 }


### PR DESCRIPTION
Automated package bump for `[
  "pcsx2_git"
]`.