### PR TITLE
chore: bump tde2e_git

### DIFF
--- a/pkgs/telegram-desktop-git/version.json
+++ b/pkgs/telegram-desktop-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260729071307-12e8d4a",
-  "rev": "12e8d4a956b0e73c1f738112870a32ea079fa05f",
-  "hash": "sha256-j3uuX53JZqgJrzIFMxYvN0wKFwVSy1JFgVJf2+FOqsI="
+  "version": "unstable-20260730155513-798fc5c",
+  "rev": "798fc5c970011291c1e5c7ef9c644acbbff9baf9",
+  "hash": "sha256-tQV1Bt78wy0HhFkP5AZhO0rjO9ssYH85SmMTUDjbojY="
 }


### PR DESCRIPTION
Automated package bump for `[
  "tde2e_git",
  "tg-owt_git",
  "telegram-desktop-unwrapped_git",
  "telegram-desktop_git"
]`.