### PR TITLE
chore: bump qtile-module_git

### DIFF
--- a/pkgs/qtile-git/manifest.json
+++ b/pkgs/qtile-git/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260808014105-8385631",
-  "rev": "8385631f1c55b7a8c95546383ad2fbd09fcc08d3",
-  "hash": "sha256-04oSoqKzr9OKb7xOTmLzRUJl8x6aQzH7t9d4LYlgkO8="
+  "version": "unstable-20260809194612-7f0f60b",
+  "rev": "7f0f60be4a32bfcac746610402aebb29fa935ec5",
+  "hash": "sha256-oBJ+yHD0LPVPCNvaVaVqOtZjjN8peC9ePPIQ4LaR5nc="
 }


### PR DESCRIPTION
Automated package bump for `[
  "qtile-module_git"
]`.