### PR TITLE
chore: bump zed-editor_git

### DIFF
--- a/pkgs/zed-editor-git/version.json
+++ b/pkgs/zed-editor-git/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260731195713-5e1fd39",
-  "rev": "5e1fd392f67e27fa1da91bad43eef7db1a5dec23",
-  "hash": "sha256-S4jQkfcy0n0pIEQ66RfTtplFaU0DoCCB+OxVIq9Fo08=",
-  "cargoHash": "sha256-YTr2Y79BiqtQ5IJU91dPrBoSMPgdMJ7zr0C8hHp3CJE="
+  "version": "unstable-20260801213447-90d024b",
+  "rev": "90d024b88abc91264d9a0ad260eb4f365fa695c3",
+  "hash": "sha256-O8nopyAgDL0WRL4YtWezGlzb72iKxk/+uf+I4pd21+s=",
+  "cargoHash": "sha256-dWrHPGx8z3RUCMlsyjRofT0cYp+tu0iVdv2N8AoCEZc="
 }


### PR DESCRIPTION
Automated package bump for `[
  "zed-editor_git"
]`.