### PR TITLE
chore: bump openrgb_git

### DIFF
--- a/pkgs/openrgb-git/version.json
+++ b/pkgs/openrgb-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260724185306-8a831ce",
-  "rev": "8a831cef040a726793a0c9ddc4d8d54db09beba3",
-  "hash": "sha256-5ELAWY6hzEv5VxW/V2esRspDjuKAbr6eBg9EfI2RShc="
+  "version": "unstable-20260726023703-ac6d89b",
+  "rev": "ac6d89b611b0896608d0b6c7bce0543123733875",
+  "hash": "sha256-/bt0dZXF5Uuv08UH3S1lbojfHmr8xfx3Ni1VrjO20bg="
 }


### PR DESCRIPTION
Automated package bump for `[
  "openrgb_git"
]`.