### PR TITLE
chore: bump nss_git

### DIFF
--- a/pkgs/firefox-nightly/version.json
+++ b/pkgs/firefox-nightly/version.json
@@ -1,6 +1,6 @@
 {
   "version": "155.0a1",
-  "rev": "7d438b99e58d16388e4327f2460d14ad4c8be075",
-  "buildId": "20260730214347",
-  "hash": "sha256-5TfGD2nLWvo9i2Lt153amq2B9yftgakhx1NfTv5JSkU="
+  "rev": "fdd583cd5a10d051053acda8b760c3bd5d800034",
+  "buildId": "20260731085738",
+  "hash": "sha256-pcP9EKqpwpQEOxWKh2/IpPyRIhxm9l3laKI8LMg7CPI="
 }


### PR DESCRIPTION
Automated package bump for `[
  "nss_git",
  "firefox-unwrapped_nightly"
]`.