### PR TITLE
chore: bump nss_git

### DIFF
--- a/pkgs/firefox-nightly/version.json
+++ b/pkgs/firefox-nightly/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "154.0a1",
-  "rev": "7f94689f2c228a96f6c271e30880e72778b7ab15",
-  "buildId": "20260717161234",
-  "hash": "sha256-GS9zcT67jtwZup//oRG91Qq0UPB1RYg4WqYBNd6SMA0="
+  "version": "155.0a1",
+  "rev": "b52296d542b89092ffd707ca478a85ebf0f89ff5",
+  "buildId": "20260720180121",
+  "hash": "sha256-lsTOGd1yRG45nHtbUgk9jy+4Z2BXs92cMIKdjnZh7uA="
 }


### PR DESCRIPTION
Automated package bump for `[
  "nss_git",
  "firefox-unwrapped_nightly"
]`.