### PR TITLE
chore: bump nix_git

### DIFF
--- a/pkgs/nix-git/version.json
+++ b/pkgs/nix-git/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260802221354-8307c48",
-  "rev": "8307c48d25b90582c3e49999cee4a7a46495d2b7",
-  "hash": "sha256-aOAsikSo5+RrGMMpdF0n1vj1EavH/tFJ6bfP03+gaSs=",
-  "lastModifiedDate": "20260802221354"
+  "version": "unstable-20260803225231-63bafc5",
+  "rev": "63bafc5b6d78c4fc4ec0aa3733a580afed38b92d",
+  "hash": "sha256-LtV64Jyd1CSwBzOavS+cOb2D3TibiRr+qjgJr487hBQ=",
+  "lastModifiedDate": "20260803225231"
 }


### PR DESCRIPTION
Automated package bump for `[
  "nix_git"
]`.