### PR TITLE
chore: bump libdrm_git

### DIFF
--- a/pkgs/mesa-git/manifest.json
+++ b/pkgs/mesa-git/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260808225425-bab34da",
-  "rev": "bab34da4a378379e65d212b405525f50255efd31",
-  "hash": "sha256-k96S6quesbDpFlGV1CW8PeYIROY2myZ6i39PiqtHaNg="
+  "version": "unstable-20260809110300-f56d52b",
+  "rev": "f56d52b26b2937b93a518e3346282e312cfb894f",
+  "hash": "sha256-HcSgVffl73HIDTJq0LZSA2RH7tn8PGzgs4w+iPY45YA="
 }


### PR DESCRIPTION
Automated package bump for `[
  "libdrm_git",
  "wayland-protocols_git",
  "mesa_git",
  "wayland_git",
  "wlroots_git",
  "sway-unwrapped_git",
  "xdg-desktop-portal-wlr_git"
]`.