### PR TITLE
chore: bump nix_git

### DIFF
--- a/pkgs/nix-git/version.json
+++ b/pkgs/nix-git/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260718115020-bebd2f8",
-  "rev": "bebd2f851a304e9fb2e143ce0cbeff577c6a37ac",
-  "hash": "sha256-dt1zVj4MRpmffhsgQk+3tx1m/pFTXbtVWrn5KZ1y+8Q=",
-  "lastModifiedDate": "20260718115020"
+  "version": "unstable-20260720234348-aafac2b",
+  "rev": "aafac2b8d93e3d9ecf05cafb4c446f8ae97347b8",
+  "hash": "sha256-wSei3x1MGicdtM5hm+m7iw77tfPy54pVxHbl80sADTE=",
+  "lastModifiedDate": "20260720234348"
 }


### PR DESCRIPTION
Automated package bump for `[
  "nix_git"
]`.