### PR TITLE
chore: bump pcsx2_git

### DIFF
--- a/pkgs/pcsx2-git/version.json
+++ b/pkgs/pcsx2-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260804210134-624717d",
-  "rev": "624717dfade2bee3dab8e419874d3ef596d730fa",
-  "hash": "sha256-oXaPIXeWta8dRBuYO4dpAnUvhWTGlE1IGw8OBgd9lA0="
+  "version": "unstable-20260807011528-c3df236",
+  "rev": "c3df2360fc677a62c05aa39522631f0587326f66",
+  "hash": "sha256-eRppVyGAUvT5rYMV4Yv0iADLHATyd9zq+oajwJ5XxB0="
 }


### PR DESCRIPTION
Automated package bump for `[
  "pcsx2_git"
]`.