### PR TITLE
chore: bump niri_git

### DIFF
--- a/pkgs/niri-git/manifest.json
+++ b/pkgs/niri-git/manifest.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260814122556-6062844",
-  "rev": "606284464d4a99bb35710fee68192bc71085ee7c",
-  "hash": "sha256-ptAftnlkdXaVjEzA2e1DBM9NPPDOpHtsAhOI6KzY4NY=",
+  "version": "unstable-20260818151549-e9b215f",
+  "rev": "e9b215fef4b11ad36776553fb8bd45118ef03b03",
+  "hash": "sha256-uJKImwjqQ6Y+5b1IN93j6rEKGRoR0CsOuC/7vqluhJM=",
   "cargoHash": "sha256-aNovCzrTtmqTO33YtZap47npdN73zXC1bap5q5dZvZk="
 }


### PR DESCRIPTION
Automated package bump for `[
  "niri_git"
]`.