### PR TITLE
chore: bump libdrm_git

### DIFF
--- a/pkgs/mesa-git/version.json
+++ b/pkgs/mesa-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260722235231-fa95a76",
-  "rev": "fa95a76636f25ee3399f72b86e1c0648af333991",
-  "hash": "sha256-fqDXYdWRWvRzZYaMh4HALWsJVVfGqF6Dk93izHR76oc="
+  "version": "unstable-20260723211207-8b794a5",
+  "rev": "8b794a5167a729758cac9bde45fbe1886eb89c91",
+  "hash": "sha256-3+dhDvteZrH6UcOYdUQ2qHmUojR6+iPbn/Hf2/wfQjM="
 }


### PR DESCRIPTION
Automated package bump for `[
  "libdrm_git",
  "wayland-protocols_git",
  "mesa_git",
  "wayland_git",
  "wlroots_git",
  "sway-unwrapped_git",
  "xdg-desktop-portal-wlr_git"
]`.