### PR TITLE
chore: bump qtile-module_git

### DIFF
--- a/pkgs/qtile-git/version.json
+++ b/pkgs/qtile-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260725004805-b995434",
-  "rev": "b9954346d179c1a9dfb6057cdd8e259174dd9d4d",
-  "hash": "sha256-58I501w4+Mjid05CKXNxRbZjDfhw3uK2NpPe0TJW0Gc="
+  "version": "unstable-20260725164227-3bea167",
+  "rev": "3bea16756e231582893108b174060b4ca07bda3f",
+  "hash": "sha256-e4V88nPVfLeR1xiD+rD5laZtetxwipif0v/s17tveGQ="
 }


### PR DESCRIPTION
Automated package bump for `[
  "qtile-module_git"
]`.