### PR TITLE
chore: bump nss_git

### DIFF
--- a/pkgs/firefox-nightly/manifest.json
+++ b/pkgs/firefox-nightly/manifest.json
@@ -1,7 +1,7 @@
 {
   "version": "156.0a1",
-  "rev": "7c611117298561f542198076e70e641d4dd080bc",
-  "buildId": "20260816214904",
-  "hash": "sha256-6JeyTAZjMmt1iundygIRHtuIvK4rzkhWFjJzyKJOdk8=",
+  "rev": "6fd3453f587cfcd74637bad0b7b67f3d4680e679",
+  "buildId": "20260817210808",
+  "hash": "sha256-76kSr0eyp6IahEKTYVAeosuiaCLXrLbe+j8aCjxKpQY=",
   "newtabNpmDepsHash": "sha256-6NhZWVpbB0kX3d+9QaxFIgGeCfhqusNTANI6pwROWWw="
 }

--- a/pkgs/nss-git/manifest.json
+++ b/pkgs/nss-git/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260813170106-e360927",
-  "rev": "e3609273b3ee3913d48ccd4ab8891ad549aa46e3",
-  "hash": "sha256-3jfVSk/YMIdq7BioD8UhgtxYR6tqXZ5HKGZMNmoJX0Q="
+  "version": "unstable-20260818010629-fd71b4f",
+  "rev": "fd71b4f3f67c358dd06e38deb0f4a5bf602a89af",
+  "hash": "sha256-nno2C8+NDHq4VjvAbrQyHvXg3w9F2Y3BJnHAw/qiHvM="
 }


### PR DESCRIPTION
Automated package bump for `[
  "nss_git",
  "firefox-unwrapped_nightly"
]`.