### PR TITLE
chore: bump zed-editor_git

### DIFF
--- a/pkgs/zed-editor-git/manifest.json
+++ b/pkgs/zed-editor-git/manifest.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260820004805-32a0e81",
-  "rev": "32a0e813a5132ee66b2cbc47d64b4c36b409f7f3",
-  "hash": "sha256-3k1iVY+nuilpWC4Dl7gGZn6++7NsbZmlHH/ovvDbwuE=",
-  "cargoHash": "sha256-1alxztJQfIMaB3fXzlxM4773RDAY//PPeJmJVeplKf4="
+  "version": "unstable-20260820220943-91bf967",
+  "rev": "91bf967e279fba3b326c096aeb66053cb2373547",
+  "hash": "sha256-RL3f9m81U6Ntpk2NpX420zm9Z8hkbzhnizGVDP1Rthw=",
+  "cargoHash": "sha256-HpGhYdLHzF53X6sKMmZoe57hw8/rklo5oYaRMMER0Tg="
 }


### PR DESCRIPTION
Automated package bump for `[
  "zed-editor_git"
]`.