### PR TITLE
chore: bump openrgb_git

### DIFF
--- a/pkgs/openrgb-git/version.json
+++ b/pkgs/openrgb-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260802230334-84cf974",
-  "rev": "84cf974d70333bb07114be179596a55bd150627f",
-  "hash": "sha256-TxAEqN5iyaLIxiOS80ymsyNdcwK9LQD1bwyBc8KvBD8="
+  "version": "unstable-20260804035802-bfaef77",
+  "rev": "bfaef777190668860e17e7f57e99987670b606c5",
+  "hash": "sha256-m14zBHqBCrsddJYIm15P/x9NfoZmarpZabSSJsNDnc4="
 }


### PR DESCRIPTION
Automated package bump for `[
  "openrgb_git"
]`.