### PR TITLE
chore: bump libdrm_git

### DIFF
--- a/pkgs/mesa-git/manifest.json
+++ b/pkgs/mesa-git/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260819005732-24c8a88",
-  "rev": "24c8a889798562010742bc58bb0fc9c6bdc4ed07",
-  "hash": "sha256-5GjOj8HHiEkF3ak6vBHQHWb4zXV7UxU932Itc452em0="
+  "version": "unstable-20260820012347-c7432ef",
+  "rev": "c7432ef5b912d1bebec4624b96cb90c131bd5aca",
+  "hash": "sha256-rjwXIE/6R07w3ZGHd3kHlM1tYW8a4IizBI1WOHYKwt0="
 }

--- a/pkgs/wlroots-git/manifest.json
+++ b/pkgs/wlroots-git/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260814135945-012ca82",
-  "rev": "012ca825e326ba3ec9dc5c2a0c81f08851405563",
-  "hash": "sha256-eq0pBV9W2raEZT83QJpXQy76TL3j5eZLWBdBXVxAl1g="
+  "version": "unstable-20260819075337-0288763",
+  "rev": "0288763a5353baea0da9d9d83698413f46c9680b",
+  "hash": "sha256-bNAwEax3wq8KGkW4Fgyd+c0ERmGrp5RnNFz2GrNAdN4="
 }


### PR DESCRIPTION
Automated package bump for `[
  "libdrm_git",
  "wayland-protocols_git",
  "mesa_git",
  "wayland_git",
  "wlroots_git",
  "sway-unwrapped_git",
  "xdg-desktop-portal-wlr_git"
]`.