### PR TITLE
chore: bump pcsx2_git

### DIFF
--- a/pkgs/pcsx2-git/version.json
+++ b/pkgs/pcsx2-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260728021327-dee4938",
-  "rev": "dee4938c2b61bea356008043ec0733d70ca0c98c",
-  "hash": "sha256-u8NzacLC/GXfRMKpzLZUa+/LUhpzs7+98BTZb0hb5iY="
+  "version": "unstable-20260729002759-4a92f1c",
+  "rev": "4a92f1c472657222689b5c5786266c2f2df3da31",
+  "hash": "sha256-lun8/Ssjydrm/jth6emVDn64mId5B/SeqoSOQlC3KJ4="
 }


### PR DESCRIPTION
Automated package bump for `[
  "pcsx2_git"
]`.