### PR TITLE
chore: bump zed-editor_git

### DIFF
--- a/pkgs/zed-editor-git/manifest.json
+++ b/pkgs/zed-editor-git/manifest.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260815195510-bc538de",
-  "rev": "bc538def4545534201bbfcac4e95ac34ea6501b6",
-  "hash": "sha256-CuI8dYstUJxXPbPi4QtJDZvN6OURJu96l0lTbFHLvUE=",
-  "cargoHash": "sha256-8NsWrg9W3Se0MQ6kSdV/emZfG/6VPpX6ftPOYCAZgD8="
+  "version": "unstable-20260817014711-8968bf7",
+  "rev": "8968bf78084f30809aa2ce1574a3be68ed02a513",
+  "hash": "sha256-JJhiZZmB/FdUmJVUjvOrcpDihqrIhSsmByiMiQe94h0=",
+  "cargoHash": "sha256-qjKbA6hMjXH8eM668NDnhZF1nVrybUhob8Y0EvA8IqE="
 }


### PR DESCRIPTION
Automated package bump for `[
  "zed-editor_git"
]`.