### PR TITLE
chore: bump zed-editor_git

### DIFF
--- a/pkgs/zed-editor-git/version.json
+++ b/pkgs/zed-editor-git/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260730031959-5e549b8",
-  "rev": "5e549b871fb87d1038d9b1b242bf7d4d4e3b4d8f",
-  "hash": "sha256-kZ4nH/kagA2uz0oeU5BQ2UWsbs2L3hYHhWniOxTXVk8=",
-  "cargoHash": "sha256-cpIMI7Xm4A6Dp1WLgfLbaUTld3tpFlk1OuaUNXQeZfA="
+  "version": "unstable-20260730233700-ae394f3",
+  "rev": "ae394f3d474f4996d2cdef6ee97551fdb6748acd",
+  "hash": "sha256-iCLhTSsKTVGbXZ3LAVZ6vtUVd8i7EjqP+AKtSjgG8dk=",
+  "cargoHash": "sha256-3KlGn8Efm8WxOwuyY+YqpWaorovMilDeQlE5wHPWyE4="
 }


### PR DESCRIPTION
Automated package bump for `[
  "zed-editor_git"
]`.