### PR TITLE
chore: bump tde2e_git

### DIFF
--- a/pkgs/telegram-desktop-git/version.json
+++ b/pkgs/telegram-desktop-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260801051843-e861100",
-  "rev": "e86110012eb34965fcccfa04d8e4922c75b8d225",
-  "hash": "sha256-w4c3aKq/BvXVQUEwqxCKjhRS29P2CmbFitnnxPHJOx4="
+  "version": "unstable-20260803070543-8ed7b58",
+  "rev": "8ed7b58848f720121026521cae0df050dd15c2a7",
+  "hash": "sha256-fDRRCPeICaClu393GxjBpn9y2hWfR6yJeDEFWvxEh/Y="
 }

--- a/pkgs/tg-owt-git/version.json
+++ b/pkgs/tg-owt-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260409072434-89df288",
-  "rev": "89df288dd6ba5b2ec95b3c5eaf1e7e0c3a870fc4",
-  "hash": "sha256-wdO3AACCEN3IDYWt5a+f7zrcPFoqz+c7vLpo6LZk29w="
+  "version": "unstable-20260803061618-19d51d3",
+  "rev": "19d51d3c19632a63fdbe17c62f10332d978cb940",
+  "hash": "sha256-Cb1XWnryZEKTyvhBeOsYX5KZG88zUOAlSRhfyIh06g4="
 }


### PR DESCRIPTION
Automated package bump for `[
  "tde2e_git",
  "tg-owt_git",
  "telegram-desktop-unwrapped_git",
  "telegram-desktop_git"
]`.