### PR TITLE
chore: bump nss_git

### DIFF
--- a/pkgs/firefox-nightly/manifest.json
+++ b/pkgs/firefox-nightly/manifest.json
@@ -1,7 +1,7 @@
 {
   "version": "156.0a1",
-  "rev": "6d751cf5d0af4b7fcc1b232b6c2ba0551afabe1d",
-  "buildId": "20260815213849",
-  "hash": "sha256-DzMsW8KWu5fHgoHq2Zd1IXUe8LiHIcBNQjXDgluSsJk=",
+  "rev": "7c611117298561f542198076e70e641d4dd080bc",
+  "buildId": "20260816214904",
+  "hash": "sha256-6JeyTAZjMmt1iundygIRHtuIvK4rzkhWFjJzyKJOdk8=",
   "newtabNpmDepsHash": "sha256-6NhZWVpbB0kX3d+9QaxFIgGeCfhqusNTANI6pwROWWw="
 }


### PR DESCRIPTION
Automated package bump for `[
  "nss_git",
  "firefox-unwrapped_nightly"
]`.