### PR TITLE
chore: bump pcsx2_git

### DIFF
--- a/pkgs/pcsx2-git/version.json
+++ b/pkgs/pcsx2-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260729193502-523785d",
-  "rev": "523785d3df43735e03afb1c97b910545f8087ec0",
-  "hash": "sha256-Zo4XdLvlvyxpkhUG7+Y75ZS73tTVBhLY/oAPLcE7P1k="
+  "version": "unstable-20260731004311-773f96a",
+  "rev": "773f96a312ad69ac6b388b498ea163759ea153be",
+  "hash": "sha256-LSl7d6G94z+DPxcb3GwXnoKNUlQKPef+qJHudrTAAkg="
 }


### PR DESCRIPTION
Automated package bump for `[
  "pcsx2_git"
]`.