### PR TITLE
chore: bump libdrm_git

### DIFF
--- a/pkgs/mesa-git/manifest.json
+++ b/pkgs/mesa-git/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260815122155-f0bcf54",
-  "rev": "f0bcf54488119f97502da9f4cca87a214e502a3e",
-  "hash": "sha256-K6728IMgVd9vhzsKIizsixyxxmmTepepcqcP4oB3rgo="
+  "version": "unstable-20260817011531-41fe6cb",
+  "rev": "41fe6cb36e2e50fa5f8610a8ed500de438fd5e4d",
+  "hash": "sha256-bWF0gXWExDpoEtHUGu2dxBh/4Yq+BTdRiBIPcks8+OY="
 }


### PR DESCRIPTION
Automated package bump for `[
  "libdrm_git",
  "wayland-protocols_git",
  "mesa_git",
  "wayland_git",
  "wlroots_git",
  "sway-unwrapped_git",
  "xdg-desktop-portal-wlr_git"
]`.