### PR TITLE
chore: bump openrgb_git

### DIFF
--- a/pkgs/openrgb-git/manifest.json
+++ b/pkgs/openrgb-git/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260807201707-e33a560",
-  "rev": "e33a56001a88c5c90f07adf177e8a6a2d077f48b",
-  "hash": "sha256-7tno2q9SiQpV1cOayTf5baXQw/qYAQ8mkYFtsV6Xpjo="
+  "version": "unstable-20260808204539-bfccc1a",
+  "rev": "bfccc1a95d6ed1325d9f9203533ed887e2bffd33",
+  "hash": "sha256-W1ADrBfDhueQQV4g91u9ZMrU9zrPvr3hBJIo4g0CLho="
 }


### PR DESCRIPTION
Automated package bump for `[
  "openrgb_git"
]`.