### PR TITLE
chore: bump tde2e_git

### DIFF
--- a/pkgs/telegram-desktop-git/version.json
+++ b/pkgs/telegram-desktop-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260804154450-64a2405",
-  "rev": "64a2405631f13253af37f831d49969588bce9d17",
-  "hash": "sha256-5Be2V/G1TNhAIcboPOQfz4SDvDDiW93IGXArQCDwMXs="
+  "version": "unstable-20260805104813-0233582",
+  "rev": "02335826ba5df9f4482acc07d44d6971742d1e43",
+  "hash": "sha256-5D9OxqGtnZAu1OUTmD6iJM611nA5uTUr7e3JIRBJ2xY="
 }


### PR DESCRIPTION
Automated package bump for `[
  "tde2e_git",
  "tg-owt_git",
  "telegram-desktop-unwrapped_git",
  "telegram-desktop_git"
]`.