### PR TITLE
chore: bump zed-editor_git

### DIFF
--- a/pkgs/zed-editor-git/version.json
+++ b/pkgs/zed-editor-git/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260728210115-06b6160",
-  "rev": "06b6160d46ae8a9074cd367ed64f742b47beca64",
-  "hash": "sha256-rAtRfOIsAvzryfNYOTEAzO3+wXa8SA0PH9QGkAHf9Js=",
-  "cargoHash": "sha256-XLNfK6le0lyUWqI6Wdal7RtiH/KxSqqK+rGzKOlzPZg="
+  "version": "unstable-20260730031959-5e549b8",
+  "rev": "5e549b871fb87d1038d9b1b242bf7d4d4e3b4d8f",
+  "hash": "sha256-kZ4nH/kagA2uz0oeU5BQ2UWsbs2L3hYHhWniOxTXVk8=",
+  "cargoHash": "sha256-cpIMI7Xm4A6Dp1WLgfLbaUTld3tpFlk1OuaUNXQeZfA="
 }


### PR DESCRIPTION
Automated package bump for `[
  "zed-editor_git"
]`.