### PR TITLE
chore: bump zed-editor_git

### DIFF
--- a/pkgs/zed-editor-git/version.json
+++ b/pkgs/zed-editor-git/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260726011929-e191dd0",
-  "rev": "e191dd00c7e36cfcbbdccad2babca096067777c0",
-  "hash": "sha256-oRzAV9yAYPWZZJVUD2SzS/51uHej1PR+0MkAt3brKjs=",
-  "cargoHash": "sha256-8WgOW6l+SYP6b/wTkseWKbhoS+7H8v8Me2sMTUOBNxs="
+  "version": "unstable-20260727005539-50da8c4",
+  "rev": "50da8c40dcd596a91fe252537d8e4249f2fd3a50",
+  "hash": "sha256-bZlxzd+sWmtZJG7xXqkp5KljnWFShRbxFV0xC538qXo=",
+  "cargoHash": "sha256-lqlta0am3rkAZRrGpD7PdMkcDww11iULKDgafBVxliY="
 }


### PR DESCRIPTION
Automated package bump for `[
  "zed-editor_git"
]`.