### PR TITLE
chore: bump pcsx2_git

### DIFF
--- a/pkgs/pcsx2-git/version.json
+++ b/pkgs/pcsx2-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260721213117-66c0771",
-  "rev": "66c0771d12b16d6f5277eba1d1d9483fe86d7776",
-  "hash": "sha256-QzcyC40Mi7qrgyJUhpjuFVFkkLPDBVFD0Y9z2v+V+oc="
+  "version": "unstable-20260725003033-ee4a83b",
+  "rev": "ee4a83b0c9fb304be2ac272e0f9c00eb9855ed0a",
+  "hash": "sha256-AcqOs+KowqLAaR2yL8QD+A2G4EyT7cVrLYk8v9mQ2e4="
 }


### PR DESCRIPTION
Automated package bump for `[
  "pcsx2_git"
]`.