### PR TITLE
chore: bump pcsx2_git

### DIFF
--- a/pkgs/pcsx2-git/manifest.json
+++ b/pkgs/pcsx2-git/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260807011528-c3df236",
-  "rev": "c3df2360fc677a62c05aa39522631f0587326f66",
-  "hash": "sha256-eRppVyGAUvT5rYMV4Yv0iADLHATyd9zq+oajwJ5XxB0="
+  "version": "unstable-20260808182600-d88510e",
+  "rev": "d88510e3a68e10ac2fbae8b13f9e7bf101bee906",
+  "hash": "sha256-pTJFOP/42lOzBfvn/06crYVMIdPwBYbEiHFxBXLhBqM="
 }


### PR DESCRIPTION
Automated package bump for `[
  "pcsx2_git"
]`.