### PR TITLE
chore: bump niri_git

### DIFF
--- a/pkgs/niri-git/manifest.json
+++ b/pkgs/niri-git/manifest.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260813130615-720c388",
-  "rev": "720c388427c5589cc630f8188d44153d93ff8b0c",
-  "hash": "sha256-Yq5bu6KDiG5xttJ9wVsE/dKQ0AvO4RYx2YQmDaYVsXg=",
+  "version": "unstable-20260814122556-6062844",
+  "rev": "606284464d4a99bb35710fee68192bc71085ee7c",
+  "hash": "sha256-ptAftnlkdXaVjEzA2e1DBM9NPPDOpHtsAhOI6KzY4NY=",
   "cargoHash": "sha256-aNovCzrTtmqTO33YtZap47npdN73zXC1bap5q5dZvZk="
 }


### PR DESCRIPTION
Automated package bump for `[
  "niri_git"
]`.