### PR TITLE
chore: bump libdrm_git

### DIFF
--- a/pkgs/libdrm-git/manifest.json
+++ b/pkgs/libdrm-git/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260728183040-82f74e7",
-  "rev": "82f74e7a5a7403392e91352af00210ae26a81f19",
-  "hash": "sha256-c83rpdyN5pnyNTZzNsWjMXNLGkEPAA2vzzf1Jf8VIqM="
+  "version": "unstable-20260813202246-773536b",
+  "rev": "773536b1e5dde694dd743815528aff8bb2cf2cc3",
+  "hash": "sha256-7XBMU3bNsIKOwDXjdfVqf0fU1Bji18GKrvy7Uho7PeM="
 }

--- a/pkgs/mesa-git/manifest.json
+++ b/pkgs/mesa-git/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260811233329-eb03131",
-  "rev": "eb03131ca07be8a8f4abd09fcae66686007afd13",
-  "hash": "sha256-ww9qMLXOW/MSkvHuaUxX71Keuwbfw7RhWz4TSw4kFLs="
+  "version": "unstable-20260814022703-096fc2b",
+  "rev": "096fc2be80a2bb854e63f719e53fc14f084510f0",
+  "hash": "sha256-PkbixwZL0hhS7XqEN5eFwgKGaCVmA9PhCy8BLx4VRuU="
 }

--- a/pkgs/portal-wlr-git/manifest.json
+++ b/pkgs/portal-wlr-git/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260807201331-3feb9fb",
-  "rev": "3feb9fb97a13a47ad083189b7277bd6456364bd8",
-  "hash": "sha256-pGwt/TcsUsqROEJq31yRCPA7U4PU6LnDgmpQwQYsEKw="
+  "version": "unstable-20260813081827-c0255d7",
+  "rev": "c0255d7b047b7263629ab5a314661045ff7f65e3",
+  "hash": "sha256-W+0FrP5dlmf/dxcXt6pv4HFbpvJABNRl4TEghCSIy9c="
 }

--- a/pkgs/wlroots-git/manifest.json
+++ b/pkgs/wlroots-git/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260804210227-8abebd0",
-  "rev": "8abebd0f0d199006c207043d348b74a7f95772b5",
-  "hash": "sha256-xrlcVq37X5nqGbeVAqAfyuoLpq/swpv82d8Xe67aJPQ="
+  "version": "unstable-20260813151928-a58b1a7",
+  "rev": "a58b1a7a759449dcd52e89a4c0af136dd03f8622",
+  "hash": "sha256-sl4nkkB1GInoExP1clvmqXPnRDX+7KEAChiC7wSr35A="
 }


### PR DESCRIPTION
Automated package bump for `[
  "libdrm_git",
  "wayland-protocols_git",
  "mesa_git",
  "wayland_git",
  "wlroots_git",
  "sway-unwrapped_git",
  "xdg-desktop-portal-wlr_git"
]`.