### PR TITLE
chore: bump shadps4_git

### DIFF
--- a/pkgs/shadps4-git/manifest.json
+++ b/pkgs/shadps4-git/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260817212218-0000a06",
-  "rev": "0000a06d8f94a0a33d153ee246536f0cb59eb0a6",
-  "hash": "sha256-v1EGw4zCpMUbmM5yvDC4J/lGnlCI6KdyVWcfTxVshhk="
+  "version": "unstable-20260818213612-46ae080",
+  "rev": "46ae0800384179d9686e78e4e2f7a31f21430210",
+  "hash": "sha256-25pCnWaEskzURmgCVaH+8dTTF8iT1iwufVViH9jmxFs="
 }


### PR DESCRIPTION
Automated package bump for `[
  "shadps4_git"
]`.