### PR TITLE
chore: bump nix_git

### DIFF
--- a/pkgs/nix-git/version.json
+++ b/pkgs/nix-git/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260728065114-6eb7331",
-  "rev": "6eb73313e44ce05ff2a24ab212c6583d676df924",
-  "hash": "sha256-ttY5pMxCd5gIjwVKAD4hAYTWJZyCM5qkWT5GL4MCuiU=",
-  "lastModifiedDate": "20260728065114"
+  "version": "unstable-20260729214300-f21b630",
+  "rev": "f21b6305ce436092a3de45a990c9d8b85c05af16",
+  "hash": "sha256-RmYX51igC2mX4UyGwsS1XdM5O/qV8eJfrN8unVGxjTM=",
+  "lastModifiedDate": "20260729214300"
 }


### PR DESCRIPTION
Automated package bump for `[
  "nix_git"
]`.