### PR TITLE
chore: bump shadps4_git

### DIFF
--- a/pkgs/shadps4-git/version.json
+++ b/pkgs/shadps4-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260726191324-dc5a33d",
-  "rev": "dc5a33d6f179db120c4bf209aae3ae722b724894",
-  "hash": "sha256-HDEUY1eTH4yb4NmaEYqhSEFuQNnBdIW1vXJMXhICVV8="
+  "version": "unstable-20260728194640-9894036",
+  "rev": "9894036b3f5be4c95588d9abdc49352a5bf112eb",
+  "hash": "sha256-8FPqlvwJNZci9aWGowfN1NnJcQoN9SLrJ7PgjujYYu0="
 }


### PR DESCRIPTION
Automated package bump for `[
  "shadps4_git"
]`.