### PR TITLE
chore: bump zed-editor_git

### DIFF
--- a/pkgs/zed-editor-git/manifest.json
+++ b/pkgs/zed-editor-git/manifest.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260817014711-8968bf7",
-  "rev": "8968bf78084f30809aa2ce1574a3be68ed02a513",
-  "hash": "sha256-JJhiZZmB/FdUmJVUjvOrcpDihqrIhSsmByiMiQe94h0=",
+  "version": "unstable-20260817225045-aa37186",
+  "rev": "aa3718614b3ade75524be6f8b2e101bd1166e02c",
+  "hash": "sha256-RwSxpaFNCk+hbbKo0nGFS26gLnoBQtTeg6PituCIxFs=",
   "cargoHash": "sha256-qjKbA6hMjXH8eM668NDnhZF1nVrybUhob8Y0EvA8IqE="
 }


### PR DESCRIPTION
Automated package bump for `[
  "zed-editor_git"
]`.