### PR TITLE
chore: bump libdrm_git

### DIFF
--- a/pkgs/mesa-git/version.json
+++ b/pkgs/mesa-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260802215238-99098b3",
-  "rev": "99098b31471dc07c815a421c56da243b79c73b26",
-  "hash": "sha256-3XXRGdPtApbPccCLxYaREz1JXAtLsiXq1tEiZTwIKfY="
+  "version": "unstable-20260804030720-0269993",
+  "rev": "0269993175d37cd35094d0d5ee704d1f5bb85a7a",
+  "hash": "sha256-VVI+rnR/4OzfGcwOyIiUu+wRf4BXBoxoUigvAFl0x4A="
 }


### PR DESCRIPTION
Automated package bump for `[
  "libdrm_git",
  "wayland-protocols_git",
  "mesa_git",
  "wayland_git",
  "wlroots_git",
  "sway-unwrapped_git",
  "xdg-desktop-portal-wlr_git"
]`.