### PR TITLE
chore: bump nss_git

### DIFF
--- a/pkgs/firefox-nightly/manifest.json
+++ b/pkgs/firefox-nightly/manifest.json
@@ -1,7 +1,7 @@
 {
   "version": "156.0a1",
-  "rev": "b0bc20aac45f7cb55b18adbf4d2313457659d140",
-  "buildId": "20260818092026",
-  "hash": "sha256-fcRi2UoAGPWOGKr9WMmaB/MQO5h+MRHVFXcEuXXd4/A=",
+  "rev": "ad5db99e4d2e00e9b5db2700c69050d709c7f340",
+  "buildId": "20260819210808",
+  "hash": "sha256-D/EYKjh82ZRbrJ2do4E0obYkbnpMoaINMDSWsuipkwM=",
   "newtabNpmDepsHash": "sha256-6NhZWVpbB0kX3d+9QaxFIgGeCfhqusNTANI6pwROWWw="
 }

--- a/pkgs/nss-git/manifest.json
+++ b/pkgs/nss-git/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260818223737-d41ffa9",
-  "rev": "d41ffa901a914af1a1394083186d950c0308ac3d",
-  "hash": "sha256-ltbdNLmQxsh+tTQenaMrsIMcCyuDph8Id8qsXKQogSg="
+  "version": "unstable-20260819225631-e8f520b",
+  "rev": "e8f520b526c6b913d5a5cdb65b47900348c1db9a",
+  "hash": "sha256-gb1TLj13H8yRSp/T3phCM3FpeSfc337+69nstWQIs/4="
 }


### PR DESCRIPTION
Automated package bump for `[
  "nss_git",
  "firefox-unwrapped_nightly"
]`.