### PR TITLE
chore: bump nss_git

### DIFF
--- a/pkgs/firefox-nightly/manifest.json
+++ b/pkgs/firefox-nightly/manifest.json
@@ -1,7 +1,7 @@
 {
   "version": "156.0a1",
-  "rev": "04b29f9c2d2dbf5639c3f45ea812bb4c21dc81c6",
-  "buildId": "20260820214844",
-  "hash": "sha256-p7/85aCSOUk9i8jtQX06pqbcAMksuiMgfkqXOLlBNLM=",
+  "rev": "22598deb7560ad7baef8c8f5082dcfc1e92efd54",
+  "buildId": "20260821213723",
+  "hash": "sha256-KHKSKnm/6DXE864gaiF1UglpqLMhQ2AnVtRyrSQ2i6M=",
   "newtabNpmDepsHash": "sha256-6NhZWVpbB0kX3d+9QaxFIgGeCfhqusNTANI6pwROWWw="
 }

--- a/pkgs/nss-git/manifest.json
+++ b/pkgs/nss-git/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260820200451-840912d",
-  "rev": "840912db6779433947b0b513c4e28eb659422857",
-  "hash": "sha256-ABPXDX49D6j8W6WJrZIotuagMRxZjgGcBAYB9HEd6yc="
+  "version": "unstable-20260821083530-6ca13d9",
+  "rev": "6ca13d99c4a3517d84a0b68a7a7132821d3e0591",
+  "hash": "sha256-c2exHTl8Tiuc7pFHeveW5PvjRtFMGnZQ76PCPOYYHc8="
 }


### PR DESCRIPTION
Automated package bump for `[
  "nss_git",
  "firefox-unwrapped_nightly"
]`.