### PR TITLE
chore: bump niri_git

### DIFF
--- a/pkgs/niri-git/manifest.json
+++ b/pkgs/niri-git/manifest.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260811204258-fec411e",
-  "rev": "fec411ea5119b5f0299feb32a2d5d3887349b6d3",
-  "hash": "sha256-VRLLdBVnAe5Z9aCP4vIasIYFYwYfbq618jUmblrti5s=",
-  "cargoHash": "sha256-st1aKaxpk9tlwjVuVfW/ibXIdeCOzKtcSwJM5X/Ymog="
+  "version": "unstable-20260813130615-720c388",
+  "rev": "720c388427c5589cc630f8188d44153d93ff8b0c",
+  "hash": "sha256-Yq5bu6KDiG5xttJ9wVsE/dKQ0AvO4RYx2YQmDaYVsXg=",
+  "cargoHash": "sha256-aNovCzrTtmqTO33YtZap47npdN73zXC1bap5q5dZvZk="
 }


### PR DESCRIPTION
Automated package bump for `[
  "niri_git"
]`.