### PR TITLE
chore: bump libdrm_git

### DIFF
--- a/pkgs/mesa-git/manifest.json
+++ b/pkgs/mesa-git/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260818010842-c14545d",
-  "rev": "c14545d36aff5f21b3174ed6b4514926fff23606",
-  "hash": "sha256-S2urw1aj7FOG2PUMAuw0JSOftSO6GkcbgxU/q1Kg7jY="
+  "version": "unstable-20260819005732-24c8a88",
+  "rev": "24c8a889798562010742bc58bb0fc9c6bdc4ed07",
+  "hash": "sha256-5GjOj8HHiEkF3ak6vBHQHWb4zXV7UxU932Itc452em0="
 }


### PR DESCRIPTION
Automated package bump for `[
  "libdrm_git",
  "wayland-protocols_git",
  "mesa_git",
  "wayland_git",
  "wlroots_git",
  "sway-unwrapped_git",
  "xdg-desktop-portal-wlr_git"
]`.