### PR TITLE
chore: bump openrgb_git

### DIFF
--- a/pkgs/openrgb-git/version.json
+++ b/pkgs/openrgb-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260729220521-e5dc869",
-  "rev": "e5dc869c9b466541a678cf6e0964dc2a4335c1b8",
-  "hash": "sha256-p/IfoneM2/bNCUDCTjFTYU0bSMgI6yX2HAbBs68ZLhM="
+  "version": "unstable-20260731040403-ccd103a",
+  "rev": "ccd103a29fcb723372b69c872e695c7693e0ca1c",
+  "hash": "sha256-DiN52lev2mksHW4MXTyft5nmY+6+ktbbN9LHAqX3NiY="
 }


### PR DESCRIPTION
Automated package bump for `[
  "openrgb_git"
]`.