### PR TITLE
chore: bump nss_git

### DIFF
--- a/pkgs/firefox-nightly/manifest.json
+++ b/pkgs/firefox-nightly/manifest.json
@@ -1,7 +1,7 @@
 {
   "version": "156.0a1",
-  "rev": "6fd3453f587cfcd74637bad0b7b67f3d4680e679",
-  "buildId": "20260817210808",
-  "hash": "sha256-76kSr0eyp6IahEKTYVAeosuiaCLXrLbe+j8aCjxKpQY=",
+  "rev": "b0bc20aac45f7cb55b18adbf4d2313457659d140",
+  "buildId": "20260818092026",
+  "hash": "sha256-fcRi2UoAGPWOGKr9WMmaB/MQO5h+MRHVFXcEuXXd4/A=",
   "newtabNpmDepsHash": "sha256-6NhZWVpbB0kX3d+9QaxFIgGeCfhqusNTANI6pwROWWw="
 }

--- a/pkgs/nss-git/manifest.json
+++ b/pkgs/nss-git/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260818010629-fd71b4f",
-  "rev": "fd71b4f3f67c358dd06e38deb0f4a5bf602a89af",
-  "hash": "sha256-nno2C8+NDHq4VjvAbrQyHvXg3w9F2Y3BJnHAw/qiHvM="
+  "version": "unstable-20260818223737-d41ffa9",
+  "rev": "d41ffa901a914af1a1394083186d950c0308ac3d",
+  "hash": "sha256-ltbdNLmQxsh+tTQenaMrsIMcCyuDph8Id8qsXKQogSg="
 }


### PR DESCRIPTION
Automated package bump for `[
  "nss_git",
  "firefox-unwrapped_nightly"
]`.