### PR TITLE
chore: bump libdrm_git

### DIFF
--- a/pkgs/mesa-git/version.json
+++ b/pkgs/mesa-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260730031438-13e6e00",
-  "rev": "13e6e00b1a56a21392bdd43c8f1154eb4063cfa4",
-  "hash": "sha256-/Ull6sVyW4GGEQn5pZxQD9MTFTNMDPoIP7xfh/S7fuw="
+  "version": "unstable-20260731012036-32b2249",
+  "rev": "32b22499f488c169d2d5d5d00b6f299b17839f82",
+  "hash": "sha256-Go7xh5CXLx3Y0yhiCx6g844sJLnPVRw6WgIUhmdBITw="
 }


### PR DESCRIPTION
Automated package bump for `[
  "libdrm_git",
  "wayland-protocols_git",
  "mesa_git",
  "wayland_git",
  "wlroots_git",
  "sway-unwrapped_git",
  "xdg-desktop-portal-wlr_git"
]`.