### PR TITLE
chore: bump nix_git

### DIFF
--- a/pkgs/nix-git/manifest.json
+++ b/pkgs/nix-git/manifest.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260819235734-b2c0502",
-  "rev": "b2c05023da75b852fbf3edf8a9266d55711610f9",
-  "hash": "sha256-+JXcAKdTMmGsxeDbSShxWdG+ECGK/A1rJImyT2zybJY=",
-  "lastModifiedDate": "20260819235734"
+  "version": "unstable-20260821010506-649e823",
+  "rev": "649e823fb24ed118d72e613be35fa8ea1b64afe7",
+  "hash": "sha256-Qg9f9td5iphUWSQS6zmvyZWO1F+D7j8Z3U6dGyUTg08=",
+  "lastModifiedDate": "20260821010506"
 }


### PR DESCRIPTION
Automated package bump for `[
  "nix_git"
]`.