### PR TITLE
chore: bump zed-editor_git

### DIFF
--- a/pkgs/zed-editor-git/manifest.json
+++ b/pkgs/zed-editor-git/manifest.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260808183033-08827f9",
-  "rev": "08827f9208b4848d62f3faf86ffa15155966d63c",
-  "hash": "sha256-whyXdnK5pPIqWCrNBEoY3NnUc4HZgVEjqYKPsJbCSTU=",
+  "version": "unstable-20260809222952-1271f8b",
+  "rev": "1271f8b0e8f3278eed5dd3fc12ad4bd30dce2c5d",
+  "hash": "sha256-vPxwG0rDkIfRdyLBzg6FC4Xhp7tSoyQj662j1fUhMwo=",
   "cargoHash": "sha256-QMvWeQ7ckGYqKDFYtf5gLbFo1NZXWV48nV6Uk33B6nk="
 }


### PR DESCRIPTION
Automated package bump for `[
  "zed-editor_git"
]`.