### PR TITLE
chore: bump cutty_git

### DIFF
--- a/pkgs/cutty-git/version.json
+++ b/pkgs/cutty-git/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260520194947-472afd9",
-  "rev": "472afd95b0f6f8d7278b64c405db500d758dd5f1",
-  "hash": "sha256-BtyI+eWjlpKBt5uD/TtvsLpvp7hPbz+rGtxa/bX9IA0=",
-  "cargoHash": "sha256-eyoI1eyqS7b4GGwwoT7lsBYqzz8a+BwFvqwy5/Zrrvw="
+  "version": "unstable-20260802082110-6e03de5",
+  "rev": "6e03de53deef48364a57fb7adc7b6709cbeca02e",
+  "hash": "sha256-445z04NkHzxEcHiLx0rcUxSkU65lHEwjy0kD4m/EZ4s=",
+  "cargoHash": "sha256-6bsTw3cQtpoyyjtsqwDd+nMBmHHY07kOUkVuwNfq4XQ="
 }


### PR DESCRIPTION
Automated package bump for `[
  "cutty_git"
]`.