### PR TITLE
chore: bump zed-editor_git

### DIFF
--- a/pkgs/zed-editor-git/version.json
+++ b/pkgs/zed-editor-git/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260730233700-ae394f3",
-  "rev": "ae394f3d474f4996d2cdef6ee97551fdb6748acd",
-  "hash": "sha256-iCLhTSsKTVGbXZ3LAVZ6vtUVd8i7EjqP+AKtSjgG8dk=",
-  "cargoHash": "sha256-3KlGn8Efm8WxOwuyY+YqpWaorovMilDeQlE5wHPWyE4="
+  "version": "unstable-20260731195713-5e1fd39",
+  "rev": "5e1fd392f67e27fa1da91bad43eef7db1a5dec23",
+  "hash": "sha256-S4jQkfcy0n0pIEQ66RfTtplFaU0DoCCB+OxVIq9Fo08=",
+  "cargoHash": "sha256-YTr2Y79BiqtQ5IJU91dPrBoSMPgdMJ7zr0C8hHp3CJE="
 }


### PR DESCRIPTION
Automated package bump for `[
  "zed-editor_git"
]`.