### PR TITLE
chore: bump nss_git

### DIFF
--- a/pkgs/firefox-nightly/version.json
+++ b/pkgs/firefox-nightly/version.json
@@ -1,6 +1,6 @@
 {
   "version": "154.0a1",
-  "rev": "7f94689f2c228a96f6c271e30880e72778b7ab15",
-  "buildId": "20260717161234",
-  "hash": "sha256-GS9zcT67jtwZup//oRG91Qq0UPB1RYg4WqYBNd6SMA0="
+  "rev": "d951c4a19a6958816b35a228ff38fc6ae2c34f13",
+  "buildId": "20260719211319",
+  "hash": "sha256-yVFJQVa9Xes7629uipEHpPPGeNqqo2vnOWqBPv3lBes="
 }


### PR DESCRIPTION
Automated package bump for `[
  "nss_git",
  "firefox-unwrapped_nightly"
]`.