### PR TITLE
chore: bump openrgb_git

### DIFF
--- a/pkgs/openrgb-git/manifest.json
+++ b/pkgs/openrgb-git/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260808204539-bfccc1a",
-  "rev": "bfccc1a95d6ed1325d9f9203533ed887e2bffd33",
-  "hash": "sha256-W1ADrBfDhueQQV4g91u9ZMrU9zrPvr3hBJIo4g0CLho="
+  "version": "unstable-20260809211310-606f5f6",
+  "rev": "606f5f6c86ba6becf26d41497f7d749bfc7615e5",
+  "hash": "sha256-mEGjjTYxHR0Bh3yRnTB3QqR5ckkUZg77LdTacRKCrvM="
 }


### PR DESCRIPTION
Automated package bump for `[
  "openrgb_git"
]`.