### PR TITLE
chore: bump shadps4_git

### DIFF
--- a/pkgs/shadps4-git/version.json
+++ b/pkgs/shadps4-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260720174949-4c72de0",
-  "rev": "4c72de0732ce7443a1631bf190e2606294f58f65",
-  "hash": "sha256-AYA9gdgirQSPhHDvzYoZaDT2g2qNQiGctT9KNZ3fEUI="
+  "version": "unstable-20260721161304-5c4b998",
+  "rev": "5c4b998f40399a33b94ad5e52b8e35a7807bf8d0",
+  "hash": "sha256-MbTwi5ZXbftBmXjyeFmSxrV0vuGN/TwWKaEFI6C1pvs="
 }


### PR DESCRIPTION
Automated package bump for `[
  "shadps4_git"
]`.