### PR TITLE
chore: bump pcsx2_git

### DIFF
--- a/pkgs/pcsx2-git/version.json
+++ b/pkgs/pcsx2-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260802140538-93f1086",
-  "rev": "93f10864c1a5e202ee3b9c584d6bbd39463f84f3",
-  "hash": "sha256-35N97JSPbmCWlgQrtMlCPzUcmiFSvng4HO2tIL1CGL4="
+  "version": "unstable-20260803165219-4055a19",
+  "rev": "4055a19a1ddcb102c88bc0091190d1f853658453",
+  "hash": "sha256-4F/84nz1gcN6BwqvSM5zpR5d5oIpeoJCesoACehCRpE="
 }


### PR DESCRIPTION
Automated package bump for `[
  "pcsx2_git"
]`.