### PR TITLE
chore: bump tde2e_git

### DIFF
--- a/pkgs/telegram-desktop-git/version.json
+++ b/pkgs/telegram-desktop-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260719084025-1601247",
-  "rev": "1601247ea611eb41f79b1cbf4a34e3bf982a193a",
-  "hash": "sha256-cX/8D5/BjJHnB8FxRR9IFztzVEjxN0glmq56j1nFHX0="
+  "version": "unstable-20260720191437-1829494",
+  "rev": "18294947a0f93b35a9460817a62de75e20b6bf23",
+  "hash": "sha256-xOY1h1ESv/gZQpdTVWX6mn++00g5zF/6tj0G73kq8wM="
 }


### PR DESCRIPTION
Automated package bump for `[
  "tde2e_git",
  "tg-owt_git",
  "telegram-desktop-unwrapped_git",
  "telegram-desktop_git"
]`.