### PR TITLE
chore: bump shadps4_git

### DIFF
--- a/pkgs/shadps4-git/version.json
+++ b/pkgs/shadps4-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260801030545-65c9463",
-  "rev": "65c9463c6a2f7a5bb3cb0ad02f5f3edbaeb3e49a",
-  "hash": "sha256-rWJzbrTriunLM6zAnbmIN21FLBfMQzPa3cUD9b5OAOs="
+  "version": "unstable-20260801135932-e1cf475",
+  "rev": "e1cf475263c811e09285f0ff43595a9dab00ed3d",
+  "hash": "sha256-s2dyxqkqBJ9yMajyheAwbN4eiKtxuLuCfmQVJUkJfQI="
 }


### PR DESCRIPTION
Automated package bump for `[
  "shadps4_git"
]`.