### PR TITLE
chore: bump libdrm_git

### DIFF
--- a/pkgs/libdrm-git/version.json
+++ b/pkgs/libdrm-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260714195949-f9816a4",
-  "rev": "f9816a42b0d6138851cbe5eb7a33ee1a2f2a15ca",
-  "hash": "sha256-jljFpM2GMXLBY5bDibk6bIobSNfxhW8duRNacSvXK7M="
+  "version": "unstable-20260714214327-f198c21",
+  "rev": "f198c21dfcb89127083413dd4779a13b3f9a6507",
+  "hash": "sha256-w2dJQQMdftCPfdqYy8kRznvnXgWURBW0s62m0m3VKQc="
 }

--- a/pkgs/mesa-git/version.json
+++ b/pkgs/mesa-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260720002316-df73bd9",
-  "rev": "df73bd930ae57bc1928beb1fdfb30bc3ab41b684",
-  "hash": "sha256-PPV/HuU1seV1BLQBFAmto2AMg2gCziM1R9pOz3JGbE0="
+  "version": "unstable-20260720235319-772cb76",
+  "rev": "772cb76cc80ed5bde9c8a3972f0852d68fa54f9d",
+  "hash": "sha256-PwF3DqaLZ2kZeTF5A8MYkOscZNY7vRsPcJ6jW7fSedg="
 }

--- a/pkgs/sway-unwrapped-git/version.json
+++ b/pkgs/sway-unwrapped-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260718130434-d6227fe",
-  "rev": "d6227fe978484e080937b18fbd731fc1456561f7",
-  "hash": "sha256-5IQBRQiEQPixflxbcPj9RHMwvK8eQH0y728LqY623F4="
+  "version": "unstable-20260720144956-6959a78",
+  "rev": "6959a78a8f0d52f79ad7465135b3295307a5146a",
+  "hash": "sha256-UcG1mapWRxFg0lCX/LVq1JWSMA2LQ1kTDWyxotEcV/4="
 }

--- a/pkgs/wayland-git/version.json
+++ b/pkgs/wayland-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260716152950-6c0a03a",
-  "rev": "6c0a03a8fade7386d202dde1b2ace76dd6897417",
-  "hash": "sha256-Y2PE11r8MyzVL9f4SB3/VKR/yXR7UrDMbiGkThEKODE="
+  "version": "unstable-20260720052449-5a81983",
+  "rev": "5a819837646842aa74cb0a1b3c74d2fe14694ac6",
+  "hash": "sha256-n6dKHy5MuxMplUxJhs4ZXN9rpdSMTnI9hOv3Gv8y5O4="
 }

--- a/pkgs/wlroots-git/version.json
+++ b/pkgs/wlroots-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260716180605-d64acff",
-  "rev": "d64acffc571643e1711361a967e399e0f1a9d5af",
-  "hash": "sha256-sYkVYiBHCTANCwyQ4r1mypFN1ZbSEdB4L1Z2DgwpPFc="
+  "version": "unstable-20260720161505-f6a01b4",
+  "rev": "f6a01b40d685ffadbcc5bda02741ca68ea76e863",
+  "hash": "sha256-s4SqRsC33VLZUCA6wmjasVuU5Xg6C9MgTR1ZtVMoGvw="
 }


### PR DESCRIPTION
Automated package bump for `[
  "libdrm_git",
  "wayland-protocols_git",
  "mesa_git",
  "wayland_git",
  "wlroots_git",
  "sway-unwrapped_git",
  "xdg-desktop-portal-wlr_git"
]`.