### PR TITLE
chore: bump nix_git

### DIFF
--- a/pkgs/nix-git/manifest.json
+++ b/pkgs/nix-git/manifest.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260816204606-4401a29",
-  "rev": "4401a297ccfac829ee8915803f54315551cd5321",
-  "hash": "sha256-kl8WOawW0wPAzXtOaB3+HiFLel+wf+ugyWtsoK3yfGs=",
-  "lastModifiedDate": "20260816204606"
+  "version": "unstable-20260817230731-f6ac811",
+  "rev": "f6ac811ae5dd5bf8b0f58fc38928e67dd7f88826",
+  "hash": "sha256-uc6YHGJkCtgPSvv9hFUEQnDAOEfUmnZn0wJJm043ucI=",
+  "lastModifiedDate": "20260817230731"
 }


### PR DESCRIPTION
Automated package bump for `[
  "nix_git"
]`.