### PR TITLE
chore: bump libdrm_git

### DIFF
--- a/pkgs/mesa-git/manifest.json
+++ b/pkgs/mesa-git/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260809110300-f56d52b",
-  "rev": "f56d52b26b2937b93a518e3346282e312cfb894f",
-  "hash": "sha256-HcSgVffl73HIDTJq0LZSA2RH7tn8PGzgs4w+iPY45YA="
+  "version": "unstable-20260810231502-1b2e70d",
+  "rev": "1b2e70de00f68f8cf32dca8cd1a64fba9b6410a8",
+  "hash": "sha256-ykpADwowJIru+OkNC2Fz/eLpcKSvecOfk+r54LtY5I4="
 }


### PR DESCRIPTION
Automated package bump for `[
  "libdrm_git",
  "wayland-protocols_git",
  "mesa_git",
  "wayland_git",
  "wlroots_git",
  "sway-unwrapped_git",
  "xdg-desktop-portal-wlr_git"
]`.