### PR TITLE
chore: bump openrgb_git

### DIFF
--- a/pkgs/openrgb-git/version.json
+++ b/pkgs/openrgb-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260723034725-c9c37a4",
-  "rev": "c9c37a457661f827b47d38edc5942986b3505a3a",
-  "hash": "sha256-x1htP057w7164V120qwKeGDI1sb+KqCucED2iyHwcG8="
+  "version": "unstable-20260724185306-8a831ce",
+  "rev": "8a831cef040a726793a0c9ddc4d8d54db09beba3",
+  "hash": "sha256-5ELAWY6hzEv5VxW/V2esRspDjuKAbr6eBg9EfI2RShc="
 }


### PR DESCRIPTION
Automated package bump for `[
  "openrgb_git"
]`.