### PR TITLE
chore: bump zed-editor_git

### DIFF
--- a/pkgs/zed-editor-git/version.json
+++ b/pkgs/zed-editor-git/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260803204345-4aad57f",
-  "rev": "4aad57fd1f002f9feeea2b7fb6229ccbcd576cb1",
-  "hash": "sha256-x7llrU8PhsGyHEqcLA8vdEJGaz/PybzJSndecFgdW8w=",
-  "cargoHash": "sha256-5KZp+ZzMdtK8QSko3S8xAZLjybbfvgkTeQmI0PJTiH0="
+  "version": "unstable-20260805033737-381953d",
+  "rev": "381953d44897c53c4d252ae30620bafaa7d060b7",
+  "hash": "sha256-SoCjQhkVw2+cqIbsvJvJWM7DDjpunnwRFXCw4m28Y+U=",
+  "cargoHash": "sha256-DExn/lCc5/HhBN2bCfVs/SpP0WB1O9V2IXGjzQx8iGo="
 }


### PR DESCRIPTION
Automated package bump for `[
  "zed-editor_git"
]`.