### PR TITLE
chore: bump shadps4_git

### DIFF
--- a/pkgs/shadps4-git/version.json
+++ b/pkgs/shadps4-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260802151825-edac3c2",
-  "rev": "edac3c2967d07c6f43986740c2fa49eee20facc3",
-  "hash": "sha256-G23AYkcZa0baC95zZE2NOckZtGpclLeweN50X4cdzz4="
+  "version": "unstable-20260803065855-e06e4ab",
+  "rev": "e06e4ab0fda441a7adaca6e27aa77a6e7331d09d",
+  "hash": "sha256-ymQPoe9mdMCEcdQCVvSncg1RF+fNH8vwBT4ufJCWVvw="
 }


### PR DESCRIPTION
Automated package bump for `[
  "shadps4_git"
]`.