### PR TITLE
chore: bump pcsx2_git

### DIFF
--- a/pkgs/pcsx2-git/version.json
+++ b/pkgs/pcsx2-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260803165219-4055a19",
-  "rev": "4055a19a1ddcb102c88bc0091190d1f853658453",
-  "hash": "sha256-4F/84nz1gcN6BwqvSM5zpR5d5oIpeoJCesoACehCRpE="
+  "version": "unstable-20260804210134-624717d",
+  "rev": "624717dfade2bee3dab8e419874d3ef596d730fa",
+  "hash": "sha256-oXaPIXeWta8dRBuYO4dpAnUvhWTGlE1IGw8OBgd9lA0="
 }


### PR DESCRIPTION
Automated package bump for `[
  "pcsx2_git"
]`.