### PR TITLE
chore: bump nix_git

### DIFF
--- a/pkgs/nix-git/version.json
+++ b/pkgs/nix-git/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260729214300-f21b630",
-  "rev": "f21b6305ce436092a3de45a990c9d8b85c05af16",
-  "hash": "sha256-RmYX51igC2mX4UyGwsS1XdM5O/qV8eJfrN8unVGxjTM=",
-  "lastModifiedDate": "20260729214300"
+  "version": "unstable-20260731003113-7362ff0",
+  "rev": "7362ff0a5883ad122e1a98b20e9bb204e2882c75",
+  "hash": "sha256-DMROpivVxmYetR/+cBKxw4KMU4wgnc/0VkuZ7yS49oQ=",
+  "lastModifiedDate": "20260731003113"
 }


### PR DESCRIPTION
Automated package bump for `[
  "nix_git"
]`.