### PR TITLE
chore: bump zed-editor_git

### DIFF
--- a/pkgs/zed-editor-git/version.json
+++ b/pkgs/zed-editor-git/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260727005539-50da8c4",
-  "rev": "50da8c40dcd596a91fe252537d8e4249f2fd3a50",
-  "hash": "sha256-bZlxzd+sWmtZJG7xXqkp5KljnWFShRbxFV0xC538qXo=",
+  "version": "unstable-20260728031802-a1510de",
+  "rev": "a1510de54e99131f3c33c4fd86a8e71753cf08de",
+  "hash": "sha256-jYCTaafzHT7qbtK81rTghol9miUBZqHmW8zlACN90gA=",
   "cargoHash": "sha256-lqlta0am3rkAZRrGpD7PdMkcDww11iULKDgafBVxliY="
 }


### PR DESCRIPTION
Automated package bump for `[
  "zed-editor_git"
]`.