### PR TITLE
chore: bump shadps4_git

### DIFF
--- a/pkgs/shadps4-git/manifest.json
+++ b/pkgs/shadps4-git/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260818213612-46ae080",
-  "rev": "46ae0800384179d9686e78e4e2f7a31f21430210",
-  "hash": "sha256-25pCnWaEskzURmgCVaH+8dTTF8iT1iwufVViH9jmxFs="
+  "version": "unstable-20260819214816-fff4431",
+  "rev": "fff44315237e2f424db8379e9383fb5c0978c8cf",
+  "hash": "sha256-nGy2HTOKuCtIyslK70ltlMZlR1qdoXmdBqcgS0MDfBo="
 }


### PR DESCRIPTION
Automated package bump for `[
  "shadps4_git"
]`.