### PR TITLE
chore: bump zed-editor_git

### DIFF
--- a/pkgs/zed-editor-git/version.json
+++ b/pkgs/zed-editor-git/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260724005458-d47347d",
-  "rev": "d47347d1aafacf1196eb66d87805592b97864549",
-  "hash": "sha256-MBMJRu7Udo0XQQ0shhPwZ9UhfoXMNuS8J4EO0+LwAUg=",
-  "cargoHash": "sha256-EhqI5McWI9epPvkN+5v8pLWmQenjn+Ts3yFAe3sLtes="
+  "version": "unstable-20260725033945-dbdea58",
+  "rev": "dbdea5834972e9eeaa2d6cf5948485b9ae122a67",
+  "hash": "sha256-mLTynfjTyR3odZViZEU1ifDIY6gTiaga1aOjQxjfubk=",
+  "cargoHash": "sha256-8WgOW6l+SYP6b/wTkseWKbhoS+7H8v8Me2sMTUOBNxs="
 }


### PR DESCRIPTION
Automated package bump for `[
  "zed-editor_git"
]`.