### PR TITLE
chore: bump niri_git

### DIFF
--- a/pkgs/niri-git/manifest.json
+++ b/pkgs/niri-git/manifest.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260818151549-e9b215f",
-  "rev": "e9b215fef4b11ad36776553fb8bd45118ef03b03",
-  "hash": "sha256-uJKImwjqQ6Y+5b1IN93j6rEKGRoR0CsOuC/7vqluhJM=",
+  "version": "unstable-20260819083147-b0eb8ad",
+  "rev": "b0eb8ad8c80094de34abd88c109aea421461622b",
+  "hash": "sha256-dzLsp/FvMerhsjfsWtFK/BTlJ5FZwLWlhsFJRRxpmbU=",
   "cargoHash": "sha256-aNovCzrTtmqTO33YtZap47npdN73zXC1bap5q5dZvZk="
 }


### PR DESCRIPTION
Automated package bump for `[
  "niri_git"
]`.