### PR TITLE
chore: bump spirv-headers_git

### DIFF
--- a/pkgs/spirv-headers-git/version.json
+++ b/pkgs/spirv-headers-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260729154237-4015a33",
-  "rev": "4015a331f5ffd6fc5c6fa7b03e08fb4a692491d7",
-  "hash": "sha256-gA4RgSX1ANzm3HcgkB/eKTbZ95uNUuickbcNC0sjNro="
+  "version": "unstable-20260805225136-942fe4b",
+  "rev": "942fe4b988359a0750b79f0ae7ed735994d3147d",
+  "hash": "sha256-pF76CrmltgR0KdYCM2ZlpeJNqb+rL8EK4Z6axjkJ+Ps="
 }


### PR DESCRIPTION
Automated package bump for `[
  "spirv-headers_git"
]`.