### PR TITLE
chore: bump zed-editor_git

### DIFF
--- a/pkgs/zed-editor-git/version.json
+++ b/pkgs/zed-editor-git/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260722011153-4ebc154",
-  "rev": "4ebc1545d299b1270bc76813fa841357ee711b19",
-  "hash": "sha256-mBWy46Yf/HDdVN9RPxHH52Ra8iYXFdgMGWUtkE4T90M=",
-  "cargoHash": "sha256-eXD1pgAJfzN0AFzc5aBfwUAJiXPZycYEqGErfpKHYv0="
+  "version": "unstable-20260723034747-6297c88",
+  "rev": "6297c88f428a99741a7bfb33f31dfe98123bb8e4",
+  "hash": "sha256-pmRG1T4zSxR9zh5EsXHB0c5kngCbbHyCkLThaSzNXKw=",
+  "cargoHash": "sha256-HBN56FTLD5dOGdp5sXaxh/0bkIACh8q18cdOWtOAuXM="
 }


### PR DESCRIPTION
Automated package bump for `[
  "zed-editor_git"
]`.