### PR TITLE
chore: bump helix_git

### DIFF
--- a/pkgs/helix-git/version.json
+++ b/pkgs/helix-git/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260722145155-a473894",
-  "rev": "a47389402cd337aaff7327e5601b9ea3cd8409f9",
-  "hash": "sha256-9YfoHElY9EZwsSri37dwNPiqHBRV45mWXejMn6JkOoE=",
+  "version": "unstable-20260723160337-079a789",
+  "rev": "079a789e8cb08ead67f19e1971a1b7438b37354b",
+  "hash": "sha256-IYDL6Vnf13Sa+wbeXZTAxvdLA4h8Ew5ha0spcJy/Yk0=",
   "cargoHash": "sha256-oo59HhwOS3EeV/YI+NWirEkdzD9pzMot2lgphZeOxfc="
 }


### PR DESCRIPTION
Automated package bump for `[
  "helix_git"
]`.