### PR TITLE
chore: bump spirv-headers_git

### DIFF
--- a/pkgs/spirv-headers-git/version.json
+++ b/pkgs/spirv-headers-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260708154953-29981f6",
-  "rev": "29981f65241605e08b0ede4cfeb999fe3b723c6a",
-  "hash": "sha256-tGY4H3+5p9M5LBK/xxRdMT9CX+qq3e7fPkaftnpjU9I="
+  "version": "unstable-20260729154237-4015a33",
+  "rev": "4015a331f5ffd6fc5c6fa7b03e08fb4a692491d7",
+  "hash": "sha256-gA4RgSX1ANzm3HcgkB/eKTbZ95uNUuickbcNC0sjNro="
 }


### PR DESCRIPTION
Automated package bump for `[
  "spirv-headers_git"
]`.