### PR TITLE
chore: bump shadps4_git

### DIFF
--- a/pkgs/shadps4-git/manifest.json
+++ b/pkgs/shadps4-git/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260819214816-fff4431",
-  "rev": "fff44315237e2f424db8379e9383fb5c0978c8cf",
-  "hash": "sha256-nGy2HTOKuCtIyslK70ltlMZlR1qdoXmdBqcgS0MDfBo="
+  "version": "unstable-20260820184818-e4ff203",
+  "rev": "e4ff203093dd1ab452fd401e6a0ccc2e5cbe6c00",
+  "hash": "sha256-9LJj2jZbKXQQthWV/J/+kuN2IpqCZZ8l8p3sh/t+ZBA="
 }


### PR DESCRIPTION
Automated package bump for `[
  "shadps4_git"
]`.