### PR TITLE
chore: bump nix_git

### DIFF
--- a/pkgs/nix-git/manifest.json
+++ b/pkgs/nix-git/manifest.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260815210536-8eb792a",
-  "rev": "8eb792a484c6da9bfda7bf9b423ae177cd805b3e",
-  "hash": "sha256-4tnCb99rbbaj7Ed2pEqy1oL17NbgJqtOG3ve6MaKYVo=",
-  "lastModifiedDate": "20260815210536"
+  "version": "unstable-20260816204606-4401a29",
+  "rev": "4401a297ccfac829ee8915803f54315551cd5321",
+  "hash": "sha256-kl8WOawW0wPAzXtOaB3+HiFLel+wf+ugyWtsoK3yfGs=",
+  "lastModifiedDate": "20260816204606"
 }


### PR DESCRIPTION
Automated package bump for `[
  "nix_git"
]`.