### PR TITLE
chore: bump nix_git

### DIFF
--- a/pkgs/nix-git/manifest.json
+++ b/pkgs/nix-git/manifest.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260808165007-85f1926",
-  "rev": "85f1926dac5d2075169133041a5727d466eee5ea",
-  "hash": "sha256-SsPNh5cPZGQ3lJzrKN524nRES9BRh+wq4iCdHr2Ee20=",
-  "lastModifiedDate": "20260808165007"
+  "version": "unstable-20260809204554-4fb76b5",
+  "rev": "4fb76b520522a1d0d490f24ae55d49400f782f08",
+  "hash": "sha256-F6NNIUpPTMvJP0LEnNL93oY7V02h4FP1fYj/Kvn4Pb0=",
+  "lastModifiedDate": "20260809204554"
 }


### PR DESCRIPTION
Automated package bump for `[
  "nix_git"
]`.