### PR TITLE
chore: bump shadps4_git

### DIFF
--- a/pkgs/shadps4-git/version.json
+++ b/pkgs/shadps4-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260723011429-dee3a04",
-  "rev": "dee3a0437d9bd830b9295644a4de4633981a3bc4",
-  "hash": "sha256-ACucUvDwAnHJPL437Z8Tqpxz5jePi3GhMjQd8j75fQk="
+  "version": "unstable-20260723200939-8161049",
+  "rev": "8161049f22903c1945cbe493b1a38131abcb9848",
+  "hash": "sha256-4wUxfhV2DoZ1Y9wtlmTGTYgCi5BKY1OVEE1tC2JVnFg="
 }


### PR DESCRIPTION
Automated package bump for `[
  "shadps4_git"
]`.