### PR TITLE
chore: bump mangohud_git

### DIFF
--- a/pkgs/mangohud-git/version.json
+++ b/pkgs/mangohud-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260716212239-275b808",
-  "rev": "275b8080ce682eaf560a8e829498eb4b1f8f0b8c",
-  "hash": "sha256-9vyzbOgtwNv8+My5mit6VxvGQft6lqX+ZtkQyDzk59A="
+  "version": "unstable-20260724005606-a36e3ce",
+  "rev": "a36e3ce7df0f77b33bdd92dc83f724e81ae0ac04",
+  "hash": "sha256-7YH/diSHCoTtEXnO1bUZE9fd80BGP6R2CorRuSkCBU8="
 }


### PR DESCRIPTION
Automated package bump for `[
  "mangohud_git"
]`.