### PR TITLE
chore: bump openrgb_git

### DIFF
--- a/pkgs/openrgb-git/manifest.json
+++ b/pkgs/openrgb-git/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260812232340-0c1a73a",
-  "rev": "0c1a73accc3a5e6ee2d9279c17c58e030cc5a6be",
-  "hash": "sha256-tRf/bmONKwNEotwJ5/gPdwi8tx0SjTff+w7P8Dls1xY="
+  "version": "unstable-20260814163340-5c1a2c4",
+  "rev": "5c1a2c4d13a26fba02a575d2c54f4d05e3d54a0c",
+  "hash": "sha256-wCayfWMFzLc11hTeY5dy3P5HtUY4+CA9Kg52WmHbiAQ="
 }


### PR DESCRIPTION
Automated package bump for `[
  "openrgb_git"
]`.