### PR TITLE
chore: bump shadps4_git

### DIFF
--- a/pkgs/shadps4-git/manifest.json
+++ b/pkgs/shadps4-git/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260808191334-c5ae3c6",
-  "rev": "c5ae3c681276bd884b9b714c2099d55796c36154",
-  "hash": "sha256-Wl1uxCBvIFZMVmAtmG866OjFEHcvQVMoTw8xus8laWg="
+  "version": "unstable-20260812025708-4d39337",
+  "rev": "4d39337392de21adc4c3bef1e2b77ff56c32afd3",
+  "hash": "sha256-B7KdcddgNnqChUv4dWn4FXXXcZFdDnmT9RYJYQU8qWk="
 }


### PR DESCRIPTION
Automated package bump for `[
  "shadps4_git"
]`.