### PR TITLE
chore: bump libdrm_git

### DIFF
--- a/pkgs/mesa-git/manifest.json
+++ b/pkgs/mesa-git/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260817011531-41fe6cb",
-  "rev": "41fe6cb36e2e50fa5f8610a8ed500de438fd5e4d",
-  "hash": "sha256-bWF0gXWExDpoEtHUGu2dxBh/4Yq+BTdRiBIPcks8+OY="
+  "version": "unstable-20260818010842-c14545d",
+  "rev": "c14545d36aff5f21b3174ed6b4514926fff23606",
+  "hash": "sha256-S2urw1aj7FOG2PUMAuw0JSOftSO6GkcbgxU/q1Kg7jY="
 }

--- a/pkgs/wayland-git/manifest.json
+++ b/pkgs/wayland-git/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260803144724-ed0b9f1",
-  "rev": "ed0b9f17118653df9867b109fb521c59f09069ab",
-  "hash": "sha256-DUnMDMJwOXpyvlsBQ/2t+/LbsmeR1gKTv6jrVLnHQQQ="
+  "version": "unstable-20260817154057-28e0825",
+  "rev": "28e08252c7dfd71ebc31a0c006d3dad05b0b4c68",
+  "hash": "sha256-ihMVhKQ5iPtko9C1LDmaj+5wAtA09fifex1b+NRV6cU="
 }


### PR DESCRIPTION
Automated package bump for `[
  "libdrm_git",
  "wayland-protocols_git",
  "mesa_git",
  "wayland_git",
  "wlroots_git",
  "sway-unwrapped_git",
  "xdg-desktop-portal-wlr_git"
]`.