### PR TITLE
chore: bump zed-editor_git

### DIFF
--- a/pkgs/zed-editor-git/version.json
+++ b/pkgs/zed-editor-git/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260725033945-dbdea58",
-  "rev": "dbdea5834972e9eeaa2d6cf5948485b9ae122a67",
-  "hash": "sha256-mLTynfjTyR3odZViZEU1ifDIY6gTiaga1aOjQxjfubk=",
+  "version": "unstable-20260726011929-e191dd0",
+  "rev": "e191dd00c7e36cfcbbdccad2babca096067777c0",
+  "hash": "sha256-oRzAV9yAYPWZZJVUD2SzS/51uHej1PR+0MkAt3brKjs=",
   "cargoHash": "sha256-8WgOW6l+SYP6b/wTkseWKbhoS+7H8v8Me2sMTUOBNxs="
 }


### PR DESCRIPTION
Automated package bump for `[
  "zed-editor_git"
]`.