### PR TITLE
chore: bump shadps4_git

### DIFF
--- a/pkgs/shadps4-git/version.json
+++ b/pkgs/shadps4-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260718070056-bfb0122",
-  "rev": "bfb0122bbe3c1dc7c71d4973d321869c0eb5e015",
-  "hash": "sha256-qfs/MfXdrSjCm6cJkPcwy8LjVVkYrji/Qk2mQovhM5U="
+  "version": "unstable-20260719191434-4c0d869",
+  "rev": "4c0d869adc5c39a32fd225374227e2032dd0b22c",
+  "hash": "sha256-e/e6iEqZXOsv+P+HNIKb22cAashxps755YBVYVSFwcM="
 }


### PR DESCRIPTION
Automated package bump for `[
  "shadps4_git"
]`.