### PR TITLE
chore: bump zed-editor_git

### DIFF
--- a/pkgs/zed-editor-git/manifest.json
+++ b/pkgs/zed-editor-git/manifest.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260811214012-6bd93fc",
-  "rev": "6bd93fc3195242834f4999f3b3daab294df6b253",
-  "hash": "sha256-CuW8ONsN+ttPEAOO51ih3au7iPMxLE7jU+TZO4jHCpg=",
-  "cargoHash": "sha256-zCd6hpnNA6nATDnjXsij5+OF0WtVQL3yRy89eEtoNrg="
+  "version": "unstable-20260814002027-0ad5441",
+  "rev": "0ad5441b5370428eaa353a36f63c50c5448eead5",
+  "hash": "sha256-azs9DjJnztKlLWxbk6gUcJGcwl0oO45Cyx57e4HWb/w=",
+  "cargoHash": "sha256-grkBBo4B7tYasxZc5a0WSibaz+ZpZK+yomne+9Lb//Q="
 }


### PR DESCRIPTION
Automated package bump for `[
  "zed-editor_git"
]`.