### PR TITLE
chore: bump tde2e_git

### DIFF
--- a/pkgs/telegram-desktop-git/version.json
+++ b/pkgs/telegram-desktop-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260728082816-bd702c4",
-  "rev": "bd702c452113f5bca52843154c809dc882ba0b81",
-  "hash": "sha256-I5/z/uCVJ0mfkzcqGO40yDGE3cyUOtVPjWelf6+mMGg="
+  "version": "unstable-20260729071307-12e8d4a",
+  "rev": "12e8d4a956b0e73c1f738112870a32ea079fa05f",
+  "hash": "sha256-j3uuX53JZqgJrzIFMxYvN0wKFwVSy1JFgVJf2+FOqsI="
 }


### PR DESCRIPTION
Automated package bump for `[
  "tde2e_git",
  "tg-owt_git",
  "telegram-desktop-unwrapped_git",
  "telegram-desktop_git"
]`.