### PR TITLE
chore: bump nss_git

### DIFF
--- a/pkgs/firefox-nightly/version.json
+++ b/pkgs/firefox-nightly/version.json
@@ -1,6 +1,6 @@
 {
   "version": "155.0a1",
-  "rev": "4b4e59946a3db5ddf42ea730fc44c22a99877303",
-  "buildId": "20260727131500",
-  "hash": "sha256-pdA1uOCBYhdVVcnIh2plsRkGBAMLvmIrMKCYfYPrEnU="
+  "rev": "272c6937c93bf6c3f132ce962d9ad7d798fce830",
+  "buildId": "20260728214328",
+  "hash": "sha256-OGKJ/dKT0yWe7eEPhbNLJGJcZWSBckHRPjLVXYJFWAQ="
 }


### PR DESCRIPTION
Automated package bump for `[
  "nss_git",
  "firefox-unwrapped_nightly"
]`.