### PR TITLE
chore: bump nix_git

### DIFF
--- a/pkgs/nix-git/version.json
+++ b/pkgs/nix-git/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260803225231-63bafc5",
-  "rev": "63bafc5b6d78c4fc4ec0aa3733a580afed38b92d",
-  "hash": "sha256-LtV64Jyd1CSwBzOavS+cOb2D3TibiRr+qjgJr487hBQ=",
-  "lastModifiedDate": "20260803225231"
+  "version": "unstable-20260804083941-d8c24e6",
+  "rev": "d8c24e6118d6fb323d4fcd2f311cda9c748452fa",
+  "hash": "sha256-SbXYrP5NKa1ySGHvPWE0e39PMOczcyeiXTaxMFsv1vs=",
+  "lastModifiedDate": "20260804083941"
 }


### PR DESCRIPTION
Automated package bump for `[
  "nix_git"
]`.