### PR TITLE
chore: bump nix_git

### DIFF
--- a/pkgs/nix-git/manifest.json
+++ b/pkgs/nix-git/manifest.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260812214608-6274126",
-  "rev": "6274126b2c4a793aa28839b64125edecba5d106a",
-  "hash": "sha256-Isq1+//jI1AZUIjPbkO2r5PKQbFIP6EgJPS2jfpTZrI=",
-  "lastModifiedDate": "20260812214608"
+  "version": "unstable-20260814221653-9f36797",
+  "rev": "9f367979162ae7b246933e203c556f9ea25fcfc8",
+  "hash": "sha256-Ryi+h5z0ncMf+ISSC2hpaVLv60+wlaHqnBjWq0Lyg6A=",
+  "lastModifiedDate": "20260814221653"
 }


### PR DESCRIPTION
Automated package bump for `[
  "nix_git"
]`.