### PR TITLE
chore: bump swaylock-plugin_git

### DIFF
--- a/pkgs/swaylock-plugin-git/version.json
+++ b/pkgs/swaylock-plugin-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260710111022-117ed3f",
-  "rev": "117ed3fe7d68a6f579cac6ce7a1bf82ceddb54d0",
-  "hash": "sha256-JWZ8aZeS8XXjRPhwyJXptwdMU2y/uFG1KlZh+v92/0c="
+  "version": "unstable-20260729120749-a5a1af5",
+  "rev": "a5a1af57f8564cd7b61eea344a1c4a86c9e3f8a9",
+  "hash": "sha256-TImlEVi6LTZHy4VdnX90kkH7vbUGqdE8MSWbg8ewfDM="
 }


### PR DESCRIPTION
Automated package bump for `[
  "swaylock-plugin_git"
]`.