### PR TITLE
chore: bump openrgb_git

### DIFF
--- a/pkgs/openrgb-git/manifest.json
+++ b/pkgs/openrgb-git/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260821190135-b93fe2a",
-  "rev": "b93fe2a0584cc36ebc454644c2e3496321f47209",
-  "hash": "sha256-xUYlh6Wq/dGJUdl06ZdXm3fuBZa27nrPcTFkkWxeTYM="
+  "version": "unstable-20260822171749-3b4a660",
+  "rev": "3b4a66096a3c6b5486ae4854f7afdf009249b294",
+  "hash": "sha256-3nryHpQcM7ml7gpKh20XMdOOoe8W6ld1sfZyrMFAtXA="
 }


### PR DESCRIPTION
Automated package bump for `[
  "openrgb_git"
]`.