### PR TITLE
chore: bump openrgb_git

### DIFF
--- a/pkgs/openrgb-git/manifest.json
+++ b/pkgs/openrgb-git/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260809211310-606f5f6",
-  "rev": "606f5f6c86ba6becf26d41497f7d749bfc7615e5",
-  "hash": "sha256-mEGjjTYxHR0Bh3yRnTB3QqR5ckkUZg77LdTacRKCrvM="
+  "version": "unstable-20260810173102-684b74c",
+  "rev": "684b74ca9e2e2bfe096f074e1e8a1f7e04db5255",
+  "hash": "sha256-npsgMkR437ZEcOHk5RNzDxTwPd0zcPEOZoVk8KEbVZQ="
 }


### PR DESCRIPTION
Automated package bump for `[
  "openrgb_git"
]`.