### PR TITLE
overlays, mesa-git: stop using deprecated stdenv.isLinux

### DIFF
--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -111,7 +111,7 @@ let
   has32 = final.stdenv.hostPlatform.isLinux && final.stdenv.hostPlatform.isx86;
 
   # Required for kernel packages
-  isLinux = final.stdenv.hostPlatform.isLinux;
+  inherit (final.stdenv.hostPlatform) isLinux;
 
   # Apply Jovian overlay only on x86_64-linux
   jovian-chaotic =

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -111,7 +111,7 @@ let
   has32 = final.stdenv.hostPlatform.isLinux && final.stdenv.hostPlatform.isx86;
 
   # Required for kernel packages
-  inherit (final.stdenv) isLinux;
+  isLinux = final.stdenv.hostPlatform.isLinux;
 
   # Apply Jovian overlay only on x86_64-linux
   jovian-chaotic =

--- a/pkgs/mesa-git/default.nix
+++ b/pkgs/mesa-git/default.nix
@@ -21,7 +21,7 @@ let
 in
 gitOverride (current: {
   newInputs =
-    if final.stdenv.isLinux then
+    if final.stdenv.hostPlatform.isLinux then
       {
         wayland-protocols = final64.wayland-protocols_git;
         vulkanLayers = prev.mesa.vulkanLayers ++ [


### PR DESCRIPTION
### :fish: What?

3. Bumped package; ~~(not really, it's a tiny cleanup)~~ minor fix in `overlays/default.nix` and `pkgs/mesa-git/default.nix`.

### :fishing_pole_and_fish: Why?

`stdenv.isLinux` and `stdenv.isx86_64` are deprecated in current nixpkgs, the replacement is `stdenv.hostPlatform.isLinux` / `stdenv.hostPlatform.isx86_64`. `overlays/default.nix` still used the old `isLinux` accessor for the kernel packages binding, and since that overlay runs unconditionally for anyone who imports the default module, it throws an eval warning on basically every rebuild. `mesa-git/default.nix` had the same pattern.

Noticed it while using `linuxPackages_cachyos` on a NixOS box, figured it was worth a small PR instead of just ignoring it.

### :fish_cake: Pending

- [x] Complain with linter (ran `nix fmt` on both files, no changes needed beyond the fix itself)
- [ ] Remove some temporary fix
- [ ] Publishing to news' channel

### :whale: Extras

Nothing else changed, just the two accessors.
