### PR TITLE
chore: bump nss_git

### DIFF
--- a/pkgs/firefox-nightly/manifest.json
+++ b/pkgs/firefox-nightly/manifest.json
@@ -1,7 +1,7 @@
 {
   "version": "156.0a1",
-  "rev": "ad5db99e4d2e00e9b5db2700c69050d709c7f340",
-  "buildId": "20260819210808",
-  "hash": "sha256-D/EYKjh82ZRbrJ2do4E0obYkbnpMoaINMDSWsuipkwM=",
+  "rev": "04b29f9c2d2dbf5639c3f45ea812bb4c21dc81c6",
+  "buildId": "20260820214844",
+  "hash": "sha256-p7/85aCSOUk9i8jtQX06pqbcAMksuiMgfkqXOLlBNLM=",
   "newtabNpmDepsHash": "sha256-6NhZWVpbB0kX3d+9QaxFIgGeCfhqusNTANI6pwROWWw="
 }

--- a/pkgs/nss-git/manifest.json
+++ b/pkgs/nss-git/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260819225631-e8f520b",
-  "rev": "e8f520b526c6b913d5a5cdb65b47900348c1db9a",
-  "hash": "sha256-gb1TLj13H8yRSp/T3phCM3FpeSfc337+69nstWQIs/4="
+  "version": "unstable-20260820200451-840912d",
+  "rev": "840912db6779433947b0b513c4e28eb659422857",
+  "hash": "sha256-ABPXDX49D6j8W6WJrZIotuagMRxZjgGcBAYB9HEd6yc="
 }


### PR DESCRIPTION
Automated package bump for `[
  "nss_git",
  "firefox-unwrapped_nightly"
]`.