### PR TITLE
chore: bump nss_git

### DIFF
--- a/maintenance/failures.x86_64-linux.nix
+++ b/maintenance/failures.x86_64-linux.nix
@@ -1,4 +1,6 @@
 {
+  "firefox-unwrapped_nightly" = "/nix/store/rqkkx7mra9wchhidjc2c9mf6jrc137a8-firefox-nightly-unwrapped-155.0a1-20260811214300-85130ba";
+  "firefox_nightly" = "/nix/store/r1jwdxl742266024hrx1wihsnkc3lkvm-firefox-nightly-155.0a1-20260811214300-85130ba";
   "linuxPackages_cachyos.amdgpu-i2c" = "/nix/store/722awmn5aqs0agdlyw42cav951xk9n83-amdgpu-i2c-x86_64-unknown-linux-gnu-0-unstable-2024-12-16";
   "linuxPackages_cachyos.bcachefs" = "/nix/store/bwx732iwhzd1cpfasy5sjghwa6yc0yqv-bcachefs-x86_64-unknown-linux-gnu-7.1.8-1.38.8";
   "linuxPackages_cachyos.bcc" = "/nix/store/2954zy0lpyi930b056v9pbvgf0bnrxhj-bcc-0.37.0-x86_64-unknown-linux-gnu";

--- a/pkgs/firefox-nightly/manifest.json
+++ b/pkgs/firefox-nightly/manifest.json
@@ -1,6 +1,6 @@
 {
   "version": "155.0a1",
-  "rev": "6aae92eb653e7420b4541609f80e7311f7b7da31",
-  "buildId": "20260806211740",
-  "hash": "sha256-Mxztu46NyT1EljXWSfRKJUs+F6zrPDeWZhPMeEKAkpg="
+  "rev": "85130ba192d9f4bdf63e57502cb23fb31f95f7ca",
+  "buildId": "20260811214300",
+  "hash": "sha256-sCAm+uEmGe5sybTvprfWwYi9dsPMdJQeGEG7p0PKf1o="
 }

--- a/pkgs/nss-git/manifest.json
+++ b/pkgs/nss-git/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260806214513-dc51b81",
-  "rev": "dc51b81292977ace436f287cd531967332e977fe",
-  "hash": "sha256-2Z1gVBCyJ5/S+Yx/dVCs39aM/FVA3kjMzmHJ/TKkIWk="
+  "version": "unstable-20260811180951-f27a683",
+  "rev": "f27a6839c3862e4ba83b12ed7541c45d7511c33e",
+  "hash": "sha256-7Q9js+EpHWATx6s7Hwn885m0X5k0mMMP7OO4HpXiwy8="
 }


### PR DESCRIPTION
Automated package bump for `[
  "nss_git",
  "firefox-unwrapped_nightly"
]`.