### PR TITLE
chore: bump zed-editor_git

### DIFF
--- a/pkgs/zed-editor-git/version.json
+++ b/pkgs/zed-editor-git/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260728031802-a1510de",
-  "rev": "a1510de54e99131f3c33c4fd86a8e71753cf08de",
-  "hash": "sha256-jYCTaafzHT7qbtK81rTghol9miUBZqHmW8zlACN90gA=",
-  "cargoHash": "sha256-lqlta0am3rkAZRrGpD7PdMkcDww11iULKDgafBVxliY="
+  "version": "unstable-20260728210115-06b6160",
+  "rev": "06b6160d46ae8a9074cd367ed64f742b47beca64",
+  "hash": "sha256-rAtRfOIsAvzryfNYOTEAzO3+wXa8SA0PH9QGkAHf9Js=",
+  "cargoHash": "sha256-XLNfK6le0lyUWqI6Wdal7RtiH/KxSqqK+rGzKOlzPZg="
 }


### PR DESCRIPTION
Automated package bump for `[
  "zed-editor_git"
]`.