### PR TITLE
chore: bump nix_git

### DIFF
--- a/pkgs/nix-git/version.json
+++ b/pkgs/nix-git/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260721212736-8ddb472",
-  "rev": "8ddb47275630bf0cef1227e48a2bcf57fa56c6bc",
-  "hash": "sha256-FQk5i/OJNB2xB2LOOgM1NQG9ftlcfr6TzTX9GdGxbZI=",
-  "lastModifiedDate": "20260721212736"
+  "version": "unstable-20260722232237-d10c84c",
+  "rev": "d10c84cd0cc0efdcb29cf2611caf5fbcd10fa071",
+  "hash": "sha256-R/r6jRnANV50c8F5Fz5+1Q1moab0IGWRk+cg5ME2nMY=",
+  "lastModifiedDate": "20260722232237"
 }


### PR DESCRIPTION
Automated package bump for `[
  "nix_git"
]`.