### PR TITLE
chore: bump libdrm_git

### DIFF
--- a/pkgs/mesa-git/version.json
+++ b/pkgs/mesa-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260723211207-8b794a5",
-  "rev": "8b794a5167a729758cac9bde45fbe1886eb89c91",
-  "hash": "sha256-3+dhDvteZrH6UcOYdUQ2qHmUojR6+iPbn/Hf2/wfQjM="
+  "version": "unstable-20260725024925-7a6f569",
+  "rev": "7a6f5690575edc7113ff0da4281d8a646114be28",
+  "hash": "sha256-AGa4BeSl+vVDbqE/o8X4KyWGH8BYPc9brttwHBK/JW8="
 }


### PR DESCRIPTION
Automated package bump for `[
  "libdrm_git",
  "wayland-protocols_git",
  "mesa_git",
  "wayland_git",
  "wlroots_git",
  "sway-unwrapped_git",
  "xdg-desktop-portal-wlr_git"
]`.