### PR TITLE
chore: bump proton-cachyos

### DIFF
--- a/pkgs/proton-bin/cachyos-version.json
+++ b/pkgs/proton-bin/cachyos-version.json
@@ -1,5 +1,5 @@
 {
   "base": "11.0",
-  "release": "20260702",
-  "hash": "sha256-Qo16R7KVGYVuW61Q634PASPsJDHi03wxzr7ycD8k8lM="
+  "release": "20260703",
+  "hash": "sha256-Yv9LJ1AYByPMAFOGCP5ofiHR2Rox72TOGnyfRsPbMQs="
 }


### PR DESCRIPTION
Automated package bump for `[
  "proton-cachyos"
]`.