### PR TITLE
chore: bump openrgb_git

### DIFF
--- a/pkgs/openrgb-git/manifest.json
+++ b/pkgs/openrgb-git/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260817003442-0262031",
-  "rev": "02620313f66464c4c0f65740ca6c6b1afc9ff1e6",
-  "hash": "sha256-QArlXGYRVwOlwYzAZEwlXVPP9hsfN4aD3LMQ2HhJuBU="
+  "version": "unstable-20260818003755-550fa10",
+  "rev": "550fa1046e58ee1a94a6ae56eaba3ebbb8d133b3",
+  "hash": "sha256-DUmfowiEGPi9Gv5m4vXflv+dEtqeRsqpJ3XyXpMDpo0="
 }


### PR DESCRIPTION
Automated package bump for `[
  "openrgb_git"
]`.