### PR TITLE
chore: bump openrgb_git

### DIFF
--- a/pkgs/openrgb-git/manifest.json
+++ b/pkgs/openrgb-git/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260812010022-790e148",
-  "rev": "790e1485f66921246280ff3b82769503d1b2ae87",
-  "hash": "sha256-8GfqaxnbJRvHKNKosNjgmfGLT7jBQPmI62YeQiH8jxA="
+  "version": "unstable-20260812232340-0c1a73a",
+  "rev": "0c1a73accc3a5e6ee2d9279c17c58e030cc5a6be",
+  "hash": "sha256-tRf/bmONKwNEotwJ5/gPdwi8tx0SjTff+w7P8Dls1xY="
 }


### PR DESCRIPTION
Automated package bump for `[
  "openrgb_git"
]`.