### PR TITLE
chore: bump zed-editor_git

### DIFF
--- a/pkgs/zed-editor-git/version.json
+++ b/pkgs/zed-editor-git/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260720040828-339d96b",
-  "rev": "339d96b5a81a8fd8434b766e501c6a4c27f59b60",
-  "hash": "sha256-7JSkOoOZBCBrPTe+PMabjJ4tPkQJA+9RdYFYneam4LI=",
-  "cargoHash": "sha256-SLKZNFOI0PTNbiyF9Bv7tGn5we0XpOdOg4Pp1fVz2S0="
+  "version": "unstable-20260721035704-914e1c9",
+  "rev": "914e1c9873b6b85bfeedc5b58e8270885bdd532e",
+  "hash": "sha256-jfvtKJZsn8Ixeq5L2OKLkplqIgIaIWVS9Gj6D25PSYI=",
+  "cargoHash": "sha256-+T++7uKNDfqTDjT9rmw2UNO8MEQje0iADKVXEHL2iec="
 }


### PR DESCRIPTION
Automated package bump for `[
  "zed-editor_git"
]`.