### PR TITLE
chore: bump tde2e_git

### DIFF
--- a/pkgs/tdlib-git/manifest.json
+++ b/pkgs/tdlib-git/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260717141848-022d602",
-  "rev": "022d60202e446ad1287b9fb68e687c8a0760788b",
-  "hash": "sha256-jO/9S3G0F25AInn9H3sw6KrLOKVmTQV+AxIPo5dzpBg="
+  "version": "unstable-20260824164527-d1085f9",
+  "rev": "d1085f9cebc5a62379991ae1652673954f229c1f",
+  "hash": "sha256-knrR1ppu+M7ib3UssWeoEdgRt+GkV3MbEcCVpeEoLxc="
 }

--- a/pkgs/telegram-desktop-git/manifest.json
+++ b/pkgs/telegram-desktop-git/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260807064826-8e18cb7",
-  "rev": "8e18cb71103d83d7d98994ff27f0a2bca55c489c",
-  "hash": "sha256-CYm1JTpCYgPKmmDQB9ibKu08BlY3P+3oC4W+2y/4y5c="
+  "version": "unstable-20260824201506-baef81d",
+  "rev": "baef81d583c26b02adc3c15aecf1a9c23ce1ec29",
+  "hash": "sha256-4RYUG0DEQyblcg/OAZvjS8LGxy22fa9pHj9BfjIMylU="
 }


### PR DESCRIPTION
Automated package bump for `[
  "tde2e_git",
  "tg-owt_git",
  "telegram-desktop-unwrapped_git",
  "telegram-desktop_git"
]`.