### PR TITLE
chore: bump niri_git

### DIFF
--- a/pkgs/niri-git/version.json
+++ b/pkgs/niri-git/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260719102020-f036de6",
-  "rev": "f036de655d309edc13fef545a3809330796cbe83",
-  "hash": "sha256-38yvDuO09V/GG19oJO+B5nn38NhvvZEWKRGFE4WPUi4=",
-  "cargoHash": "sha256-jmYkGX4M69W16qr9kLHfnAAJWvJ87IMVBQcC2wE9Phc="
+  "version": "unstable-20260720180526-7f26c3e",
+  "rev": "7f26c3ee804fb6ed458ef7fb0e3c794f14e0b3bc",
+  "hash": "sha256-9EMn69JBcFWFgUM7f0VBAX+jBby5b9H3M59U75+5yI4=",
+  "cargoHash": "sha256-HypBB3PL4nVFMNH2+jEK0+dG9dJ920nHi8GwRoeH/v4="
 }


### PR DESCRIPTION
Automated package bump for `[
  "niri_git"
]`.