### PR TITLE
chore: bump nix_git

### DIFF
--- a/pkgs/nix-git/version.json
+++ b/pkgs/nix-git/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260727204822-06fc317",
-  "rev": "06fc31797cfa0daa3628c195491d9a027d13f4ae",
-  "hash": "sha256-k0+R645moO8aJuNynITzsu8pltyCuTrVHwDST54YkZs=",
-  "lastModifiedDate": "20260727204822"
+  "version": "unstable-20260728065114-6eb7331",
+  "rev": "6eb73313e44ce05ff2a24ab212c6583d676df924",
+  "hash": "sha256-ttY5pMxCd5gIjwVKAD4hAYTWJZyCM5qkWT5GL4MCuiU=",
+  "lastModifiedDate": "20260728065114"
 }


### PR DESCRIPTION
Automated package bump for `[
  "nix_git"
]`.