### PR TITLE
chore: bump shadps4_git

### DIFF
--- a/pkgs/shadps4-git/manifest.json
+++ b/pkgs/shadps4-git/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260812025708-4d39337",
-  "rev": "4d39337392de21adc4c3bef1e2b77ff56c32afd3",
-  "hash": "sha256-B7KdcddgNnqChUv4dWn4FXXXcZFdDnmT9RYJYQU8qWk="
+  "version": "unstable-20260813205102-28c84fb",
+  "rev": "28c84fb5a7b19c7fb86156a1d6bb3e7e5a6cef64",
+  "hash": "sha256-APBDo63aH2Q85oP9cW18yJz4GO+N59YbSGXhk0tgLcE="
 }


### PR DESCRIPTION
Automated package bump for `[
  "shadps4_git"
]`.