### PR TITLE
chore: bump proton-ge-custom

### DIFF
--- a/pkgs/proton-bin/ge-version.json
+++ b/pkgs/proton-bin/ge-version.json
@@ -1,5 +1,5 @@
 {
   "base": "11",
-  "release": "1",
-  "hash": "sha256-zm3WY+oBcloxgF7VwWVyOiU83wlFpmQpBzMHQq4t5eQ="
+  "release": "3",
+  "hash": "sha256-hhwu3I1A0FH7HnppLeuVO+Ur0znEbZDyt93lDdrZEmY="
 }


### PR DESCRIPTION
Automated package bump for `[
  "proton-ge-custom"
]`.