### PR TITLE
chore: bump tde2e_git

### DIFF
--- a/pkgs/telegram-desktop-git/version.json
+++ b/pkgs/telegram-desktop-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260724160100-2a6fd2c",
-  "rev": "2a6fd2cb752f8b3caca9b3589b2e89d28b36f00d",
-  "hash": "sha256-QG7sN9Sgf2FF57xJq97CNw/90ptwmv1CxxOafkS7JxI="
+  "version": "unstable-20260727143040-fccb267",
+  "rev": "fccb2672b05f7b788708e39a7b482e50ebdea510",
+  "hash": "sha256-gpqkZ2jLli8arOTsvJJnvWeaPofbxK9qSsSYaYDxNfQ="
 }


### PR DESCRIPTION
Automated package bump for `[
  "tde2e_git",
  "tg-owt_git",
  "telegram-desktop-unwrapped_git",
  "telegram-desktop_git"
]`.