### PR TITLE
chore: bump libdrm_git

### DIFF
--- a/pkgs/mesa-git/version.json
+++ b/pkgs/mesa-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260729021100-5b7bcac",
-  "rev": "5b7bcac9bab7044034a6031fdf46ea803f92e861",
-  "hash": "sha256-y0kiSQi3MMgElu7NKwk0PGfSQ/YBz3AHWDbwFIiLD7E="
+  "version": "unstable-20260730031438-13e6e00",
+  "rev": "13e6e00b1a56a21392bdd43c8f1154eb4063cfa4",
+  "hash": "sha256-/Ull6sVyW4GGEQn5pZxQD9MTFTNMDPoIP7xfh/S7fuw="
 }


### PR DESCRIPTION
Automated package bump for `[
  "libdrm_git",
  "wayland-protocols_git",
  "mesa_git",
  "wayland_git",
  "wlroots_git",
  "sway-unwrapped_git",
  "xdg-desktop-portal-wlr_git"
]`.