### PR TITLE
chore: bump openrgb_git

### DIFF
--- a/pkgs/openrgb-git/manifest.json
+++ b/pkgs/openrgb-git/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260816005128-5e6d627",
-  "rev": "5e6d627f519a791487e766aeee51eed7bf7129ef",
-  "hash": "sha256-VUJbXzX9U8so1g6yI3wYRN6A3Q4nq7ENSSfDM/PiKbE="
+  "version": "unstable-20260817003442-0262031",
+  "rev": "02620313f66464c4c0f65740ca6c6b1afc9ff1e6",
+  "hash": "sha256-QArlXGYRVwOlwYzAZEwlXVPP9hsfN4aD3LMQ2HhJuBU="
 }


### PR DESCRIPTION
Automated package bump for `[
  "openrgb_git"
]`.