### PR TITLE
chore: bump spirv-headers_git

### DIFF
--- a/pkgs/spirv-headers-git/manifest.json
+++ b/pkgs/spirv-headers-git/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260812154501-f0bf307",
-  "rev": "f0bf307f7c49d26484db596185cece53c37701fc",
-  "hash": "sha256-RcgLXqv8m3nNDZK7/PKd63uY8jsL7DncdWhAYIDJKzM="
+  "version": "unstable-20260814155455-0d25db9",
+  "rev": "0d25db97cb9b8f725e4c95e4553001710e7fc39d",
+  "hash": "sha256-HvdKHnraSSWBriVgiNfhnC60moYRseDb3aRxxoANX1I="
 }


### PR DESCRIPTION
Automated package bump for `[
  "spirv-headers_git"
]`.