### PR TITLE
chore: bump openrgb_git

### DIFF
--- a/pkgs/openrgb-git/version.json
+++ b/pkgs/openrgb-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260727041815-791d882",
-  "rev": "791d8820d67c3e4f924f4d1df96c5c4dcb9cd91d",
-  "hash": "sha256-i41I18t/SZEM6Ux3cXjQA38rqVE3slWmlMXqyYb8mE4="
+  "version": "unstable-20260727222754-069eecc",
+  "rev": "069eeccb603d4c864e4be2be889f7ecef43de261",
+  "hash": "sha256-RmEIZPYbMH+4bpYZ0tqu9f0g7Kq15x/qvNa8lvMuQBs="
 }


### PR DESCRIPTION
Automated package bump for `[
  "openrgb_git"
]`.