### PR TITLE
chore: bump libdrm_git

### DIFF
--- a/pkgs/mesa-git/version.json
+++ b/pkgs/mesa-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260725024925-7a6f569",
-  "rev": "7a6f5690575edc7113ff0da4281d8a646114be28",
-  "hash": "sha256-AGa4BeSl+vVDbqE/o8X4KyWGH8BYPc9brttwHBK/JW8="
+  "version": "unstable-20260726035125-1863e52",
+  "rev": "1863e52e5ce30f3e773c4f15c9abad47e2b92964",
+  "hash": "sha256-HdLC+X8Ciwk9SiqpZVFuf573RvWylai5orfcDFwXOS8="
 }


### PR DESCRIPTION
Automated package bump for `[
  "libdrm_git",
  "wayland-protocols_git",
  "mesa_git",
  "wayland_git",
  "wlroots_git",
  "sway-unwrapped_git",
  "xdg-desktop-portal-wlr_git"
]`.