### PR TITLE
chore: bump nix_git

### DIFF
--- a/pkgs/nix-git/version.json
+++ b/pkgs/nix-git/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260722232237-d10c84c",
-  "rev": "d10c84cd0cc0efdcb29cf2611caf5fbcd10fa071",
-  "hash": "sha256-R/r6jRnANV50c8F5Fz5+1Q1moab0IGWRk+cg5ME2nMY=",
-  "lastModifiedDate": "20260722232237"
+  "version": "unstable-20260724172546-731e197",
+  "rev": "731e197c4f1ae09815bcd968571f09057c450609",
+  "hash": "sha256-ThcOJQuo78GbVl9bdj/1X40fTCYSU5PcZkqktA8rVh8=",
+  "lastModifiedDate": "20260724172546"
 }


### PR DESCRIPTION
Automated package bump for `[
  "nix_git"
]`.