### PR TITLE
chore: bump shadps4_git

### DIFF
--- a/pkgs/shadps4-git/version.json
+++ b/pkgs/shadps4-git/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260805202212-e96b578",
-  "rev": "e96b5786d4b262f5b15388df2826f9b2eb164ac4",
-  "hash": "sha256-V+rIy42Ho3ULrESDL7DvCOMY29nA6AnKxWF1fVY1yG8="
+  "version": "unstable-20260806225322-ef91a55",
+  "rev": "ef91a55e90e42fb053ad4fdf10c3e5f6fc34433b",
+  "hash": "sha256-ttQlR3hoW2l/jv+TLoqrF16negllqam7lyE6Gny8Ap8="
 }


### PR DESCRIPTION
Automated package bump for `[
  "shadps4_git"
]`.