### PR TITLE
chore: bump shadps4_git

### DIFF
--- a/pkgs/shadps4-git/version.json
+++ b/pkgs/shadps4-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260728194640-9894036",
-  "rev": "9894036b3f5be4c95588d9abdc49352a5bf112eb",
-  "hash": "sha256-8FPqlvwJNZci9aWGowfN1NnJcQoN9SLrJ7PgjujYYu0="
+  "version": "unstable-20260729153853-24e68ba",
+  "rev": "24e68bafdea0bb89a909a691903e1e204210ff93",
+  "hash": "sha256-dnstgpJFHi8LGK3kuPc69Su4qqE7iSEHl4bm3kysJ3s="
 }


### PR DESCRIPTION
Automated package bump for `[
  "shadps4_git"
]`.