### PR TITLE
chore: bump libportal_git

### DIFF
--- a/pkgs/libportal-git/manifest.json
+++ b/pkgs/libportal-git/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260719052218-646419a",
-  "rev": "646419a712ad4eca710c1e6fc12acba0a4201b06",
-  "hash": "sha256-a63PpVRaptV3kWWEQkuV/uNZGUEL11ev6x2qeP2Oyuc="
+  "version": "unstable-20260809192800-4260f07",
+  "rev": "4260f07d3f6c0a85d1ecf9b85881fc57c96dadd5",
+  "hash": "sha256-BTBf4EiztPWBCF6X4uLP7sA9Njs/jPkccznOplUfyqU="
 }


### PR DESCRIPTION
Automated package bump for `[
  "libportal_git"
]`.