### PR TITLE
chore: bump shadps4_git

### DIFF
--- a/pkgs/shadps4-git/version.json
+++ b/pkgs/shadps4-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260725221439-d976c33",
-  "rev": "d976c33ca88a540bd948f9fafd64f86610c61070",
-  "hash": "sha256-aZqgJGZ2CSMk7aRupi1ilN7TfTBMRDapYsMAAzLyZcI="
+  "version": "unstable-20260726191324-dc5a33d",
+  "rev": "dc5a33d6f179db120c4bf209aae3ae722b724894",
+  "hash": "sha256-HDEUY1eTH4yb4NmaEYqhSEFuQNnBdIW1vXJMXhICVV8="
 }


### PR DESCRIPTION
Automated package bump for `[
  "shadps4_git"
]`.