### PR TITLE
chore: bump libdrm_git

### DIFF
--- a/pkgs/mesa-git/version.json
+++ b/pkgs/mesa-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260801024101-a8259a8",
-  "rev": "a8259a857aa9c90eef3ffecca4ccea35a3492b55",
-  "hash": "sha256-TyB2tCjfcfTLqUIAEaSL7abvsXtigV6p7BbtxaZUgv0="
+  "version": "unstable-20260801162546-84f0901",
+  "rev": "84f090168c2e5248acd930f5c201c6d3ecda3c87",
+  "hash": "sha256-y5aj8DMBz5pV91beHFq/tJw5BkeyAefIMHQMUBh6dOU="
 }


### PR DESCRIPTION
Automated package bump for `[
  "libdrm_git",
  "wayland-protocols_git",
  "mesa_git",
  "wayland_git",
  "wlroots_git",
  "sway-unwrapped_git",
  "xdg-desktop-portal-wlr_git"
]`.