### PR TITLE
chore: bump nss_git

### DIFF
--- a/maintenance/failures.x86_64-linux.nix
+++ b/maintenance/failures.x86_64-linux.nix
@@ -1,4 +1,6 @@
 {
+  "firefox-unwrapped_nightly" = "/nix/store/gv09dzdvfa1jb5mxk0l7yk599cc4jmq2-firefox-nightly-unwrapped-155.0a1-20260803221840-7f451c7";
+  "firefox_nightly" = "/nix/store/ziqvh4cfn1s9zayri6ccwir14csvf445-firefox-nightly-155.0a1-20260803221840-7f451c7";
   "linuxPackages_cachyos.amdgpu-i2c" = "/nix/store/h2j3j1ab9vnsnrfha3qi4523q1w3kh70-amdgpu-i2c-x86_64-unknown-linux-gnu-0-unstable-2024-12-16";
   "linuxPackages_cachyos.bcachefs" = "/nix/store/42gl4rjvq85xqf7gqxh8jdx6iar7pgak-bcachefs-x86_64-unknown-linux-gnu-7.1.5-1.38.8";
   "linuxPackages_cachyos.bcc" = "/nix/store/2954zy0lpyi930b056v9pbvgf0bnrxhj-bcc-0.37.0-x86_64-unknown-linux-gnu";

--- a/pkgs/firefox-nightly/version.json
+++ b/pkgs/firefox-nightly/version.json
@@ -1,6 +1,6 @@
 {
   "version": "155.0a1",
-  "rev": "1a4138fff3c97b328b33c107266a461edf83140a",
-  "buildId": "20260802201228",
-  "hash": "sha256-CcwrNn8XBB9lV1V0iGzNtN0YShcBUNoxJrqOAl7cNMk="
+  "rev": "7f451c7918ffe36840b0ef31dfc2272ded671f81",
+  "buildId": "20260803221840",
+  "hash": "sha256-VLgMEMqZ+CQcrUSRgJkq/GDRUEpZ2t6W9OYlskTCWYU="
 }

--- a/pkgs/nss-git/version.json
+++ b/pkgs/nss-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260723073250-d69b81b",
-  "rev": "d69b81b67cc6d6734df20f16e4f89182b319da84",
-  "hash": "sha256-zyqfhD6jbHbLWHdYtsw/+LiJxHxhSMGX3XsKag8fbzo="
+  "version": "unstable-20260803193555-64be41a",
+  "rev": "64be41ad30c4f5300cc68200c0b912963ed5b85c",
+  "hash": "sha256-umQn1oiL/YydF3hgZApt6wBuJJgDHimFKVn+bUZnCUA="
 }


### PR DESCRIPTION
Automated package bump for `[
  "nss_git",
  "firefox-unwrapped_nightly"
]`.