### PR TITLE
chore: bump zed-editor_git

### DIFF
--- a/pkgs/zed-editor-git/manifest.json
+++ b/pkgs/zed-editor-git/manifest.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260819013841-7a7c3e1",
-  "rev": "7a7c3e1d2f03195c5fa19bc890da330ad7f3abef",
-  "hash": "sha256-JJkW7yVu/6O2yVvPXNQtm1abeaLwLaN2SxLrHOuv0oQ=",
-  "cargoHash": "sha256-RUIHLZOP691MPu0km9nvMcTuD4Xy3fAmWdptKM9zHHk="
+  "version": "unstable-20260820004805-32a0e81",
+  "rev": "32a0e813a5132ee66b2cbc47d64b4c36b409f7f3",
+  "hash": "sha256-3k1iVY+nuilpWC4Dl7gGZn6++7NsbZmlHH/ovvDbwuE=",
+  "cargoHash": "sha256-1alxztJQfIMaB3fXzlxM4773RDAY//PPeJmJVeplKf4="
 }


### PR DESCRIPTION
Automated package bump for `[
  "zed-editor_git"
]`.