### PR TITLE
chore: bump zed-editor_git

### DIFF
--- a/pkgs/zed-editor-git/manifest.json
+++ b/pkgs/zed-editor-git/manifest.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260809222952-1271f8b",
-  "rev": "1271f8b0e8f3278eed5dd3fc12ad4bd30dce2c5d",
-  "hash": "sha256-vPxwG0rDkIfRdyLBzg6FC4Xhp7tSoyQj662j1fUhMwo=",
+  "version": "unstable-20260810224222-6634c94",
+  "rev": "6634c945d3af826e6466d6da3eee0782c62b5a8d",
+  "hash": "sha256-zn+lwzo82zzBqJwI+7i74fwwnkLO939ztxo58yH1WeE=",
   "cargoHash": "sha256-QMvWeQ7ckGYqKDFYtf5gLbFo1NZXWV48nV6Uk33B6nk="
 }


### PR DESCRIPTION
Automated package bump for `[
  "zed-editor_git"
]`.