### PR TITLE
chore: bump shadps4_git

### DIFF
--- a/pkgs/shadps4-git/manifest.json
+++ b/pkgs/shadps4-git/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260814165320-bed2fd8",
-  "rev": "bed2fd8d5f1481e84486204e0aaee80d2409b1c1",
-  "hash": "sha256-WriIX9xfKhCVp+zl4cb+VlASbCJ3qiNjlVXJTlzxtLY="
+  "version": "unstable-20260815230001-4cc54cd",
+  "rev": "4cc54cdadd3947bd88b379ac8e96a619ecec25bc",
+  "hash": "sha256-KN6O4qCfG1V9wUcNi767MNYksgGw83CNdw+/TdX22FA="
 }


### PR DESCRIPTION
Automated package bump for `[
  "shadps4_git"
]`.