### PR TITLE
chore: bump nix_git

### DIFF
--- a/pkgs/nix-git/version.json
+++ b/pkgs/nix-git/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260726214041-f5f9c3a",
-  "rev": "f5f9c3a7fa1ef674d9c836d29b5670d49a0beb14",
-  "hash": "sha256-fGjKSIX0gdJrKT5JzSRBg8DZuiC7NO3wGwQqXkLPiwA=",
-  "lastModifiedDate": "20260726214041"
+  "version": "unstable-20260727204822-06fc317",
+  "rev": "06fc31797cfa0daa3628c195491d9a027d13f4ae",
+  "hash": "sha256-k0+R645moO8aJuNynITzsu8pltyCuTrVHwDST54YkZs=",
+  "lastModifiedDate": "20260727204822"
 }


### PR DESCRIPTION
Automated package bump for `[
  "nix_git"
]`.