### PR TITLE
chore: bump libdrm_git

### DIFF
--- a/pkgs/mesa-git/manifest.json
+++ b/pkgs/mesa-git/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260821013812-d2e56df",
-  "rev": "d2e56dfcda6383956d8a3297a3ac9879bd9a9e35",
-  "hash": "sha256-M6nDXTey6+W7lcEhdJBHXiKh3/2+RjqGPevz5sTtRP4="
+  "version": "unstable-20260821210437-00e42c5",
+  "rev": "00e42c51b10d8e0769489156fa414f111897d515",
+  "hash": "sha256-fW9RDInG7zBtXR1UolAijKxv6GBTALxsD60uu76NwQQ="
 }

--- a/pkgs/wlroots-git/manifest.json
+++ b/pkgs/wlroots-git/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260819075337-0288763",
-  "rev": "0288763a5353baea0da9d9d83698413f46c9680b",
-  "hash": "sha256-bNAwEax3wq8KGkW4Fgyd+c0ERmGrp5RnNFz2GrNAdN4="
+  "version": "unstable-20260819123543-329a88e",
+  "rev": "329a88e72424486180ff3339440fa9f8f711af02",
+  "hash": "sha256-f7Bgszop3boeEfvfLDcByDyK8eAnvLWRVmFbk1a8RO0="
 }


### PR DESCRIPTION
Automated package bump for `[
  "libdrm_git",
  "wayland-protocols_git",
  "mesa_git",
  "wayland_git",
  "wlroots_git",
  "sway-unwrapped_git",
  "xdg-desktop-portal-wlr_git"
]`.