### PR TITLE
chore: bump nix_git

### DIFF
--- a/pkgs/nix-git/version.json
+++ b/pkgs/nix-git/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260804083941-d8c24e6",
-  "rev": "d8c24e6118d6fb323d4fcd2f311cda9c748452fa",
-  "hash": "sha256-SbXYrP5NKa1ySGHvPWE0e39PMOczcyeiXTaxMFsv1vs=",
-  "lastModifiedDate": "20260804083941"
+  "version": "unstable-20260806010426-9137203",
+  "rev": "9137203c1d85c9d13b3d1ef91ba8885b185e5947",
+  "hash": "sha256-CFcOMFIJGsvNsDt5awut3tf8woW/4XD3VPs2u8htpV0=",
+  "lastModifiedDate": "20260806010426"
 }


### PR DESCRIPTION
Automated package bump for `[
  "nix_git"
]`.