### PR TITLE
chore: bump nss_git

### DIFF
--- a/pkgs/firefox-nightly/version.json
+++ b/pkgs/firefox-nightly/version.json
@@ -1,6 +1,6 @@
 {
   "version": "155.0a1",
-  "rev": "2500ad5c8ac76a6a2c166cbbe891f14257e988f3",
-  "buildId": "20260801211258",
-  "hash": "sha256-ISVgtZ4VMJ98LrKy+K0Tbp1ckanj0j7pK2iPbFdhifE="
+  "rev": "1a4138fff3c97b328b33c107266a461edf83140a",
+  "buildId": "20260802201228",
+  "hash": "sha256-CcwrNn8XBB9lV1V0iGzNtN0YShcBUNoxJrqOAl7cNMk="
 }


### PR DESCRIPTION
Automated package bump for `[
  "nss_git",
  "firefox-unwrapped_nightly"
]`.