### PR TITLE
chore: bump shadps4_git

### DIFF
--- a/pkgs/shadps4-git/manifest.json
+++ b/pkgs/shadps4-git/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260815230001-4cc54cd",
-  "rev": "4cc54cdadd3947bd88b379ac8e96a619ecec25bc",
-  "hash": "sha256-KN6O4qCfG1V9wUcNi767MNYksgGw83CNdw+/TdX22FA="
+  "version": "unstable-20260817212218-0000a06",
+  "rev": "0000a06d8f94a0a33d153ee246536f0cb59eb0a6",
+  "hash": "sha256-v1EGw4zCpMUbmM5yvDC4J/lGnlCI6KdyVWcfTxVshhk="
 }


### PR DESCRIPTION
Automated package bump for `[
  "shadps4_git"
]`.