### PR TITLE
chore: bump zed-editor_git

### DIFF
--- a/pkgs/zed-editor-git/manifest.json
+++ b/pkgs/zed-editor-git/manifest.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260814002027-0ad5441",
-  "rev": "0ad5441b5370428eaa353a36f63c50c5448eead5",
-  "hash": "sha256-azs9DjJnztKlLWxbk6gUcJGcwl0oO45Cyx57e4HWb/w=",
-  "cargoHash": "sha256-grkBBo4B7tYasxZc5a0WSibaz+ZpZK+yomne+9Lb//Q="
+  "version": "unstable-20260815003000-9bde578",
+  "rev": "9bde578ef5afa84920c4300af25f9dee31c96fcf",
+  "hash": "sha256-cMiEuDJCjRAbz25g8TO/FOpa48TcQg6NAntA4hk86Xc=",
+  "cargoHash": "sha256-8NsWrg9W3Se0MQ6kSdV/emZfG/6VPpX6ftPOYCAZgD8="
 }


### PR DESCRIPTION
Automated package bump for `[
  "zed-editor_git"
]`.