### PR TITLE
chore: bump libdrm_git

### DIFF
--- a/pkgs/mesa-git/manifest.json
+++ b/pkgs/mesa-git/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260814022703-096fc2b",
-  "rev": "096fc2be80a2bb854e63f719e53fc14f084510f0",
-  "hash": "sha256-PkbixwZL0hhS7XqEN5eFwgKGaCVmA9PhCy8BLx4VRuU="
+  "version": "unstable-20260815012726-8220394",
+  "rev": "822039414ce22530906183913e5afd7a6f075670",
+  "hash": "sha256-4C0+3o0keBqM+9rI01ymJhojmLDl8DwKVls6VBp2/7o="
 }

--- a/pkgs/wlroots-git/manifest.json
+++ b/pkgs/wlroots-git/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260813151928-a58b1a7",
-  "rev": "a58b1a7a759449dcd52e89a4c0af136dd03f8622",
-  "hash": "sha256-sl4nkkB1GInoExP1clvmqXPnRDX+7KEAChiC7wSr35A="
+  "version": "unstable-20260814135945-012ca82",
+  "rev": "012ca825e326ba3ec9dc5c2a0c81f08851405563",
+  "hash": "sha256-eq0pBV9W2raEZT83QJpXQy76TL3j5eZLWBdBXVxAl1g="
 }


### PR DESCRIPTION
Automated package bump for `[
  "libdrm_git",
  "wayland-protocols_git",
  "mesa_git",
  "wayland_git",
  "wlroots_git",
  "sway-unwrapped_git",
  "xdg-desktop-portal-wlr_git"
]`.