### PR TITLE
chore: bump libdrm_git

### DIFF
--- a/pkgs/mesa-git/manifest.json
+++ b/pkgs/mesa-git/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260808135848-057132b",
-  "rev": "057132b93b6c1b0d4da2efac1b285e75e9aa0e29",
-  "hash": "sha256-/HLA2Am1HTyBpabHgZRfja5muM40H8kOtofmOa/xf4c="
+  "version": "unstable-20260808225425-bab34da",
+  "rev": "bab34da4a378379e65d212b405525f50255efd31",
+  "hash": "sha256-k96S6quesbDpFlGV1CW8PeYIROY2myZ6i39PiqtHaNg="
 }


### PR DESCRIPTION
Automated package bump for `[
  "libdrm_git",
  "wayland-protocols_git",
  "mesa_git",
  "wayland_git",
  "wlroots_git",
  "sway-unwrapped_git",
  "xdg-desktop-portal-wlr_git"
]`.