### PR TITLE
chore: bump openrgb_git

### DIFF
--- a/pkgs/openrgb-git/version.json
+++ b/pkgs/openrgb-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260804165254-2e09228",
-  "rev": "2e0922856899d4d5f99c04f5748e942c17e488bb",
-  "hash": "sha256-qT+GnpXD9G7ADILOuexQDZpJWUfV2r1q7pC9HYEtrRs="
+  "version": "unstable-20260805130248-6e832b3",
+  "rev": "6e832b337ff93f8da28e656117147e00cbdc0d6f",
+  "hash": "sha256-82PL51mHoQ+rmvmYj4CBH3QlaBMhtNe4OrhSjomxGAM="
 }


### PR DESCRIPTION
Automated package bump for `[
  "openrgb_git"
]`.