### PR TITLE
chore: bump pcsx2_git

### DIFF
--- a/pkgs/pcsx2-git/version.json
+++ b/pkgs/pcsx2-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260725190836-fa50a11",
-  "rev": "fa50a11eac0c6be1d7f5b9b653271e9ced5692f9",
-  "hash": "sha256-JFeawCGVK1kHE+O8FYAtBkNr8cY/2p06dNbu0/R2Zzw="
+  "version": "unstable-20260728021327-dee4938",
+  "rev": "dee4938c2b61bea356008043ec0733d70ca0c98c",
+  "hash": "sha256-u8NzacLC/GXfRMKpzLZUa+/LUhpzs7+98BTZb0hb5iY="
 }


### PR DESCRIPTION
Automated package bump for `[
  "pcsx2_git"
]`.