### PR TITLE
chore: bump shadps4_git

### DIFF
--- a/pkgs/shadps4-git/version.json
+++ b/pkgs/shadps4-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260729153853-24e68ba",
-  "rev": "24e68bafdea0bb89a909a691903e1e204210ff93",
-  "hash": "sha256-dnstgpJFHi8LGK3kuPc69Su4qqE7iSEHl4bm3kysJ3s="
+  "version": "unstable-20260730220613-bf4809f",
+  "rev": "bf4809fed2865da53ede58723965635e514e2ef5",
+  "hash": "sha256-oalm3bTfDZF9OnZOimxzKhr4M4U2neozxna8zMyJan4="
 }


### PR DESCRIPTION
Automated package bump for `[
  "shadps4_git"
]`.