### PR TITLE
chore: bump nss_git

### DIFF
--- a/pkgs/firefox-nightly/version.json
+++ b/pkgs/firefox-nightly/version.json
@@ -1,6 +1,6 @@
 {
   "version": "155.0a1",
-  "rev": "1a4138fff3c97b328b33c107266a461edf83140a",
-  "buildId": "20260802201228",
-  "hash": "sha256-CcwrNn8XBB9lV1V0iGzNtN0YShcBUNoxJrqOAl7cNMk="
+  "rev": "6aae92eb653e7420b4541609f80e7311f7b7da31",
+  "buildId": "20260806211740",
+  "hash": "sha256-Mxztu46NyT1EljXWSfRKJUs+F6zrPDeWZhPMeEKAkpg="
 }

--- a/pkgs/nss-git/version.json
+++ b/pkgs/nss-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260723073250-d69b81b",
-  "rev": "d69b81b67cc6d6734df20f16e4f89182b319da84",
-  "hash": "sha256-zyqfhD6jbHbLWHdYtsw/+LiJxHxhSMGX3XsKag8fbzo="
+  "version": "unstable-20260806214513-dc51b81",
+  "rev": "dc51b81292977ace436f287cd531967332e977fe",
+  "hash": "sha256-2Z1gVBCyJ5/S+Yx/dVCs39aM/FVA3kjMzmHJ/TKkIWk="
 }


### PR DESCRIPTION
Automated package bump for `[
  "nss_git",
  "firefox-unwrapped_nightly"
]`.