### PR TITLE
chore: bump pcsx2_git

### DIFF
--- a/pkgs/pcsx2-git/version.json
+++ b/pkgs/pcsx2-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260801175335-2ce2cb6",
-  "rev": "2ce2cb6459439d9e289bf48e42e4dc11bcb1e422",
-  "hash": "sha256-v5fs5v3AqcWLs849yiMjoX/h0b3TttWkBEmHkgE5Cek="
+  "version": "unstable-20260802140538-93f1086",
+  "rev": "93f10864c1a5e202ee3b9c584d6bbd39463f84f3",
+  "hash": "sha256-35N97JSPbmCWlgQrtMlCPzUcmiFSvng4HO2tIL1CGL4="
 }


### PR DESCRIPTION
Automated package bump for `[
  "pcsx2_git"
]`.