### PR TITLE
pkgs: use stdenv.hostPlatform for platform attributes

### DIFF
--- a/pkgs/linux-cachyos/default.nix
+++ b/pkgs/linux-cachyos/default.nix
@@ -4,7 +4,7 @@
 }@inputs:
 
 let
-  inherit (final.stdenv) isx86_64 isLinux;
+  inherit (final.stdenv.hostPlatform) isx86_64 isLinux;
   inherit (final.lib.trivial) importJSON;
 
   # CachyOS repeating stuff.

--- a/pkgs/mangohud-git/default.nix
+++ b/pkgs/mangohud-git/default.nix
@@ -6,7 +6,7 @@
 }:
 
 let
-  inherit (final.stdenv) is32bit;
+  inherit (final.stdenv.hostPlatform) is32bit;
 
   # Subproject definitions from MangoHud master (rev 7f4201f86b6754dbeb8863e404b14e7356186d1c)
   imgui = rec {

--- a/pkgs/mesa-git/default.nix
+++ b/pkgs/mesa-git/default.nix
@@ -7,7 +7,7 @@
 }:
 
 let
-  inherit (final.stdenv) is32bit;
+  inherit (final.stdenv.hostPlatform) is32bit;
 
   packageCache = final64.callPackage ./package-cache-dir.nix { };
 


### PR DESCRIPTION
### :fish: What?

Updated direct platform attribute access on `stdenv` (`isx86_64`, `isLinux`, and `is32bit`) to use `stdenv.hostPlatform` instead across `pkgs/linux-cachyos`, `pkgs/mangohud-git`, and `pkgs/mesa-git`.

### :fishing_pole_and_fish: Why?

Direct platform checks on `stdenv` are deprecated in NixOS unstable in favor of `stdenv.hostPlatform`, causing evaluation warnings whenever these packages are evaluated during builds.

### :fish_cake: Pending

- [x] Complain with linter;

### :whale: Extras

None.