### PR TITLE
chore: bump tde2e_git

### DIFF
--- a/pkgs/telegram-desktop-git/version.json
+++ b/pkgs/telegram-desktop-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260720191437-1829494",
-  "rev": "18294947a0f93b35a9460817a62de75e20b6bf23",
-  "hash": "sha256-xOY1h1ESv/gZQpdTVWX6mn++00g5zF/6tj0G73kq8wM="
+  "version": "unstable-20260721150543-a77926b",
+  "rev": "a77926bdca896ccd3e0bd32d51a6b1d9670b6203",
+  "hash": "sha256-ifOeOdfwoUs3vBkNY+qJcM91GSaMn0T0up+49ALF67I="
 }


### PR DESCRIPTION
Automated package bump for `[
  "tde2e_git",
  "tg-owt_git",
  "telegram-desktop-unwrapped_git",
  "telegram-desktop_git"
]`.