### PR TITLE
chore: bump shadps4_git

### DIFF
--- a/pkgs/shadps4-git/version.json
+++ b/pkgs/shadps4-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260723200939-8161049",
-  "rev": "8161049f22903c1945cbe493b1a38131abcb9848",
-  "hash": "sha256-4wUxfhV2DoZ1Y9wtlmTGTYgCi5BKY1OVEE1tC2JVnFg="
+  "version": "unstable-20260724190302-d392abe",
+  "rev": "d392abed77dfa3cfe9a3775f89c6afbe89cc54cd",
+  "hash": "sha256-EYYJOrn/3FsxU8Foe0e1F41FWx3G2TVkV3dWSvxijio="
 }


### PR DESCRIPTION
Automated package bump for `[
  "shadps4_git"
]`.