### PR TITLE
chore: bump tde2e_git

### DIFF
--- a/pkgs/telegram-desktop-git/manifest.json
+++ b/pkgs/telegram-desktop-git/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260806072328-a1e89e1",
-  "rev": "a1e89e1f64f08cb058caf1c61ff43f319f98a6ec",
-  "hash": "sha256-zpGfubIZtTmLjAgxYGcMy2N3Xlf9NOppcxsMSUS/KEA="
+  "version": "unstable-20260807064826-8e18cb7",
+  "rev": "8e18cb71103d83d7d98994ff27f0a2bca55c489c",
+  "hash": "sha256-CYm1JTpCYgPKmmDQB9ibKu08BlY3P+3oC4W+2y/4y5c="
 }


### PR DESCRIPTION
Automated package bump for `[
  "tde2e_git",
  "tg-owt_git",
  "telegram-desktop-unwrapped_git",
  "telegram-desktop_git"
]`.