### PR TITLE
chore: bump libdrm_git

### DIFF
--- a/pkgs/mesa-git/version.json
+++ b/pkgs/mesa-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260726035125-1863e52",
-  "rev": "1863e52e5ce30f3e773c4f15c9abad47e2b92964",
-  "hash": "sha256-HdLC+X8Ciwk9SiqpZVFuf573RvWylai5orfcDFwXOS8="
+  "version": "unstable-20260726235055-0d4d190",
+  "rev": "0d4d1907bd35acfe80208d10deeb0cb134f79c60",
+  "hash": "sha256-/Ncd+aMlNBOspJO1SjUCjMN1GVk+HKnovahF6FoD3ts="
 }


### PR DESCRIPTION
Automated package bump for `[
  "libdrm_git",
  "wayland-protocols_git",
  "mesa_git",
  "wayland_git",
  "wlroots_git",
  "sway-unwrapped_git",
  "xdg-desktop-portal-wlr_git"
]`.