### PR TITLE
chore: bump nix_git

### DIFF
--- a/pkgs/nix-git/version.json
+++ b/pkgs/nix-git/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260731223137-2c4d1ff",
-  "rev": "2c4d1ff574ae8ec35723fe636221d0d7bf5cf0f0",
-  "hash": "sha256-tHzKTqWcdofda6n2e3Nwtl0tinKoWmAxLEvjxZqU+WU=",
-  "lastModifiedDate": "20260731223137"
+  "version": "unstable-20260801114719-a86a363",
+  "rev": "a86a363831d4eab7ad5c1d62a6bdc0380c94bd63",
+  "hash": "sha256-fff2uvLY95oUB5cIxvfPSrCNHd5BA3dZphn0z5Tkux8=",
+  "lastModifiedDate": "20260801114719"
 }


### PR DESCRIPTION
Automated package bump for `[
  "nix_git"
]`.