### PR TITLE
chore: bump tde2e_git

### DIFF
--- a/pkgs/telegram-desktop-git/version.json
+++ b/pkgs/telegram-desktop-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260801032621-ee93b40",
-  "rev": "ee93b401ced86ece3f2582fc2ca4da72dfc4f06a",
-  "hash": "sha256-VlQn0vqwQHrchId7ksDAvXd+lFMVdSFUP29pb/HF8/I="
+  "version": "unstable-20260801051843-e861100",
+  "rev": "e86110012eb34965fcccfa04d8e4922c75b8d225",
+  "hash": "sha256-w4c3aKq/BvXVQUEwqxCKjhRS29P2CmbFitnnxPHJOx4="
 }


### PR DESCRIPTION
Automated package bump for `[
  "tde2e_git",
  "tg-owt_git",
  "telegram-desktop-unwrapped_git",
  "telegram-desktop_git"
]`.