### PR TITLE
chore: bump shadps4_git

### DIFF
--- a/pkgs/shadps4-git/version.json
+++ b/pkgs/shadps4-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260730220613-bf4809f",
-  "rev": "bf4809fed2865da53ede58723965635e514e2ef5",
-  "hash": "sha256-oalm3bTfDZF9OnZOimxzKhr4M4U2neozxna8zMyJan4="
+  "version": "unstable-20260801030545-65c9463",
+  "rev": "65c9463c6a2f7a5bb3cb0ad02f5f3edbaeb3e49a",
+  "hash": "sha256-rWJzbrTriunLM6zAnbmIN21FLBfMQzPa3cUD9b5OAOs="
 }


### PR DESCRIPTION
Automated package bump for `[
  "shadps4_git"
]`.