### PR TITLE
chore: bump libdrm_git

### DIFF
--- a/pkgs/mesa-git/version.json
+++ b/pkgs/mesa-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260722005429-d49a00b",
-  "rev": "d49a00bdf15fd48b31af93aaf5feed3eebcbda12",
-  "hash": "sha256-1goYOt83HlE1qxyJr3kgSfcNlwRyE8rkdJnR+uoGNxg="
+  "version": "unstable-20260722235231-fa95a76",
+  "rev": "fa95a76636f25ee3399f72b86e1c0648af333991",
+  "hash": "sha256-fqDXYdWRWvRzZYaMh4HALWsJVVfGqF6Dk93izHR76oc="
 }


### PR DESCRIPTION
Automated package bump for `[
  "libdrm_git",
  "wayland-protocols_git",
  "mesa_git",
  "wayland_git",
  "wlroots_git",
  "sway-unwrapped_git",
  "xdg-desktop-portal-wlr_git"
]`.