### PR TITLE
chore: bump shadps4_git

### DIFF
--- a/pkgs/shadps4-git/manifest.json
+++ b/pkgs/shadps4-git/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260806225322-ef91a55",
-  "rev": "ef91a55e90e42fb053ad4fdf10c3e5f6fc34433b",
-  "hash": "sha256-ttQlR3hoW2l/jv+TLoqrF16negllqam7lyE6Gny8Ap8="
+  "version": "unstable-20260807165156-e080fdb",
+  "rev": "e080fdbd6ed74c55636aa2dbf0b0b4add154dc02",
+  "hash": "sha256-bKAo1J4zFLbHzrPGDDr8w3XAvNMI3RnJ6b1dHNsCnq0="
 }


### PR DESCRIPTION
Automated package bump for `[
  "shadps4_git"
]`.