### PR TITLE
chore: bump nss_git

### DIFF
--- a/pkgs/firefox-nightly/version.json
+++ b/pkgs/firefox-nightly/version.json
@@ -1,6 +1,6 @@
 {
   "version": "155.0a1",
-  "rev": "d573d849c063353bda3a67541ab219c8a548773a",
-  "buildId": "20260729213106",
-  "hash": "sha256-7EsBXBuwA7jUMhX1ydP/XZgtoqD9FF3PW28UGU/bkZs="
+  "rev": "7d438b99e58d16388e4327f2460d14ad4c8be075",
+  "buildId": "20260730214347",
+  "hash": "sha256-5TfGD2nLWvo9i2Lt153amq2B9yftgakhx1NfTv5JSkU="
 }


### PR DESCRIPTION
Automated package bump for `[
  "nss_git",
  "firefox-unwrapped_nightly"
]`.