### PR TITLE
chore: bump openrgb_git

### DIFF
--- a/pkgs/openrgb-git/manifest.json
+++ b/pkgs/openrgb-git/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260819184354-eebe4dd",
-  "rev": "eebe4dd0dd59191b0d6b1f81696575fa38f2d8c5",
-  "hash": "sha256-1xqkuTGDh8q+6Xej+dWkyd52aKeEckBwCNYIvQEdEmY="
+  "version": "unstable-20260820164339-5795280",
+  "rev": "5795280b49e52e9c5553d6aa97f0415f1e27b7b3",
+  "hash": "sha256-fXnY4N4QRjFNpVUG32JgSurKHlOt8AAeCVF3rkDUZeY="
 }


### PR DESCRIPTION
Automated package bump for `[
  "openrgb_git"
]`.