### PR TITLE
chore: bump nss_git

### DIFF
--- a/pkgs/firefox-nightly/version.json
+++ b/pkgs/firefox-nightly/version.json
@@ -1,6 +1,6 @@
 {
   "version": "155.0a1",
-  "rev": "0f72a20bbd4e238b077e0216e8a63b0b7c9243e0",
-  "buildId": "20260725205014",
-  "hash": "sha256-0nz5vYGBs1AgbL3IJwIZtQkQyInBMiVWpnBa58TSVIA="
+  "rev": "4c201594e8be406786dd33b609429a29d5a10813",
+  "buildId": "20260726215019",
+  "hash": "sha256-qf1qDNAUdZCGfJc+6NXgh+3Nx6VKxTxqHmsKIByhx+k="
 }


### PR DESCRIPTION
Automated package bump for `[
  "nss_git",
  "firefox-unwrapped_nightly"
]`.