### PR TITLE
chore: bump openrgb_git

### DIFF
--- a/pkgs/openrgb-git/version.json
+++ b/pkgs/openrgb-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260802000151-286514b",
-  "rev": "286514b50944706fbc1cb980db349269e105379d",
-  "hash": "sha256-0ALW4GvIKGs/0AXLlMAV5iZ+3ZOty20xRrECOklBB/o="
+  "version": "unstable-20260802230334-84cf974",
+  "rev": "84cf974d70333bb07114be179596a55bd150627f",
+  "hash": "sha256-TxAEqN5iyaLIxiOS80ymsyNdcwK9LQD1bwyBc8KvBD8="
 }


### PR DESCRIPTION
Automated package bump for `[
  "openrgb_git"
]`.