### PR TITLE
chore: bump tde2e_git

### DIFF
--- a/pkgs/telegram-desktop-git/version.json
+++ b/pkgs/telegram-desktop-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260805104813-0233582",
-  "rev": "02335826ba5df9f4482acc07d44d6971742d1e43",
-  "hash": "sha256-5D9OxqGtnZAu1OUTmD6iJM611nA5uTUr7e3JIRBJ2xY="
+  "version": "unstable-20260806072328-a1e89e1",
+  "rev": "a1e89e1f64f08cb058caf1c61ff43f319f98a6ec",
+  "hash": "sha256-zpGfubIZtTmLjAgxYGcMy2N3Xlf9NOppcxsMSUS/KEA="
 }


### PR DESCRIPTION
Automated package bump for `[
  "tde2e_git",
  "tg-owt_git",
  "telegram-desktop-unwrapped_git",
  "telegram-desktop_git"
]`.