### PR TITLE
chore: bump qtile-module_git

### DIFF
--- a/pkgs/qtile-git/manifest.json
+++ b/pkgs/qtile-git/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260811180847-22f9cf6",
-  "rev": "22f9cf6fbc01a0124ec7e21c53c9f32729ac223f",
-  "hash": "sha256-ULT5eYnGJdRyno5ctV+QpOnxKKMmnZGMVmT/L4A0tYw="
+  "version": "unstable-20260819075100-287dcec",
+  "rev": "287dcec7a6dc99dab9344af5b83a3cdb883894bc",
+  "hash": "sha256-kH2LtcCsZcxzutbRkDcnib/YXkblkV+FoG3h4QwuMwk="
 }


### PR DESCRIPTION
Automated package bump for `[
  "qtile-module_git"
]`.