### PR TITLE
chore: bump zed-editor_git

### DIFF
--- a/pkgs/zed-editor-git/manifest.json
+++ b/pkgs/zed-editor-git/manifest.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260815003000-9bde578",
-  "rev": "9bde578ef5afa84920c4300af25f9dee31c96fcf",
-  "hash": "sha256-cMiEuDJCjRAbz25g8TO/FOpa48TcQg6NAntA4hk86Xc=",
+  "version": "unstable-20260815195510-bc538de",
+  "rev": "bc538def4545534201bbfcac4e95ac34ea6501b6",
+  "hash": "sha256-CuI8dYstUJxXPbPi4QtJDZvN6OURJu96l0lTbFHLvUE=",
   "cargoHash": "sha256-8NsWrg9W3Se0MQ6kSdV/emZfG/6VPpX6ftPOYCAZgD8="
 }


### PR DESCRIPTION
Automated package bump for `[
  "zed-editor_git"
]`.