### PR TITLE
cache-friendly: evaluate deferred nixpkgs config before re-import

### DIFF
--- a/overlays/cache-friendly.nix
+++ b/overlays/cache-friendly.nix
@@ -9,9 +9,6 @@ let
 
   isCross = stdenv.buildPlatform != stdenv.hostPlatform;
 
-  # Since nixpkgs f13ff45, `flakeNixpkgs.config` is a deferredModuleWith whose
-  # merged value is { imports = [...] }, not a plain config attrset. Evaluate
-  # it into one, else the config would be silently dropped on re-import.
   config =
     if nixpkgsConfig == null then
       flakes.nixpkgs.legacyPackages.${system}.config

--- a/overlays/cache-friendly.nix
+++ b/overlays/cache-friendly.nix
@@ -9,8 +9,19 @@ let
 
   isCross = stdenv.buildPlatform != stdenv.hostPlatform;
 
+  # Since nixpkgs f13ff45, `flakeNixpkgs.config` is a deferredModuleWith whose
+  # merged value is { imports = [...] }, not a plain config attrset. Evaluate
+  # it into one, else the config would be silently dropped on re-import.
   config =
-    if nixpkgsConfig == null then flakes.nixpkgs.legacyPackages.${system}.config else nixpkgsConfig;
+    if nixpkgsConfig == null then
+      flakes.nixpkgs.legacyPackages.${system}.config
+    else if builtins.isAttrs nixpkgsConfig && builtins.isList (nixpkgsConfig.imports or null) then
+      (final.lib.evalModules {
+        modules = nixpkgsConfig.imports;
+        class = "nixpkgsConfig";
+      }).config
+    else
+      nixpkgsConfig;
 
   prevPkgs =
     if isCross then


### PR DESCRIPTION
Since nixpkgs e701ff0, `nixpkgs.config` is typed `deferredModuleWith`, so `flakeNixpkgs.config` (typed like it) merges to a deferred module ({ imports = [...] }) instead of a plain config attrset. Passing that module as the `config` argument to `import nixpkgs` splices it as a literal config value, so its `imports` are never applied and the config (e.g. `allowUnfreePredicate`) is silently dropped — unfree packages in the re-imported set (e.g. jovian-chaotic.steam) then fail check-meta.

Evaluate the deferred module into a plain config attrset via `evalModules` before re-importing. Plain attrset configs (older nixpkgs, or a manually-set `flakeNixpkgs.config`) pass through unchanged.

### :fish: What?

1. Fixed a bug;

### :fishing_pole_and_fish: Why?

- (1) Fixes #2276 — since nixpkgs f13ff45 the `flake-nixpkgs` overlay drops `allowUnfreePredicate`, so unfree packages are refused; verified `jovian-chaotic.steam` evaluates while keeping the nyx binary cache.

### :fish_cake: Pending

- [ ] None.

### :whale: Extras

- None.