### PR TITLE
chore: bump openrgb_git

### DIFF
--- a/pkgs/openrgb-git/version.json
+++ b/pkgs/openrgb-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260727222754-069eecc",
-  "rev": "069eeccb603d4c864e4be2be889f7ecef43de261",
-  "hash": "sha256-RmEIZPYbMH+4bpYZ0tqu9f0g7Kq15x/qvNa8lvMuQBs="
+  "version": "unstable-20260728133825-7607582",
+  "rev": "760758230a06858af42e0bf97d92724f5435b686",
+  "hash": "sha256-A/a2H61XBSDlUwYFVRQD7ZI5L8FWVj2bMRLB2t9a554="
 }


### PR DESCRIPTION
Automated package bump for `[
  "openrgb_git"
]`.