### PR TITLE
chore: bump shadps4_git

### DIFF
--- a/pkgs/shadps4-git/manifest.json
+++ b/pkgs/shadps4-git/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260807165156-e080fdb",
-  "rev": "e080fdbd6ed74c55636aa2dbf0b0b4add154dc02",
-  "hash": "sha256-bKAo1J4zFLbHzrPGDDr8w3XAvNMI3RnJ6b1dHNsCnq0="
+  "version": "unstable-20260808191334-c5ae3c6",
+  "rev": "c5ae3c681276bd884b9b714c2099d55796c36154",
+  "hash": "sha256-Wl1uxCBvIFZMVmAtmG866OjFEHcvQVMoTw8xus8laWg="
 }


### PR DESCRIPTION
Automated package bump for `[
  "shadps4_git"
]`.