### PR TITLE
chore: bump nix_git

### DIFF
--- a/pkgs/nix-git/version.json
+++ b/pkgs/nix-git/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260720234348-aafac2b",
-  "rev": "aafac2b8d93e3d9ecf05cafb4c446f8ae97347b8",
-  "hash": "sha256-wSei3x1MGicdtM5hm+m7iw77tfPy54pVxHbl80sADTE=",
-  "lastModifiedDate": "20260720234348"
+  "version": "unstable-20260721212736-8ddb472",
+  "rev": "8ddb47275630bf0cef1227e48a2bcf57fa56c6bc",
+  "hash": "sha256-FQk5i/OJNB2xB2LOOgM1NQG9ftlcfr6TzTX9GdGxbZI=",
+  "lastModifiedDate": "20260721212736"
 }


### PR DESCRIPTION
Automated package bump for `[
  "nix_git"
]`.