### PR TITLE
chore: bump pcsx2_git

### DIFF
--- a/pkgs/pcsx2-git/version.json
+++ b/pkgs/pcsx2-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260731004311-773f96a",
-  "rev": "773f96a312ad69ac6b388b498ea163759ea153be",
-  "hash": "sha256-LSl7d6G94z+DPxcb3GwXnoKNUlQKPef+qJHudrTAAkg="
+  "version": "unstable-20260731212042-779d5c4",
+  "rev": "779d5c4339cd83004bc561cdb28bd5bf75b0f371",
+  "hash": "sha256-TdQ0CxquE+rFLwZw5qgrjXlbNsAe733fgH/jENJrJi0="
 }


### PR DESCRIPTION
Automated package bump for `[
  "pcsx2_git"
]`.