### PR TITLE
chore: bump libdrm_git

### DIFF
--- a/pkgs/mesa-git/manifest.json
+++ b/pkgs/mesa-git/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260820012347-c7432ef",
-  "rev": "c7432ef5b912d1bebec4624b96cb90c131bd5aca",
-  "hash": "sha256-rjwXIE/6R07w3ZGHd3kHlM1tYW8a4IizBI1WOHYKwt0="
+  "version": "unstable-20260821013812-d2e56df",
+  "rev": "d2e56dfcda6383956d8a3297a3ac9879bd9a9e35",
+  "hash": "sha256-M6nDXTey6+W7lcEhdJBHXiKh3/2+RjqGPevz5sTtRP4="
 }


### PR DESCRIPTION
Automated package bump for `[
  "libdrm_git",
  "wayland-protocols_git",
  "mesa_git",
  "wayland_git",
  "wlroots_git",
  "sway-unwrapped_git",
  "xdg-desktop-portal-wlr_git"
]`.