### PR TITLE
chore: bump tde2e_git

### DIFF
--- a/pkgs/telegram-desktop-git/version.json
+++ b/pkgs/telegram-desktop-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260727143040-fccb267",
-  "rev": "fccb2672b05f7b788708e39a7b482e50ebdea510",
-  "hash": "sha256-gpqkZ2jLli8arOTsvJJnvWeaPofbxK9qSsSYaYDxNfQ="
+  "version": "unstable-20260728082816-bd702c4",
+  "rev": "bd702c452113f5bca52843154c809dc882ba0b81",
+  "hash": "sha256-I5/z/uCVJ0mfkzcqGO40yDGE3cyUOtVPjWelf6+mMGg="
 }


### PR DESCRIPTION
Automated package bump for `[
  "tde2e_git",
  "tg-owt_git",
  "telegram-desktop-unwrapped_git",
  "telegram-desktop_git"
]`.