### PR TITLE
chore: bump libdrm_git

### DIFF
--- a/pkgs/mesa-git/version.json
+++ b/pkgs/mesa-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260720235319-772cb76",
-  "rev": "772cb76cc80ed5bde9c8a3972f0852d68fa54f9d",
-  "hash": "sha256-PwF3DqaLZ2kZeTF5A8MYkOscZNY7vRsPcJ6jW7fSedg="
+  "version": "unstable-20260722005429-d49a00b",
+  "rev": "d49a00bdf15fd48b31af93aaf5feed3eebcbda12",
+  "hash": "sha256-1goYOt83HlE1qxyJr3kgSfcNlwRyE8rkdJnR+uoGNxg="
 }


### PR DESCRIPTION
Automated package bump for `[
  "libdrm_git",
  "wayland-protocols_git",
  "mesa_git",
  "wayland_git",
  "wlroots_git",
  "sway-unwrapped_git",
  "xdg-desktop-portal-wlr_git"
]`.