### PR TITLE
chore: bump zed-editor_git

### DIFF
--- a/pkgs/zed-editor-git/manifest.json
+++ b/pkgs/zed-editor-git/manifest.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260810224222-6634c94",
-  "rev": "6634c945d3af826e6466d6da3eee0782c62b5a8d",
-  "hash": "sha256-zn+lwzo82zzBqJwI+7i74fwwnkLO939ztxo58yH1WeE=",
-  "cargoHash": "sha256-QMvWeQ7ckGYqKDFYtf5gLbFo1NZXWV48nV6Uk33B6nk="
+  "version": "unstable-20260811214012-6bd93fc",
+  "rev": "6bd93fc3195242834f4999f3b3daab294df6b253",
+  "hash": "sha256-CuW8ONsN+ttPEAOO51ih3au7iPMxLE7jU+TZO4jHCpg=",
+  "cargoHash": "sha256-zCd6hpnNA6nATDnjXsij5+OF0WtVQL3yRy89eEtoNrg="
 }


### PR DESCRIPTION
Automated package bump for `[
  "zed-editor_git"
]`.