### PR TITLE
chore: bump nix_git

### DIFF
--- a/pkgs/nix-git/manifest.json
+++ b/pkgs/nix-git/manifest.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260814221653-9f36797",
-  "rev": "9f367979162ae7b246933e203c556f9ea25fcfc8",
-  "hash": "sha256-Ryi+h5z0ncMf+ISSC2hpaVLv60+wlaHqnBjWq0Lyg6A=",
-  "lastModifiedDate": "20260814221653"
+  "version": "unstable-20260815210536-8eb792a",
+  "rev": "8eb792a484c6da9bfda7bf9b423ae177cd805b3e",
+  "hash": "sha256-4tnCb99rbbaj7Ed2pEqy1oL17NbgJqtOG3ve6MaKYVo=",
+  "lastModifiedDate": "20260815210536"
 }


### PR DESCRIPTION
Automated package bump for `[
  "nix_git"
]`.