### PR TITLE
chore: bump shadps4_git

### DIFF
--- a/pkgs/shadps4-git/manifest.json
+++ b/pkgs/shadps4-git/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260813205102-28c84fb",
-  "rev": "28c84fb5a7b19c7fb86156a1d6bb3e7e5a6cef64",
-  "hash": "sha256-APBDo63aH2Q85oP9cW18yJz4GO+N59YbSGXhk0tgLcE="
+  "version": "unstable-20260814165320-bed2fd8",
+  "rev": "bed2fd8d5f1481e84486204e0aaee80d2409b1c1",
+  "hash": "sha256-WriIX9xfKhCVp+zl4cb+VlASbCJ3qiNjlVXJTlzxtLY="
 }


### PR DESCRIPTION
Automated package bump for `[
  "shadps4_git"
]`.