### PR TITLE
chore: bump spirv-headers_git

### DIFF
--- a/pkgs/spirv-headers-git/manifest.json
+++ b/pkgs/spirv-headers-git/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260805225136-942fe4b",
-  "rev": "942fe4b988359a0750b79f0ae7ed735994d3147d",
-  "hash": "sha256-pF76CrmltgR0KdYCM2ZlpeJNqb+rL8EK4Z6axjkJ+Ps="
+  "version": "unstable-20260812154501-f0bf307",
+  "rev": "f0bf307f7c49d26484db596185cece53c37701fc",
+  "hash": "sha256-RcgLXqv8m3nNDZK7/PKd63uY8jsL7DncdWhAYIDJKzM="
 }


### PR DESCRIPTION
Automated package bump for `[
  "spirv-headers_git"
]`.