### PR TITLE
chore: bump pcsx2_git

### DIFF
--- a/pkgs/pcsx2-git/manifest.json
+++ b/pkgs/pcsx2-git/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260819120041-6db638d",
-  "rev": "6db638dc0373769b4c5d5b5dd7ed6da641b9a18e",
-  "hash": "sha256-qhilQvZUVQ+9mX5NUcw33J1lu4RDzSxXYS0fqAdqoxI="
+  "version": "unstable-20260821175723-3e29183",
+  "rev": "3e29183a37e74cbc8c17bda8afb63c2d9bc6fd14",
+  "hash": "sha256-Nyhb521rQ5+wG/eRUsHrCeLGAhYXsl351U9m9O0olvM="
 }


### PR DESCRIPTION
Automated package bump for `[
  "pcsx2_git"
]`.