### PR TITLE
chore: bump nss_git

### DIFF
--- a/pkgs/firefox-nightly/version.json
+++ b/pkgs/firefox-nightly/version.json
@@ -1,6 +1,6 @@
 {
   "version": "155.0a1",
-  "rev": "272c6937c93bf6c3f132ce962d9ad7d798fce830",
-  "buildId": "20260728214328",
-  "hash": "sha256-OGKJ/dKT0yWe7eEPhbNLJGJcZWSBckHRPjLVXYJFWAQ="
+  "rev": "d573d849c063353bda3a67541ab219c8a548773a",
+  "buildId": "20260729213106",
+  "hash": "sha256-7EsBXBuwA7jUMhX1ydP/XZgtoqD9FF3PW28UGU/bkZs="
 }


### PR DESCRIPTION
Automated package bump for `[
  "nss_git",
  "firefox-unwrapped_nightly"
]`.