### PR TITLE
chore: bump zed-editor_git

### DIFF
--- a/pkgs/zed-editor-git/version.json
+++ b/pkgs/zed-editor-git/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260801213447-90d024b",
-  "rev": "90d024b88abc91264d9a0ad260eb4f365fa695c3",
-  "hash": "sha256-O8nopyAgDL0WRL4YtWezGlzb72iKxk/+uf+I4pd21+s=",
+  "version": "unstable-20260803014600-35cb755",
+  "rev": "35cb7558a9d9a6f2eaf31ce2e4dce4a0575820ef",
+  "hash": "sha256-Z02GpBuvVaAd+51QPVqQvcPEnoFGIA2pVaoBZ31HkjQ=",
   "cargoHash": "sha256-dWrHPGx8z3RUCMlsyjRofT0cYp+tu0iVdv2N8AoCEZc="
 }


### PR DESCRIPTION
Automated package bump for `[
  "zed-editor_git"
]`.