### PR TITLE
chore: bump nss_git

### DIFF
--- a/pkgs/firefox-nightly/version.json
+++ b/pkgs/firefox-nightly/version.json
@@ -1,6 +1,6 @@
 {
   "version": "155.0a1",
-  "rev": "9f4db3078551c6d54c40f3de27b603f52b89d35a",
-  "buildId": "20260721202327",
-  "hash": "sha256-L/ZFRDPHo2Bk/fKw0JYfqxzjalOtAq4Eh7wasGBW5Bg="
+  "rev": "9f2e8c25f0b40fdce8d2f2ca40281e8711815a6d",
+  "buildId": "20260723204011",
+  "hash": "sha256-POdCU6oYkbe62yVk6aI9/8CFu0ZsulNDhfM73sx7f40="
 }

--- a/pkgs/nss-git/version.json
+++ b/pkgs/nss-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260721212321-3a815ee",
-  "rev": "3a815eed03674d42124c81336c943d3977f0124b",
-  "hash": "sha256-ZObiUa+RFMXao2XUZTCuLQgkDoEfV9ZvWmCxIrpUe18="
+  "version": "unstable-20260723073250-d69b81b",
+  "rev": "d69b81b67cc6d6734df20f16e4f89182b319da84",
+  "hash": "sha256-zyqfhD6jbHbLWHdYtsw/+LiJxHxhSMGX3XsKag8fbzo="
 }


### PR DESCRIPTION
Automated package bump for `[
  "nss_git",
  "firefox-unwrapped_nightly"
]`.