### PR TITLE
chore: bump zed-editor_git

### DIFF
--- a/pkgs/zed-editor-git/version.json
+++ b/pkgs/zed-editor-git/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260718224055-f032f4d",
-  "rev": "f032f4d433da3747f9d7bcc9e9cd52d6ca3fb3e4",
-  "hash": "sha256-FJLAMZSb56UVIPI8sVsK5rWFtzBt5W/e4m4tr4/w73c=",
+  "version": "unstable-20260720040828-339d96b",
+  "rev": "339d96b5a81a8fd8434b766e501c6a4c27f59b60",
+  "hash": "sha256-7JSkOoOZBCBrPTe+PMabjJ4tPkQJA+9RdYFYneam4LI=",
   "cargoHash": "sha256-SLKZNFOI0PTNbiyF9Bv7tGn5we0XpOdOg4Pp1fVz2S0="
 }


### PR DESCRIPTION
Automated package bump for `[
  "zed-editor_git"
]`.