### PR TITLE
chore: bump pcsx2_git

### DIFF
--- a/pkgs/pcsx2-git/version.json
+++ b/pkgs/pcsx2-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260719130544-30962c8",
-  "rev": "30962c8d088793d847a5287d4ab5691a90187fce",
-  "hash": "sha256-LlG+D3LKgTNSP5FDE8tFOGJRAQHPR7mu1PvvUwwcnPQ="
+  "version": "unstable-20260720172701-8f49597",
+  "rev": "8f495970823e8b2b956a538c0bfd84a382de07e8",
+  "hash": "sha256-cN9TKSN8IwY5RSyG8fL7Ad5DHEKidd0wKOJwdPSdTZ4="
 }


### PR DESCRIPTION
Automated package bump for `[
  "pcsx2_git"
]`.