### PR TITLE
chore: bump shadps4_git

### DIFF
--- a/pkgs/shadps4-git/version.json
+++ b/pkgs/shadps4-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260719191434-4c0d869",
-  "rev": "4c0d869adc5c39a32fd225374227e2032dd0b22c",
-  "hash": "sha256-e/e6iEqZXOsv+P+HNIKb22cAashxps755YBVYVSFwcM="
+  "version": "unstable-20260720174949-4c72de0",
+  "rev": "4c72de0732ce7443a1631bf190e2606294f58f65",
+  "hash": "sha256-AYA9gdgirQSPhHDvzYoZaDT2g2qNQiGctT9KNZ3fEUI="
 }


### PR DESCRIPTION
Automated package bump for `[
  "shadps4_git"
]`.