### PR TITLE
chore: bump openrgb_git

### DIFF
--- a/pkgs/openrgb-git/manifest.json
+++ b/pkgs/openrgb-git/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260814163340-5c1a2c4",
-  "rev": "5c1a2c4d13a26fba02a575d2c54f4d05e3d54a0c",
-  "hash": "sha256-wCayfWMFzLc11hTeY5dy3P5HtUY4+CA9Kg52WmHbiAQ="
+  "version": "unstable-20260816005128-5e6d627",
+  "rev": "5e6d627f519a791487e766aeee51eed7bf7129ef",
+  "hash": "sha256-VUJbXzX9U8so1g6yI3wYRN6A3Q4nq7ENSSfDM/PiKbE="
 }


### PR DESCRIPTION
Automated package bump for `[
  "openrgb_git"
]`.