### PR TITLE
chore: bump openrgb_git

### DIFF
--- a/pkgs/openrgb-git/manifest.json
+++ b/pkgs/openrgb-git/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260810173102-684b74c",
-  "rev": "684b74ca9e2e2bfe096f074e1e8a1f7e04db5255",
-  "hash": "sha256-npsgMkR437ZEcOHk5RNzDxTwPd0zcPEOZoVk8KEbVZQ="
+  "version": "unstable-20260812010022-790e148",
+  "rev": "790e1485f66921246280ff3b82769503d1b2ae87",
+  "hash": "sha256-8GfqaxnbJRvHKNKosNjgmfGLT7jBQPmI62YeQiH8jxA="
 }


### PR DESCRIPTION
Automated package bump for `[
  "openrgb_git"
]`.