### PR TITLE
chore: bump shadps4_git

### DIFF
--- a/pkgs/shadps4-git/version.json
+++ b/pkgs/shadps4-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260801135932-e1cf475",
-  "rev": "e1cf475263c811e09285f0ff43595a9dab00ed3d",
-  "hash": "sha256-s2dyxqkqBJ9yMajyheAwbN4eiKtxuLuCfmQVJUkJfQI="
+  "version": "unstable-20260802151825-edac3c2",
+  "rev": "edac3c2967d07c6f43986740c2fa49eee20facc3",
+  "hash": "sha256-G23AYkcZa0baC95zZE2NOckZtGpclLeweN50X4cdzz4="
 }


### PR DESCRIPTION
Automated package bump for `[
  "shadps4_git"
]`.