### PR TITLE
chore: bump zed-editor_git

### DIFF
--- a/pkgs/zed-editor-git/version.json
+++ b/pkgs/zed-editor-git/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260805033737-381953d",
-  "rev": "381953d44897c53c4d252ae30620bafaa7d060b7",
-  "hash": "sha256-SoCjQhkVw2+cqIbsvJvJWM7DDjpunnwRFXCw4m28Y+U=",
-  "cargoHash": "sha256-DExn/lCc5/HhBN2bCfVs/SpP0WB1O9V2IXGjzQx8iGo="
+  "version": "unstable-20260805202419-8287854",
+  "rev": "82878540b5410b288a2c92cb9ee5675533e4d807",
+  "hash": "sha256-5YQFsv3tIKgPxldxPZFSD1DRpYVZ9fIo7VtIL8NEUc0=",
+  "cargoHash": "sha256-AmC+An5IfavgOc5oJmSI2VInlPellLRa6xDgZqRKVLo="
 }


### PR DESCRIPTION
Automated package bump for `[
  "zed-editor_git"
]`.