### PR TITLE
chore: bump nix_git

### DIFF
--- a/pkgs/nix-git/version.json
+++ b/pkgs/nix-git/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260724172546-731e197",
-  "rev": "731e197c4f1ae09815bcd968571f09057c450609",
-  "hash": "sha256-ThcOJQuo78GbVl9bdj/1X40fTCYSU5PcZkqktA8rVh8=",
-  "lastModifiedDate": "20260724172546"
+  "version": "unstable-20260726214041-f5f9c3a",
+  "rev": "f5f9c3a7fa1ef674d9c836d29b5670d49a0beb14",
+  "hash": "sha256-fGjKSIX0gdJrKT5JzSRBg8DZuiC7NO3wGwQqXkLPiwA=",
+  "lastModifiedDate": "20260726214041"
 }


### PR DESCRIPTION
Automated package bump for `[
  "nix_git"
]`.