### PR TITLE
chore: bump pcsx2_git

### DIFF
--- a/pkgs/pcsx2-git/version.json
+++ b/pkgs/pcsx2-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260731212042-779d5c4",
-  "rev": "779d5c4339cd83004bc561cdb28bd5bf75b0f371",
-  "hash": "sha256-TdQ0CxquE+rFLwZw5qgrjXlbNsAe733fgH/jENJrJi0="
+  "version": "unstable-20260801175335-2ce2cb6",
+  "rev": "2ce2cb6459439d9e289bf48e42e4dc11bcb1e422",
+  "hash": "sha256-v5fs5v3AqcWLs849yiMjoX/h0b3TttWkBEmHkgE5Cek="
 }


### PR DESCRIPTION
Automated package bump for `[
  "pcsx2_git"
]`.