### PR TITLE
chore: bump nss_git

### DIFF
--- a/pkgs/firefox-nightly/version.json
+++ b/pkgs/firefox-nightly/version.json
@@ -1,6 +1,6 @@
 {
   "version": "155.0a1",
-  "rev": "b52296d542b89092ffd707ca478a85ebf0f89ff5",
-  "buildId": "20260720180121",
-  "hash": "sha256-lsTOGd1yRG45nHtbUgk9jy+4Z2BXs92cMIKdjnZh7uA="
+  "rev": "9f4db3078551c6d54c40f3de27b603f52b89d35a",
+  "buildId": "20260721202327",
+  "hash": "sha256-L/ZFRDPHo2Bk/fKw0JYfqxzjalOtAq4Eh7wasGBW5Bg="
 }

--- a/pkgs/nss-git/version.json
+++ b/pkgs/nss-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260717230157-1d6469a",
-  "rev": "1d6469a80ed9a48310c703c5e6d3b3f09a97a77b",
-  "hash": "sha256-bDayz2HFW5nL32YUilW0MIO3RRTwDkpF8qQ/OxkEW2I="
+  "version": "unstable-20260721212321-3a815ee",
+  "rev": "3a815eed03674d42124c81336c943d3977f0124b",
+  "hash": "sha256-ZObiUa+RFMXao2XUZTCuLQgkDoEfV9ZvWmCxIrpUe18="
 }


### PR DESCRIPTION
Automated package bump for `[
  "nss_git",
  "firefox-unwrapped_nightly"
]`.