### PR TITLE
chore: bump nss_git

### DIFF
--- a/pkgs/firefox-nightly/version.json
+++ b/pkgs/firefox-nightly/version.json
@@ -1,6 +1,6 @@
 {
   "version": "155.0a1",
-  "rev": "4c201594e8be406786dd33b609429a29d5a10813",
-  "buildId": "20260726215019",
-  "hash": "sha256-qf1qDNAUdZCGfJc+6NXgh+3Nx6VKxTxqHmsKIByhx+k="
+  "rev": "4b4e59946a3db5ddf42ea730fc44c22a99877303",
+  "buildId": "20260727131500",
+  "hash": "sha256-pdA1uOCBYhdVVcnIh2plsRkGBAMLvmIrMKCYfYPrEnU="
 }


### PR DESCRIPTION
Automated package bump for `[
  "nss_git",
  "firefox-unwrapped_nightly"
]`.