### PR TITLE
chore: bump qtile-module_git

### DIFF
--- a/pkgs/qtile-git/version.json
+++ b/pkgs/qtile-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260717014207-8bde8a1",
-  "rev": "8bde8a1bb770704ecb3e27cf3b6a57c4ad3e08dd",
-  "hash": "sha256-GlBrAbhw/7mn6v0hZ8BYZr0nhOb6x9TneH2hYE8LcD4="
+  "version": "unstable-20260723004206-f4a9b44",
+  "rev": "f4a9b4479b0f6df3342a97795787d42734897e43",
+  "hash": "sha256-fTJBuruo/1mMoLpPUydTGw+MzXh8pBfyOxQMwxJVZsQ="
 }


### PR DESCRIPTION
Automated package bump for `[
  "qtile-module_git",
  "qtile-extras_git"
]`.