### PR TITLE
chore: bump openrgb_git

### DIFF
--- a/pkgs/openrgb-git/manifest.json
+++ b/pkgs/openrgb-git/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260820164339-5795280",
-  "rev": "5795280b49e52e9c5553d6aa97f0415f1e27b7b3",
-  "hash": "sha256-fXnY4N4QRjFNpVUG32JgSurKHlOt8AAeCVF3rkDUZeY="
+  "version": "unstable-20260821190135-b93fe2a",
+  "rev": "b93fe2a0584cc36ebc454644c2e3496321f47209",
+  "hash": "sha256-xUYlh6Wq/dGJUdl06ZdXm3fuBZa27nrPcTFkkWxeTYM="
 }


### PR DESCRIPTION
Automated package bump for `[
  "openrgb_git"
]`.