### PR TITLE
chore: bump nvidia_cachyos-gcc

### DIFF
--- a/pkgs/nvidia-cachyos/version.json
+++ b/pkgs/nvidia-cachyos/version.json
@@ -1,8 +1,8 @@
 {
-  "version": "610.43.03",
-  "hash": "sha256-ReLUwTSiPDXlDyU6SqY+fl6NF+PRhdSgfIpY6WEu05I=",
-  "aarch64Hash": "sha256-jSdlXo60ilXLKWKvZfgbBnVqVYuw6zhnGuiDgwxYz94=",
-  "openHash": "sha256-QCXmqo2xNyIwjGv0da2MUC8ex641Mmc5DUI+uRFVwgE=",
-  "settingsHash": "sha256-z/t+SdEQdVJPwjKIRHO02d264Kt47eWiOwwsaxmh4xQ=",
-  "persistencedHash": "sha256-sOKUsAFHh0/COH+nNgbH9+7hWgivOzq4YmTuk9MOFfI="
+  "version": "610.57.04",
+  "hash": "sha256-suk1xmuDuwDAyFe8jg7g/VLekoa0DJzB7sKafOfrEW0=",
+  "aarch64Hash": "sha256-QCefrMBCmpOwuOyXv1k5Gj0iB2CYlPgnG3JToUw/j54=",
+  "openHash": "sha256-rQHOOOY4KL92Ww3KDwh+j4eGU7oNAH8LutZC5wmFnPo=",
+  "settingsHash": "sha256-ZEMo8I8Zc2Tq6RVDNYpAH+f094dUaZiBqO+5f6lIjRI=",
+  "persistencedHash": "sha256-aXmD2VY1RLlgAnlHhOUMWzvMyhI6JTClcFLm4imF/mA="
 }


### PR DESCRIPTION
Automated package bump for `[
  "nvidia_cachyos-gcc"
]`.