### PR TITLE
chore: bump nix_git

### DIFF
--- a/pkgs/nix-git/manifest.json
+++ b/pkgs/nix-git/manifest.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260806010426-9137203",
-  "rev": "9137203c1d85c9d13b3d1ef91ba8885b185e5947",
-  "hash": "sha256-CFcOMFIJGsvNsDt5awut3tf8woW/4XD3VPs2u8htpV0=",
-  "lastModifiedDate": "20260806010426"
+  "version": "unstable-20260808165007-85f1926",
+  "rev": "85f1926dac5d2075169133041a5727d466eee5ea",
+  "hash": "sha256-SsPNh5cPZGQ3lJzrKN524nRES9BRh+wq4iCdHr2Ee20=",
+  "lastModifiedDate": "20260808165007"
 }


### PR DESCRIPTION
Automated package bump for `[
  "nix_git"
]`.