### PR TITLE
chore: bump zed-editor_git

### DIFF
--- a/pkgs/zed-editor-git/version.json
+++ b/pkgs/zed-editor-git/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260723034747-6297c88",
-  "rev": "6297c88f428a99741a7bfb33f31dfe98123bb8e4",
-  "hash": "sha256-pmRG1T4zSxR9zh5EsXHB0c5kngCbbHyCkLThaSzNXKw=",
-  "cargoHash": "sha256-HBN56FTLD5dOGdp5sXaxh/0bkIACh8q18cdOWtOAuXM="
+  "version": "unstable-20260724005458-d47347d",
+  "rev": "d47347d1aafacf1196eb66d87805592b97864549",
+  "hash": "sha256-MBMJRu7Udo0XQQ0shhPwZ9UhfoXMNuS8J4EO0+LwAUg=",
+  "cargoHash": "sha256-EhqI5McWI9epPvkN+5v8pLWmQenjn+Ts3yFAe3sLtes="
 }


### PR DESCRIPTION
Automated package bump for `[
  "zed-editor_git"
]`.