### PR TITLE
chore: bump libdrm_git

### DIFF
--- a/pkgs/mesa-git/manifest.json
+++ b/pkgs/mesa-git/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260810231502-1b2e70d",
-  "rev": "1b2e70de00f68f8cf32dca8cd1a64fba9b6410a8",
-  "hash": "sha256-ykpADwowJIru+OkNC2Fz/eLpcKSvecOfk+r54LtY5I4="
+  "version": "unstable-20260811233329-eb03131",
+  "rev": "eb03131ca07be8a8f4abd09fcae66686007afd13",
+  "hash": "sha256-ww9qMLXOW/MSkvHuaUxX71Keuwbfw7RhWz4TSw4kFLs="
 }

--- a/pkgs/wlroots-git/manifest.json
+++ b/pkgs/wlroots-git/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260723215828-2cec06a",
-  "rev": "2cec06a4617cd9c712c6b35831cd1d75c41fe2af",
-  "hash": "sha256-MZMJE8N7zo3+pOCjO91be05/Z/KCYucMRGMzktimXsQ="
+  "version": "unstable-20260804210227-8abebd0",
+  "rev": "8abebd0f0d199006c207043d348b74a7f95772b5",
+  "hash": "sha256-xrlcVq37X5nqGbeVAqAfyuoLpq/swpv82d8Xe67aJPQ="
 }


### PR DESCRIPTION
Automated package bump for `[
  "libdrm_git",
  "wayland-protocols_git",
  "mesa_git",
  "wayland_git",
  "wlroots_git",
  "sway-unwrapped_git",
  "xdg-desktop-portal-wlr_git"
]`.