### PR TITLE
chore: bump shadps4_git

### DIFF
--- a/pkgs/shadps4-git/version.json
+++ b/pkgs/shadps4-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260803065855-e06e4ab",
-  "rev": "e06e4ab0fda441a7adaca6e27aa77a6e7331d09d",
-  "hash": "sha256-ymQPoe9mdMCEcdQCVvSncg1RF+fNH8vwBT4ufJCWVvw="
+  "version": "unstable-20260805202212-e96b578",
+  "rev": "e96b5786d4b262f5b15388df2826f9b2eb164ac4",
+  "hash": "sha256-V+rIy42Ho3ULrESDL7DvCOMY29nA6AnKxWF1fVY1yG8="
 }


### PR DESCRIPTION
Automated package bump for `[
  "shadps4_git"
]`.