### PR TITLE
chore: bump zed-editor_git

### DIFF
--- a/pkgs/zed-editor-git/manifest.json
+++ b/pkgs/zed-editor-git/manifest.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260820220943-91bf967",
-  "rev": "91bf967e279fba3b326c096aeb66053cb2373547",
-  "hash": "sha256-RL3f9m81U6Ntpk2NpX420zm9Z8hkbzhnizGVDP1Rthw=",
-  "cargoHash": "sha256-HpGhYdLHzF53X6sKMmZoe57hw8/rklo5oYaRMMER0Tg="
+  "version": "unstable-20260821213155-fd82517",
+  "rev": "fd82517a115d97a07835b52f0512b22b38e38ccf",
+  "hash": "sha256-reR0OSQXSnDocPZ6t8BVMXyHp9nyegIhvwLwFRNiSH8=",
+  "cargoHash": "sha256-Le7txmbo/EfFcBBbAZj7LGVFgn5aAemvYMStysX26Mc="
 }


### PR DESCRIPTION
Automated package bump for `[
  "zed-editor_git"
]`.