### PR TITLE
chore: bump openrgb_git

### DIFF
--- a/pkgs/openrgb-git/version.json
+++ b/pkgs/openrgb-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260731192336-2afbd64",
-  "rev": "2afbd64c8eadc185cfc4d401ce8a925ed99e8288",
-  "hash": "sha256-yOm7uS4ylpvYQEBq/nFzSD3E8Op+7AYf5WNxe30dyjY="
+  "version": "unstable-20260802000151-286514b",
+  "rev": "286514b50944706fbc1cb980db349269e105379d",
+  "hash": "sha256-0ALW4GvIKGs/0AXLlMAV5iZ+3ZOty20xRrECOklBB/o="
 }


### PR DESCRIPTION
Automated package bump for `[
  "openrgb_git"
]`.