### PR TITLE
chore: bump tde2e_git

### DIFF
--- a/pkgs/telegram-desktop-git/version.json
+++ b/pkgs/telegram-desktop-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260721150543-a77926b",
-  "rev": "a77926bdca896ccd3e0bd32d51a6b1d9670b6203",
-  "hash": "sha256-ifOeOdfwoUs3vBkNY+qJcM91GSaMn0T0up+49ALF67I="
+  "version": "unstable-20260723202510-a8dca06",
+  "rev": "a8dca061b0ec0aee3da22e48e510f34bcd7ead10",
+  "hash": "sha256-eqxcfvrLmrBO85fJ+Lh5t8pbhdVkAH9wifWb3J7LLpI="
 }


### PR DESCRIPTION
Automated package bump for `[
  "tde2e_git",
  "tg-owt_git",
  "telegram-desktop-unwrapped_git",
  "telegram-desktop_git"
]`.