### PR TITLE
chore: bump libdrm_git

### DIFF
--- a/pkgs/mesa-git/version.json
+++ b/pkgs/mesa-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260731012036-32b2249",
-  "rev": "32b22499f488c169d2d5d5d00b6f299b17839f82",
-  "hash": "sha256-Go7xh5CXLx3Y0yhiCx6g844sJLnPVRw6WgIUhmdBITw="
+  "version": "unstable-20260801024101-a8259a8",
+  "rev": "a8259a857aa9c90eef3ffecca4ccea35a3492b55",
+  "hash": "sha256-TyB2tCjfcfTLqUIAEaSL7abvsXtigV6p7BbtxaZUgv0="
 }

--- a/pkgs/sway-unwrapped-git/version.json
+++ b/pkgs/sway-unwrapped-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260720144956-6959a78",
-  "rev": "6959a78a8f0d52f79ad7465135b3295307a5146a",
-  "hash": "sha256-UcG1mapWRxFg0lCX/LVq1JWSMA2LQ1kTDWyxotEcV/4="
+  "version": "unstable-20260731114707-5bc72de",
+  "rev": "5bc72dee4771a2d2d2648b8f69d30e0747f263f6",
+  "hash": "sha256-wzuESkvvb6r+BSVcOayRMSfKRDyAvrjqpr63vVi9eSY="
 }


### PR DESCRIPTION
Automated package bump for `[
  "libdrm_git",
  "wayland-protocols_git",
  "mesa_git",
  "wayland_git",
  "wlroots_git",
  "sway-unwrapped_git",
  "xdg-desktop-portal-wlr_git"
]`.