### PR TITLE
chore: bump pcsx2_git

### DIFF
--- a/pkgs/pcsx2-git/manifest.json
+++ b/pkgs/pcsx2-git/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260809224508-8c1bb57",
-  "rev": "8c1bb5742ee4d9c4352fa5e890596ad17428adba",
-  "hash": "sha256-m0U4i+9FsTW5/eaMSz4P89dqU6CYQpgkw8GOVYpO6do="
+  "version": "unstable-20260810163519-2cf8dab",
+  "rev": "2cf8dabe6b2b5a0d92295eb869a78f2b9a764b6f",
+  "hash": "sha256-OkGgjPVLQerUJ09Gkb6Qt5WxkMf9i95wKLBTFTaFZoo="
 }


### PR DESCRIPTION
Automated package bump for `[
  "pcsx2_git"
]`.