### PR TITLE
chore: bump pcsx2_git

### DIFF
--- a/pkgs/pcsx2-git/version.json
+++ b/pkgs/pcsx2-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260725003033-ee4a83b",
-  "rev": "ee4a83b0c9fb304be2ac272e0f9c00eb9855ed0a",
-  "hash": "sha256-AcqOs+KowqLAaR2yL8QD+A2G4EyT7cVrLYk8v9mQ2e4="
+  "version": "unstable-20260725190836-fa50a11",
+  "rev": "fa50a11eac0c6be1d7f5b9b653271e9ced5692f9",
+  "hash": "sha256-JFeawCGVK1kHE+O8FYAtBkNr8cY/2p06dNbu0/R2Zzw="
 }


### PR DESCRIPTION
Automated package bump for `[
  "pcsx2_git"
]`.