### PR TITLE
chore: bump shadps4_git

### DIFF
--- a/pkgs/shadps4-git/version.json
+++ b/pkgs/shadps4-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260721161304-5c4b998",
-  "rev": "5c4b998f40399a33b94ad5e52b8e35a7807bf8d0",
-  "hash": "sha256-MbTwi5ZXbftBmXjyeFmSxrV0vuGN/TwWKaEFI6C1pvs="
+  "version": "unstable-20260723011429-dee3a04",
+  "rev": "dee3a0437d9bd830b9295644a4de4633981a3bc4",
+  "hash": "sha256-ACucUvDwAnHJPL437Z8Tqpxz5jePi3GhMjQd8j75fQk="
 }


### PR DESCRIPTION
Automated package bump for `[
  "shadps4_git"
]`.