### PR TITLE
treewide: fix remaining deprecation warnings

### DIFF
--- a/modules/common/nyx-overlay.nix
+++ b/modules/common/nyx-overlay.nix
@@ -18,7 +18,8 @@ let
   onTopOfUserPkgs = flakes.self.overlays.default;
 
   # Workaround because of https://github.com/NixOS/nixos-search/pull/803#issuecomment-2717855951
-  configType = if (options ? "nixpkgs") then options.nixpkgs.config.type else lib.types.attrs;
+  configType =
+    if (options ? "nixpkgs") then options.nixpkgs.config.type else lib.types.attrsOf lib.types.anything;
 in
 {
   options = with lib; {

--- a/pkgs/libdrm-git/default.nix
+++ b/pkgs/libdrm-git/default.nix
@@ -19,5 +19,5 @@ gitOverride (current: {
     owner = "mesa";
     repo = "drm";
   };
-  withUpdateScript = !final.stdenv.is32bit;
+  withUpdateScript = !final.stdenv.hostPlatform.is32bit;
 })

--- a/pkgs/mangohud-git/default.nix
+++ b/pkgs/mangohud-git/default.nix
@@ -68,7 +68,7 @@ gitOverride {
     repo = "MangoHud";
   };
   ref = "master";
-  withUpdateScript = !final.stdenv.is32bit;
+  withUpdateScript = !is32bit;
 
   postOverride = prevAttrs: {
     nativeBuildInputs = (prevAttrs.nativeBuildInputs or [ ]) ++ [


### PR DESCRIPTION
### :fish: What?

1. Replace remaining `final.stdenv.is32bit` accesses with `stdenv.hostPlatform.is32bit` in `pkgs/libdrm-git` and `pkgs/mangohud-git`;
2. Replace deprecated `lib.types.attrs` with `lib.types.attrsOf lib.types.anything` in `modules/common/nyx-overlay.nix`.

### :fishing_pole_and_fish: Why?

Follow-up to #2368. Direct platform attribute access on `stdenv` and `lib.types.attrs` are deprecated in NixOS unstable, causing evaluation warnings during builds.

### :fish_cake: Pending

- [x] Complain with linter;

### :whale: Extras

None.