### PR TITLE
chore: bump libdrm_git

### DIFF
--- a/pkgs/mesa-git/manifest.json
+++ b/pkgs/mesa-git/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260815012726-8220394",
-  "rev": "822039414ce22530906183913e5afd7a6f075670",
-  "hash": "sha256-4C0+3o0keBqM+9rI01ymJhojmLDl8DwKVls6VBp2/7o="
+  "version": "unstable-20260815122155-f0bcf54",
+  "rev": "f0bcf54488119f97502da9f4cca87a214e502a3e",
+  "hash": "sha256-K6728IMgVd9vhzsKIizsixyxxmmTepepcqcP4oB3rgo="
 }


### PR DESCRIPTION
Automated package bump for `[
  "libdrm_git",
  "wayland-protocols_git",
  "mesa_git",
  "wayland_git",
  "wlroots_git",
  "sway-unwrapped_git",
  "xdg-desktop-portal-wlr_git"
]`.