### PR TITLE
chore: bump mesa_git

### DIFF
--- a/pkgs/mesa-git/version.json
+++ b/pkgs/mesa-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260722005429-d49a00b",
-  "rev": "d49a00bdf15fd48b31af93aaf5feed3eebcbda12",
-  "hash": "sha256-1goYOt83HlE1qxyJr3kgSfcNlwRyE8rkdJnR+uoGNxg="
+  "version": "unstable-20260722114638-d3d45a7",
+  "rev": "d3d45a7fb41433149924d0bbbf9d9bd1ddb9c33a",
+  "hash": "sha256-HyPc5X2CpdgpLVLwqpBKI9f3JVqhryErZ1j/iiJyCkI="
 }


### PR DESCRIPTION
Automated package bump for `[ "mesa_git" ]`.