### PR TITLE
chore: bump pcsx2_git

### DIFF
--- a/pkgs/pcsx2-git/version.json
+++ b/pkgs/pcsx2-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260729002759-4a92f1c",
-  "rev": "4a92f1c472657222689b5c5786266c2f2df3da31",
-  "hash": "sha256-lun8/Ssjydrm/jth6emVDn64mId5B/SeqoSOQlC3KJ4="
+  "version": "unstable-20260729193502-523785d",
+  "rev": "523785d3df43735e03afb1c97b910545f8087ec0",
+  "hash": "sha256-Zo4XdLvlvyxpkhUG7+Y75ZS73tTVBhLY/oAPLcE7P1k="
 }


### PR DESCRIPTION
Automated package bump for `[
  "pcsx2_git"
]`.