### PR TITLE
chore: bump mangohud_git

### DIFF
--- a/pkgs/mangohud-git/version.json
+++ b/pkgs/mangohud-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260724005606-a36e3ce",
-  "rev": "a36e3ce7df0f77b33bdd92dc83f724e81ae0ac04",
-  "hash": "sha256-7YH/diSHCoTtEXnO1bUZE9fd80BGP6R2CorRuSkCBU8="
+  "version": "unstable-20260724042331-4a2473c",
+  "rev": "4a2473c85c21b005f086b38a07ed5c34e1e2ddd8",
+  "hash": "sha256-ZCkhVkAJlzLv8zV9wZMV5nOnrBWmEfFPA9WG3zp/pnY="
 }


### PR DESCRIPTION
Automated package bump for `[
  "mangohud_git"
]`.