### PR TITLE
chore: bump shadps4_git

### DIFF
--- a/pkgs/shadps4-git/manifest.json
+++ b/pkgs/shadps4-git/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260820184818-e4ff203",
-  "rev": "e4ff203093dd1ab452fd401e6a0ccc2e5cbe6c00",
-  "hash": "sha256-9LJj2jZbKXQQthWV/J/+kuN2IpqCZZ8l8p3sh/t+ZBA="
+  "version": "unstable-20260821162712-500f413",
+  "rev": "500f413735595a8c6d0c2dac5ad93568aeb04c1b",
+  "hash": "sha256-ikgIIhTvxB9RcvgWrTAM7bCzcGc9bDI2lr2LM8yXpVQ="
 }


### PR DESCRIPTION
Automated package bump for `[
  "shadps4_git"
]`.