### PR TITLE
chore: bump openrgb_git

### DIFF
--- a/pkgs/openrgb-git/manifest.json
+++ b/pkgs/openrgb-git/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260818003755-550fa10",
-  "rev": "550fa1046e58ee1a94a6ae56eaba3ebbb8d133b3",
-  "hash": "sha256-DUmfowiEGPi9Gv5m4vXflv+dEtqeRsqpJ3XyXpMDpo0="
+  "version": "unstable-20260819001051-f027b7a",
+  "rev": "f027b7a312bbacccd09f027982abf7826602da8f",
+  "hash": "sha256-RdlvXgeVBnrMnOBh8wKj8YqwElA76stDdFHJQLbbj6s="
 }


### PR DESCRIPTION
Automated package bump for `[
  "openrgb_git"
]`.