### PR TITLE
chore: bump openrgb_git

### DIFF
--- a/pkgs/openrgb-git/version.json
+++ b/pkgs/openrgb-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260721134415-31992ac",
-  "rev": "31992acad1dba138f3de19e02039e732acf1602a",
-  "hash": "sha256-CXv8XEGOdvoVY5URjDs1djzWMRcJJFJlzf1VkS93AeY="
+  "version": "unstable-20260723034725-c9c37a4",
+  "rev": "c9c37a457661f827b47d38edc5942986b3505a3a",
+  "hash": "sha256-x1htP057w7164V120qwKeGDI1sb+KqCucED2iyHwcG8="
 }


### PR DESCRIPTION
Automated package bump for `[
  "openrgb_git"
]`.