### PR TITLE
chore: bump zed-editor_git

### DIFF
--- a/pkgs/zed-editor-git/version.json
+++ b/pkgs/zed-editor-git/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260721035704-914e1c9",
-  "rev": "914e1c9873b6b85bfeedc5b58e8270885bdd532e",
-  "hash": "sha256-jfvtKJZsn8Ixeq5L2OKLkplqIgIaIWVS9Gj6D25PSYI=",
-  "cargoHash": "sha256-+T++7uKNDfqTDjT9rmw2UNO8MEQje0iADKVXEHL2iec="
+  "version": "unstable-20260722011153-4ebc154",
+  "rev": "4ebc1545d299b1270bc76813fa841357ee711b19",
+  "hash": "sha256-mBWy46Yf/HDdVN9RPxHH52Ra8iYXFdgMGWUtkE4T90M=",
+  "cargoHash": "sha256-eXD1pgAJfzN0AFzc5aBfwUAJiXPZycYEqGErfpKHYv0="
 }


### PR DESCRIPTION
Automated package bump for `[
  "zed-editor_git"
]`.