### PR TITLE
chore: bump nss_git

### DIFF
--- a/maintenance/failures.x86_64-linux.nix
+++ b/maintenance/failures.x86_64-linux.nix
@@ -1,4 +1,6 @@
 {
+  "firefox-unwrapped_nightly" = "/nix/store/sb46l9giicm94ikfh5bpi5ni0m3hkd3a-firefox-nightly-unwrapped-155.0a1-20260722214024-91d6cd2";
+  "firefox_nightly" = "/nix/store/dyxzqw0jx5yqrgs97aqyyl141iazs76c-firefox-nightly-155.0a1-20260722214024-91d6cd2";
   "linuxPackages_cachyos.amdgpu-i2c" = "/nix/store/w4c2d5xx4dgj71wfhfwx7dyb79kr7x8m-amdgpu-i2c-x86_64-unknown-linux-gnu-0-unstable-2024-12-16";
   "linuxPackages_cachyos.amneziawg" = "/nix/store/qn8z7ahr94r46dc78zj1fv7maab32h5s-amneziawg-x86_64-unknown-linux-gnu-1.0.20260611";
   "linuxPackages_cachyos.bcachefs" = "/nix/store/dl6668rp3b0xc50lh9n5a82xgyana5id-bcachefs-x86_64-unknown-linux-gnu-7.1.4-1.38.8";

--- a/pkgs/firefox-nightly/version.json
+++ b/pkgs/firefox-nightly/version.json
@@ -1,6 +1,6 @@
 {
   "version": "155.0a1",
-  "rev": "9f4db3078551c6d54c40f3de27b603f52b89d35a",
-  "buildId": "20260721202327",
-  "hash": "sha256-L/ZFRDPHo2Bk/fKw0JYfqxzjalOtAq4Eh7wasGBW5Bg="
+  "rev": "91d6cd2d1476bca635bb96f82ca34eda283b5460",
+  "buildId": "20260722214024",
+  "hash": "sha256-JhNGAlmgryxcH8I43YGpaE+PiyPyPPRMyhQwc4SMfl8="
 }


### PR DESCRIPTION
Automated package bump for `[
  "nss_git",
  "firefox-unwrapped_nightly"
]`.