### PR TITLE
chore: bump nix_git

### DIFF
--- a/pkgs/nix-git/manifest.json
+++ b/pkgs/nix-git/manifest.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260818233313-f15d42f",
-  "rev": "f15d42f6095faff5992d15bd0e9334442e94244d",
-  "hash": "sha256-XTnStVakRyzqXyZvb8GEG6nqeNm5iim3TG2TEomB8W4=",
-  "lastModifiedDate": "20260818233313"
+  "version": "unstable-20260819235734-b2c0502",
+  "rev": "b2c05023da75b852fbf3edf8a9266d55711610f9",
+  "hash": "sha256-+JXcAKdTMmGsxeDbSShxWdG+ECGK/A1rJImyT2zybJY=",
+  "lastModifiedDate": "20260819235734"
 }


### PR DESCRIPTION
Automated package bump for `[
  "nix_git"
]`.