### PR TITLE
chore: bump openrgb_git

### DIFF
--- a/pkgs/openrgb-git/version.json
+++ b/pkgs/openrgb-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260805130248-6e832b3",
-  "rev": "6e832b337ff93f8da28e656117147e00cbdc0d6f",
-  "hash": "sha256-82PL51mHoQ+rmvmYj4CBH3QlaBMhtNe4OrhSjomxGAM="
+  "version": "unstable-20260807030022-2c397c5",
+  "rev": "2c397c5110f118bcbcb43cc593dfb44c8ea1e6ec",
+  "hash": "sha256-dOkMEG3ub/3fQ3RQdC8x8fSWxMOhF4UoPg/JsBBMzDE="
 }


### PR DESCRIPTION
Automated package bump for `[
  "openrgb_git"
]`.