### PR TITLE
chore: bump zed-editor_git

### DIFF
--- a/pkgs/zed-editor-git/manifest.json
+++ b/pkgs/zed-editor-git/manifest.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260805202419-8287854",
-  "rev": "82878540b5410b288a2c92cb9ee5675533e4d807",
-  "hash": "sha256-5YQFsv3tIKgPxldxPZFSD1DRpYVZ9fIo7VtIL8NEUc0=",
-  "cargoHash": "sha256-AmC+An5IfavgOc5oJmSI2VInlPellLRa6xDgZqRKVLo="
+  "version": "unstable-20260807221741-38ca910",
+  "rev": "38ca9106c5306ef93e52c35643df015a27f15b72",
+  "hash": "sha256-7LSS1tPoCNkf9vqdMfIKgpf/DPzx5n/Cm5sH0I5lbAU=",
+  "cargoHash": "sha256-QMvWeQ7ckGYqKDFYtf5gLbFo1NZXWV48nV6Uk33B6nk="
 }


### PR DESCRIPTION
Automated package bump for `[
  "zed-editor_git"
]`.