### PR TITLE
chore: bump openrgb_git

### DIFF
--- a/pkgs/openrgb-git/version.json
+++ b/pkgs/openrgb-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260804035802-bfaef77",
-  "rev": "bfaef777190668860e17e7f57e99987670b606c5",
-  "hash": "sha256-m14zBHqBCrsddJYIm15P/x9NfoZmarpZabSSJsNDnc4="
+  "version": "unstable-20260804165254-2e09228",
+  "rev": "2e0922856899d4d5f99c04f5748e942c17e488bb",
+  "hash": "sha256-qT+GnpXD9G7ADILOuexQDZpJWUfV2r1q7pC9HYEtrRs="
 }


### PR DESCRIPTION
Automated package bump for `[
  "openrgb_git"
]`.