### PR TITLE
chore: bump pcsx2_git

### DIFF
--- a/pkgs/pcsx2-git/manifest.json
+++ b/pkgs/pcsx2-git/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260808182600-d88510e",
-  "rev": "d88510e3a68e10ac2fbae8b13f9e7bf101bee906",
-  "hash": "sha256-pTJFOP/42lOzBfvn/06crYVMIdPwBYbEiHFxBXLhBqM="
+  "version": "unstable-20260809224508-8c1bb57",
+  "rev": "8c1bb5742ee4d9c4352fa5e890596ad17428adba",
+  "hash": "sha256-m0U4i+9FsTW5/eaMSz4P89dqU6CYQpgkw8GOVYpO6do="
 }


### PR DESCRIPTION
Automated package bump for `[
  "pcsx2_git"
]`.