### PR TITLE
chore: bump nix_git

### DIFF
--- a/pkgs/nix-git/manifest.json
+++ b/pkgs/nix-git/manifest.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260817230731-f6ac811",
-  "rev": "f6ac811ae5dd5bf8b0f58fc38928e67dd7f88826",
-  "hash": "sha256-uc6YHGJkCtgPSvv9hFUEQnDAOEfUmnZn0wJJm043ucI=",
-  "lastModifiedDate": "20260817230731"
+  "version": "unstable-20260818233313-f15d42f",
+  "rev": "f15d42f6095faff5992d15bd0e9334442e94244d",
+  "hash": "sha256-XTnStVakRyzqXyZvb8GEG6nqeNm5iim3TG2TEomB8W4=",
+  "lastModifiedDate": "20260818233313"
 }


### PR DESCRIPTION
Automated package bump for `[
  "nix_git"
]`.