### PR TITLE
chore: bump tde2e_git

### DIFF
--- a/pkgs/telegram-desktop-git/version.json
+++ b/pkgs/telegram-desktop-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260730155513-798fc5c",
-  "rev": "798fc5c970011291c1e5c7ef9c644acbbff9baf9",
-  "hash": "sha256-tQV1Bt78wy0HhFkP5AZhO0rjO9ssYH85SmMTUDjbojY="
+  "version": "unstable-20260801032621-ee93b40",
+  "rev": "ee93b401ced86ece3f2582fc2ca4da72dfc4f06a",
+  "hash": "sha256-VlQn0vqwQHrchId7ksDAvXd+lFMVdSFUP29pb/HF8/I="
 }


### PR DESCRIPTION
Automated package bump for `[
  "tde2e_git",
  "tg-owt_git",
  "telegram-desktop-unwrapped_git",
  "telegram-desktop_git"
]`.