### PR TITLE
chore: bump nss_git

### DIFF
--- a/maintenance/failures.x86_64-linux.nix
+++ b/maintenance/failures.x86_64-linux.nix
@@ -61,5 +61,4 @@
   "linuxPackages_cachyos-gcc.rtl88x2bu" = "/nix/store/r0msjkpdsjbwchpbbgfa0nyrg8kdn9f3-rtl88x2bu-7.1.4-unstable-2025-12-04";
   "linuxPackages_cachyos-gcc.vmm_clock" = "/nix/store/bqhfwa06gkfmcf6kw8zx2ac3s57vbi0m-vmm_clock-0.2.1";
   "linuxPackages_cachyos-gcc.yt6801" = "/nix/store/mscspc07icfr8gp1vfcl43jlrzcr29y1-yt6801-1.0.30-20250430";
-  "qtile-extras_git" = "/nix/store/ch61wkdgx5l19wmm1jj4zy4c81yb8shc-python3.14-qtile-extras-0.36.99.99";
 }

--- a/pkgs/firefox-nightly/version.json
+++ b/pkgs/firefox-nightly/version.json
@@ -1,6 +1,6 @@
 {
   "version": "155.0a1",
-  "rev": "9f2e8c25f0b40fdce8d2f2ca40281e8711815a6d",
-  "buildId": "20260723204011",
-  "hash": "sha256-POdCU6oYkbe62yVk6aI9/8CFu0ZsulNDhfM73sx7f40="
+  "rev": "0f72a20bbd4e238b077e0216e8a63b0b7c9243e0",
+  "buildId": "20260725205014",
+  "hash": "sha256-0nz5vYGBs1AgbL3IJwIZtQkQyInBMiVWpnBa58TSVIA="
 }


### PR DESCRIPTION
Automated package bump for `[
  "nss_git",
  "firefox-unwrapped_nightly"
]`.