### PR TITLE
chore: bump tde2e_git

### DIFF
--- a/pkgs/telegram-desktop-git/version.json
+++ b/pkgs/telegram-desktop-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260803070543-8ed7b58",
-  "rev": "8ed7b58848f720121026521cae0df050dd15c2a7",
-  "hash": "sha256-fDRRCPeICaClu393GxjBpn9y2hWfR6yJeDEFWvxEh/Y="
+  "version": "unstable-20260804154450-64a2405",
+  "rev": "64a2405631f13253af37f831d49969588bce9d17",
+  "hash": "sha256-5Be2V/G1TNhAIcboPOQfz4SDvDDiW93IGXArQCDwMXs="
 }


### PR DESCRIPTION
Automated package bump for `[
  "tde2e_git",
  "tg-owt_git",
  "telegram-desktop-unwrapped_git",
  "telegram-desktop_git"
]`.