### PR TITLE
chore: bump libdrm_git

### DIFF
--- a/pkgs/libdrm-git/version.json
+++ b/pkgs/libdrm-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260714214327-f198c21",
-  "rev": "f198c21dfcb89127083413dd4779a13b3f9a6507",
-  "hash": "sha256-w2dJQQMdftCPfdqYy8kRznvnXgWURBW0s62m0m3VKQc="
+  "version": "unstable-20260728183040-82f74e7",
+  "rev": "82f74e7a5a7403392e91352af00210ae26a81f19",
+  "hash": "sha256-c83rpdyN5pnyNTZzNsWjMXNLGkEPAA2vzzf1Jf8VIqM="
 }

--- a/pkgs/mesa-git/version.json
+++ b/pkgs/mesa-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260728032456-3db12cf",
-  "rev": "3db12cfcecade2764c2a80e3c1e3ce8ed34639c2",
-  "hash": "sha256-FuXGPTrYVSCMi+wQw7feqsds9SWmzEo18KvxwV7K8To="
+  "version": "unstable-20260729021100-5b7bcac",
+  "rev": "5b7bcac9bab7044034a6031fdf46ea803f92e861",
+  "hash": "sha256-y0kiSQi3MMgElu7NKwk0PGfSQ/YBz3AHWDbwFIiLD7E="
 }

--- a/pkgs/portal-wlr-git/version.json
+++ b/pkgs/portal-wlr-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260709161103-544e114",
-  "rev": "544e11481338a3784a11cb30561f06982fc0a158",
-  "hash": "sha256-qDL67snP2DFPp7Fgpru9MtC4iujWaz1A3c6ZALIoXnk="
+  "version": "unstable-20260728170217-4f70821",
+  "rev": "4f70821cee131d1cb90ba979fea7bc13588ce09f",
+  "hash": "sha256-WR9BtCj9pz75qJU3wUK/S2kyOipz0KH0rIYQmJDNzIU="
 }

--- a/pkgs/wlroots-git/version.json
+++ b/pkgs/wlroots-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260720161505-f6a01b4",
-  "rev": "f6a01b40d685ffadbcc5bda02741ca68ea76e863",
-  "hash": "sha256-s4SqRsC33VLZUCA6wmjasVuU5Xg6C9MgTR1ZtVMoGvw="
+  "version": "unstable-20260723215828-2cec06a",
+  "rev": "2cec06a4617cd9c712c6b35831cd1d75c41fe2af",
+  "hash": "sha256-MZMJE8N7zo3+pOCjO91be05/Z/KCYucMRGMzktimXsQ="
 }


### PR DESCRIPTION
Automated package bump for `[
  "libdrm_git",
  "wayland-protocols_git",
  "mesa_git",
  "wayland_git",
  "wlroots_git",
  "sway-unwrapped_git",
  "xdg-desktop-portal-wlr_git"
]`.