### PR TITLE
chore: bump openrgb_git

### DIFF
--- a/pkgs/openrgb-git/manifest.json
+++ b/pkgs/openrgb-git/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260819001051-f027b7a",
-  "rev": "f027b7a312bbacccd09f027982abf7826602da8f",
-  "hash": "sha256-RdlvXgeVBnrMnOBh8wKj8YqwElA76stDdFHJQLbbj6s="
+  "version": "unstable-20260819184354-eebe4dd",
+  "rev": "eebe4dd0dd59191b0d6b1f81696575fa38f2d8c5",
+  "hash": "sha256-1xqkuTGDh8q+6Xej+dWkyd52aKeEckBwCNYIvQEdEmY="
 }


### PR DESCRIPTION
Automated package bump for `[
  "openrgb_git"
]`.