### PR TITLE
chore: bump openrgb_git

### DIFF
--- a/pkgs/openrgb-git/version.json
+++ b/pkgs/openrgb-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260731040403-ccd103a",
-  "rev": "ccd103a29fcb723372b69c872e695c7693e0ca1c",
-  "hash": "sha256-DiN52lev2mksHW4MXTyft5nmY+6+ktbbN9LHAqX3NiY="
+  "version": "unstable-20260731192336-2afbd64",
+  "rev": "2afbd64c8eadc185cfc4d401ce8a925ed99e8288",
+  "hash": "sha256-yOm7uS4ylpvYQEBq/nFzSD3E8Op+7AYf5WNxe30dyjY="
 }


### PR DESCRIPTION
Automated package bump for `[
  "openrgb_git"
]`.