### PR TITLE
chore: bump swaylock-plugin_git

### DIFF
--- a/pkgs/swaylock-plugin-git/version.json
+++ b/pkgs/swaylock-plugin-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260729120749-a5a1af5",
-  "rev": "a5a1af57f8564cd7b61eea344a1c4a86c9e3f8a9",
-  "hash": "sha256-TImlEVi6LTZHy4VdnX90kkH7vbUGqdE8MSWbg8ewfDM="
+  "version": "unstable-20260802183609-fc63bcc",
+  "rev": "fc63bcc69f83edb208d6f1e1c70a097e4fdd6326",
+  "hash": "sha256-3XEwNMNJtHTT9WxOhjaavJRqpjqhCqEaz+7cnl9K35g="
 }


### PR DESCRIPTION
Automated package bump for `[
  "swaylock-plugin_git"
]`.