### PR TITLE
chore: bump nss_git

### DIFF
--- a/pkgs/firefox-nightly/version.json
+++ b/pkgs/firefox-nightly/version.json
@@ -1,6 +1,6 @@
 {
   "version": "155.0a1",
-  "rev": "fdd583cd5a10d051053acda8b760c3bd5d800034",
-  "buildId": "20260731085738",
-  "hash": "sha256-pcP9EKqpwpQEOxWKh2/IpPyRIhxm9l3laKI8LMg7CPI="
+  "rev": "2500ad5c8ac76a6a2c166cbbe891f14257e988f3",
+  "buildId": "20260801211258",
+  "hash": "sha256-ISVgtZ4VMJ98LrKy+K0Tbp1ckanj0j7pK2iPbFdhifE="
 }


### PR DESCRIPTION
Automated package bump for `[
  "nss_git",
  "firefox-unwrapped_nightly"
]`.