### PR TITLE
chore: bump openrgb_git

### DIFF
--- a/pkgs/openrgb-git/version.json
+++ b/pkgs/openrgb-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260719070446-b35e119",
-  "rev": "b35e11932563e91f24e8dc092e37fd4f58fbc515",
-  "hash": "sha256-OJXMMcvb7wrZ7XS6geLsnBX170g4WSoCE+MAHwph+0o="
+  "version": "unstable-20260721134415-31992ac",
+  "rev": "31992acad1dba138f3de19e02039e732acf1602a",
+  "hash": "sha256-CXv8XEGOdvoVY5URjDs1djzWMRcJJFJlzf1VkS93AeY="
 }


### PR DESCRIPTION
Automated package bump for `[
  "openrgb_git"
]`.