### PR TITLE
chore: bump nix_git

### DIFF
--- a/pkgs/nix-git/manifest.json
+++ b/pkgs/nix-git/manifest.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260809204554-4fb76b5",
-  "rev": "4fb76b520522a1d0d490f24ae55d49400f782f08",
-  "hash": "sha256-F6NNIUpPTMvJP0LEnNL93oY7V02h4FP1fYj/Kvn4Pb0=",
-  "lastModifiedDate": "20260809204554"
+  "version": "unstable-20260811195330-24b65e3",
+  "rev": "24b65e35d9d4c9d64c1bd5844a35f2a779356d63",
+  "hash": "sha256-/9wXGp+aLObxqQuOGhDOnbdV0QCRDHH8uSh/4URKVAg=",
+  "lastModifiedDate": "20260811195330"
 }


### PR DESCRIPTION
Automated package bump for `[
  "nix_git"
]`.