### PR TITLE
chore: bump zed-editor_git

### DIFF
--- a/pkgs/zed-editor-git/manifest.json
+++ b/pkgs/zed-editor-git/manifest.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260807221741-38ca910",
-  "rev": "38ca9106c5306ef93e52c35643df015a27f15b72",
-  "hash": "sha256-7LSS1tPoCNkf9vqdMfIKgpf/DPzx5n/Cm5sH0I5lbAU=",
+  "version": "unstable-20260808183033-08827f9",
+  "rev": "08827f9208b4848d62f3faf86ffa15155966d63c",
+  "hash": "sha256-whyXdnK5pPIqWCrNBEoY3NnUc4HZgVEjqYKPsJbCSTU=",
   "cargoHash": "sha256-QMvWeQ7ckGYqKDFYtf5gLbFo1NZXWV48nV6Uk33B6nk="
 }


### PR DESCRIPTION
Automated package bump for `[
  "zed-editor_git"
]`.