### PR TITLE
chore: bump pcsx2_git

### DIFF
--- a/pkgs/pcsx2-git/manifest.json
+++ b/pkgs/pcsx2-git/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260810163519-2cf8dab",
-  "rev": "2cf8dabe6b2b5a0d92295eb869a78f2b9a764b6f",
-  "hash": "sha256-OkGgjPVLQerUJ09Gkb6Qt5WxkMf9i95wKLBTFTaFZoo="
+  "version": "unstable-20260815122615-cde2448",
+  "rev": "cde2448a6cd0d27f6651c59b43102d27dcb45e48",
+  "hash": "sha256-EeQFPFS0tQVlH6W5KrPJCCby8woJjNgfLGhQp7NDfkU="
 }


### PR DESCRIPTION
Automated package bump for `[
  "pcsx2_git"
]`.