### PR TITLE
chore: bump openrgb_git

### DIFF
--- a/pkgs/openrgb-git/manifest.json
+++ b/pkgs/openrgb-git/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260807030022-2c397c5",
-  "rev": "2c397c5110f118bcbcb43cc593dfb44c8ea1e6ec",
-  "hash": "sha256-dOkMEG3ub/3fQ3RQdC8x8fSWxMOhF4UoPg/JsBBMzDE="
+  "version": "unstable-20260807201707-e33a560",
+  "rev": "e33a56001a88c5c90f07adf177e8a6a2d077f48b",
+  "hash": "sha256-7tno2q9SiQpV1cOayTf5baXQw/qYAQ8mkYFtsV6Xpjo="
 }


### PR DESCRIPTION
Automated package bump for `[
  "openrgb_git"
]`.