### PR TITLE
chore: bump niri_git

### DIFF
--- a/pkgs/niri-git/manifest.json
+++ b/pkgs/niri-git/manifest.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260819083147-b0eb8ad",
-  "rev": "b0eb8ad8c80094de34abd88c109aea421461622b",
-  "hash": "sha256-dzLsp/FvMerhsjfsWtFK/BTlJ5FZwLWlhsFJRRxpmbU=",
+  "version": "unstable-20260821184624-dd75865",
+  "rev": "dd75865f547f0eac0e9b6c4d86d2cd00c0744252",
+  "hash": "sha256-BNZUEVR2H96hCKENNKoLSSTFT8W4smp7v94hJc4Ehfc=",
   "cargoHash": "sha256-aNovCzrTtmqTO33YtZap47npdN73zXC1bap5q5dZvZk="
 }


### PR DESCRIPTION
Automated package bump for `[
  "niri_git"
]`.