### PR TITLE
chore: bump zed-editor_git

### DIFF
--- a/pkgs/zed-editor-git/manifest.json
+++ b/pkgs/zed-editor-git/manifest.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260817225045-aa37186",
-  "rev": "aa3718614b3ade75524be6f8b2e101bd1166e02c",
-  "hash": "sha256-RwSxpaFNCk+hbbKo0nGFS26gLnoBQtTeg6PituCIxFs=",
-  "cargoHash": "sha256-qjKbA6hMjXH8eM668NDnhZF1nVrybUhob8Y0EvA8IqE="
+  "version": "unstable-20260819013841-7a7c3e1",
+  "rev": "7a7c3e1d2f03195c5fa19bc890da330ad7f3abef",
+  "hash": "sha256-JJkW7yVu/6O2yVvPXNQtm1abeaLwLaN2SxLrHOuv0oQ=",
+  "cargoHash": "sha256-RUIHLZOP691MPu0km9nvMcTuD4Xy3fAmWdptKM9zHHk="
 }


### PR DESCRIPTION
Automated package bump for `[
  "zed-editor_git"
]`.