### PR TITLE
chore: bump qtile-module_git

### DIFF
--- a/pkgs/qtile-git/manifest.json
+++ b/pkgs/qtile-git/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260806021043-332bc6d",
-  "rev": "332bc6d4bb54f3baf5b16d4d8431b33279c9ed1d",
-  "hash": "sha256-wdC609oGmErx43Onqg1zn0odIqUwbRmXD+WCRC4Xu8I="
+  "version": "unstable-20260808014105-8385631",
+  "rev": "8385631f1c55b7a8c95546383ad2fbd09fcc08d3",
+  "hash": "sha256-04oSoqKzr9OKb7xOTmLzRUJl8x6aQzH7t9d4LYlgkO8="
 }


### PR DESCRIPTION
Automated package bump for `[
  "qtile-module_git"
]`.