### PR TITLE
chore: bump tde2e_git

### DIFF
--- a/pkgs/telegram-desktop-git/version.json
+++ b/pkgs/telegram-desktop-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260723202510-a8dca06",
-  "rev": "a8dca061b0ec0aee3da22e48e510f34bcd7ead10",
-  "hash": "sha256-eqxcfvrLmrBO85fJ+Lh5t8pbhdVkAH9wifWb3J7LLpI="
+  "version": "unstable-20260724160100-2a6fd2c",
+  "rev": "2a6fd2cb752f8b3caca9b3589b2e89d28b36f00d",
+  "hash": "sha256-QG7sN9Sgf2FF57xJq97CNw/90ptwmv1CxxOafkS7JxI="
 }


### PR DESCRIPTION
Automated package bump for `[
  "tde2e_git",
  "tg-owt_git",
  "telegram-desktop-unwrapped_git",
  "telegram-desktop_git"
]`.