### PR TITLE
chore: bump qtile-module_git

### DIFF
--- a/pkgs/qtile-git/version.json
+++ b/pkgs/qtile-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260725164227-3bea167",
-  "rev": "3bea16756e231582893108b174060b4ca07bda3f",
-  "hash": "sha256-e4V88nPVfLeR1xiD+rD5laZtetxwipif0v/s17tveGQ="
+  "version": "unstable-20260731124210-7e7d270",
+  "rev": "7e7d2705ef2db9335645fc4efa6749e2d835612d",
+  "hash": "sha256-RuRusEpd+j/7JVkj3DrXOmhharEuVywFjIihF/GKITE="
 }


### PR DESCRIPTION
Automated package bump for `[
  "qtile-module_git"
]`.