### PR TITLE
chore: bump shadps4_git

### DIFF
--- a/pkgs/shadps4-git/version.json
+++ b/pkgs/shadps4-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260724190302-d392abe",
-  "rev": "d392abed77dfa3cfe9a3775f89c6afbe89cc54cd",
-  "hash": "sha256-EYYJOrn/3FsxU8Foe0e1F41FWx3G2TVkV3dWSvxijio="
+  "version": "unstable-20260725221439-d976c33",
+  "rev": "d976c33ca88a540bd948f9fafd64f86610c61070",
+  "hash": "sha256-aZqgJGZ2CSMk7aRupi1ilN7TfTBMRDapYsMAAzLyZcI="
 }


### PR DESCRIPTION
Automated package bump for `[
  "shadps4_git"
]`.