### PR TITLE
chore: bump openrgb_git

### DIFF
--- a/pkgs/openrgb-git/version.json
+++ b/pkgs/openrgb-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260728133825-7607582",
-  "rev": "760758230a06858af42e0bf97d92724f5435b686",
-  "hash": "sha256-A/a2H61XBSDlUwYFVRQD7ZI5L8FWVj2bMRLB2t9a554="
+  "version": "unstable-20260729220521-e5dc869",
+  "rev": "e5dc869c9b466541a678cf6e0964dc2a4335c1b8",
+  "hash": "sha256-p/IfoneM2/bNCUDCTjFTYU0bSMgI6yX2HAbBs68ZLhM="
 }


### PR DESCRIPTION
Automated package bump for `[
  "openrgb_git"
]`.