### PR TITLE
chore: bump nss_git

### DIFF
--- a/pkgs/firefox-nightly/manifest.json
+++ b/pkgs/firefox-nightly/manifest.json
@@ -1,7 +1,7 @@
 {
-  "version": "155.0a1",
-  "rev": "6cee80f87168d5aabd9e343099e2a8e5535e5320",
-  "buildId": "20260812202037",
-  "hash": "sha256-VbNBq/DkcD2EzGoMaepkUTqwXzBn16TD0SCpa8+xFYo=",
+  "version": "156.0a1",
+  "rev": "98f1235b79c19a808e3101160efb7810b71a75d7",
+  "buildId": "20260815085631",
+  "hash": "sha256-tlbFYxczzPzAabV6Av+QMEyJguhZQVPqWTFbzWOJda0=",
   "newtabNpmDepsHash": "sha256-6NhZWVpbB0kX3d+9QaxFIgGeCfhqusNTANI6pwROWWw="
 }

--- a/pkgs/nss-git/manifest.json
+++ b/pkgs/nss-git/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260806214513-dc51b81",
-  "rev": "dc51b81292977ace436f287cd531967332e977fe",
-  "hash": "sha256-2Z1gVBCyJ5/S+Yx/dVCs39aM/FVA3kjMzmHJ/TKkIWk="
+  "version": "unstable-20260813170106-e360927",
+  "rev": "e3609273b3ee3913d48ccd4ab8891ad549aa46e3",
+  "hash": "sha256-3jfVSk/YMIdq7BioD8UhgtxYR6tqXZ5HKGZMNmoJX0Q="
 }


### PR DESCRIPTION
Automated package bump for `[ "nss_git", "firefox-unwrapped_nightly" ]`.