### PR TITLE
linux-cachyos: expose CONFIG_AMD_PRIVATE_COLOR when withPrivateHDR is enabled

### DIFF
--- a/pkgs/linux-cachyos/packages-for.nix
+++ b/pkgs/linux-cachyos/packages-for.nix
@@ -84,7 +84,11 @@ let
   kconfigToNix = inputs.final.callPackage ./lib/kconfig-to-nix.nix {
     configfile = preparedConfigfile;
   };
-  linuxConfigTransfomed = import configPath;
+  linuxConfigTransfomed =
+    (import configPath)
+    // (lib.optionalAttrs cachyConfig.withPrivateHDR {
+      "CONFIG_AMD_PRIVATE_COLOR" = "y";
+    });
 
   updaterScript =
     if withUpdateScript != null then


### PR DESCRIPTION
### :fish: What?

Expose `CONFIG_AMD_PRIVATE_COLOR = "y"` in `linuxConfigTransfomed` when `withPrivateHDR` is enabled.

### :fishing_pole_and_fish: Why?

Fixes #2369.

When `withPrivateHDR = true` is passed to `cachyOverride`, `prepare.nix` enables `AMD_PRIVATE_COLOR` in the kernel build configuration, but `linuxConfigTransfomed` was reading from static `configPath` (where `withPrivateHDR` is false). This resulted in `kernel.passthru.config.CONFIG_AMD_PRIVATE_COLOR` remaining unset and failing `chaotic.hdr` assertions.

### :fish_cake: Pending

- [x] Complain with linter;

### :whale: Extras

None.