### PR TITLE
chore: bump pcsx2_git

### DIFF
--- a/pkgs/pcsx2-git/version.json
+++ b/pkgs/pcsx2-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260720172701-8f49597",
-  "rev": "8f495970823e8b2b956a538c0bfd84a382de07e8",
-  "hash": "sha256-cN9TKSN8IwY5RSyG8fL7Ad5DHEKidd0wKOJwdPSdTZ4="
+  "version": "unstable-20260721213117-66c0771",
+  "rev": "66c0771d12b16d6f5277eba1d1d9483fe86d7776",
+  "hash": "sha256-QzcyC40Mi7qrgyJUhpjuFVFkkLPDBVFD0Y9z2v+V+oc="
 }


### PR DESCRIPTION
Automated package bump for `[
  "pcsx2_git"
]`.