### PR TITLE
chore: bump cutty_git

### DIFF
--- a/pkgs/cutty-git/version.json
+++ b/pkgs/cutty-git/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260802082110-6e03de5",
-  "rev": "6e03de53deef48364a57fb7adc7b6709cbeca02e",
-  "hash": "sha256-445z04NkHzxEcHiLx0rcUxSkU65lHEwjy0kD4m/EZ4s=",
-  "cargoHash": "sha256-6bsTw3cQtpoyyjtsqwDd+nMBmHHY07kOUkVuwNfq4XQ="
+  "version": "unstable-20260803210746-1849dd2",
+  "rev": "1849dd250260b3a00b4c0592a6545868aac12527",
+  "hash": "sha256-tw5gYnJ2LLftLBaWEC81fC0YbMubNdGLaonCrdKBRLo=",
+  "cargoHash": "sha256-2fTXa4Hr2NP8QFXuMK5K8j0dUS3k0utM5RS/26i/8DM="
 }


### PR DESCRIPTION
Automated package bump for `[
  "cutty_git"
]`.