### PR TITLE
chore: bump qtile-module_git

### DIFF
--- a/pkgs/qtile-git/version.json
+++ b/pkgs/qtile-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260731124210-7e7d270",
-  "rev": "7e7d2705ef2db9335645fc4efa6749e2d835612d",
-  "hash": "sha256-RuRusEpd+j/7JVkj3DrXOmhharEuVywFjIihF/GKITE="
+  "version": "unstable-20260806021043-332bc6d",
+  "rev": "332bc6d4bb54f3baf5b16d4d8431b33279c9ed1d",
+  "hash": "sha256-wdC609oGmErx43Onqg1zn0odIqUwbRmXD+WCRC4Xu8I="
 }


### PR DESCRIPTION
Automated package bump for `[
  "qtile-module_git"
]`.