### PR TITLE
chore: bump helix_git

### DIFF
--- a/pkgs/helix-git/version.json
+++ b/pkgs/helix-git/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260721150348-19c0a0e",
-  "rev": "19c0a0ed5a9bd807c8d8b798d53a85ccd2c2034d",
-  "hash": "sha256-peX6ZHEeH1mx2Z0kQNGcx6EH7/G4P66JYEQJnqva/MM=",
+  "version": "unstable-20260722145155-a473894",
+  "rev": "a47389402cd337aaff7327e5601b9ea3cd8409f9",
+  "hash": "sha256-9YfoHElY9EZwsSri37dwNPiqHBRV45mWXejMn6JkOoE=",
   "cargoHash": "sha256-oo59HhwOS3EeV/YI+NWirEkdzD9pzMot2lgphZeOxfc="
 }


### PR DESCRIPTION
Automated package bump for `[
  "helix_git"
]`.