### PR TITLE
chore: bump zed-editor_git

### DIFF
--- a/pkgs/zed-editor-git/version.json
+++ b/pkgs/zed-editor-git/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260803014600-35cb755",
-  "rev": "35cb7558a9d9a6f2eaf31ce2e4dce4a0575820ef",
-  "hash": "sha256-Z02GpBuvVaAd+51QPVqQvcPEnoFGIA2pVaoBZ31HkjQ=",
-  "cargoHash": "sha256-dWrHPGx8z3RUCMlsyjRofT0cYp+tu0iVdv2N8AoCEZc="
+  "version": "unstable-20260803204345-4aad57f",
+  "rev": "4aad57fd1f002f9feeea2b7fb6229ccbcd576cb1",
+  "hash": "sha256-x7llrU8PhsGyHEqcLA8vdEJGaz/PybzJSndecFgdW8w=",
+  "cargoHash": "sha256-5KZp+ZzMdtK8QSko3S8xAZLjybbfvgkTeQmI0PJTiH0="
 }


### PR DESCRIPTION
Automated package bump for `[
  "zed-editor_git"
]`.