### PR TITLE
chore: bump openrgb_git

### DIFF
--- a/pkgs/openrgb-git/version.json
+++ b/pkgs/openrgb-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260726023703-ac6d89b",
-  "rev": "ac6d89b611b0896608d0b6c7bce0543123733875",
-  "hash": "sha256-/bt0dZXF5Uuv08UH3S1lbojfHmr8xfx3Ni1VrjO20bg="
+  "version": "unstable-20260727041815-791d882",
+  "rev": "791d8820d67c3e4f924f4d1df96c5c4dcb9cd91d",
+  "hash": "sha256-i41I18t/SZEM6Ux3cXjQA38rqVE3slWmlMXqyYb8mE4="
 }


### PR DESCRIPTION
Automated package bump for `[
  "openrgb_git"
]`.