### PR TITLE
chore: bump nix_git

### DIFF
--- a/pkgs/nix-git/version.json
+++ b/pkgs/nix-git/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260801114719-a86a363",
-  "rev": "a86a363831d4eab7ad5c1d62a6bdc0380c94bd63",
-  "hash": "sha256-fff2uvLY95oUB5cIxvfPSrCNHd5BA3dZphn0z5Tkux8=",
-  "lastModifiedDate": "20260801114719"
+  "version": "unstable-20260802221354-8307c48",
+  "rev": "8307c48d25b90582c3e49999cee4a7a46495d2b7",
+  "hash": "sha256-aOAsikSo5+RrGMMpdF0n1vj1EavH/tFJ6bfP03+gaSs=",
+  "lastModifiedDate": "20260802221354"
 }


### PR DESCRIPTION
Automated package bump for `[
  "nix_git"
]`.