### PR TITLE
chore: bump libdrm_git

### DIFF
--- a/pkgs/mesa-git/version.json
+++ b/pkgs/mesa-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260801162546-84f0901",
-  "rev": "84f090168c2e5248acd930f5c201c6d3ecda3c87",
-  "hash": "sha256-y5aj8DMBz5pV91beHFq/tJw5BkeyAefIMHQMUBh6dOU="
+  "version": "unstable-20260802215238-99098b3",
+  "rev": "99098b31471dc07c815a421c56da243b79c73b26",
+  "hash": "sha256-3XXRGdPtApbPccCLxYaREz1JXAtLsiXq1tEiZTwIKfY="
 }


### PR DESCRIPTION
Automated package bump for `[
  "libdrm_git",
  "wayland-protocols_git",
  "mesa_git",
  "wayland_git",
  "wlroots_git",
  "sway-unwrapped_git",
  "xdg-desktop-portal-wlr_git"
]`.