### PR TITLE
chore: bump nix_git

### DIFF
--- a/pkgs/nix-git/version.json
+++ b/pkgs/nix-git/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260731003113-7362ff0",
-  "rev": "7362ff0a5883ad122e1a98b20e9bb204e2882c75",
-  "hash": "sha256-DMROpivVxmYetR/+cBKxw4KMU4wgnc/0VkuZ7yS49oQ=",
-  "lastModifiedDate": "20260731003113"
+  "version": "unstable-20260731223137-2c4d1ff",
+  "rev": "2c4d1ff574ae8ec35723fe636221d0d7bf5cf0f0",
+  "hash": "sha256-tHzKTqWcdofda6n2e3Nwtl0tinKoWmAxLEvjxZqU+WU=",
+  "lastModifiedDate": "20260731223137"
 }


### PR DESCRIPTION
Automated package bump for `[
  "nix_git"
]`.