### PR TITLE
chore: bump nix_git

### DIFF
--- a/pkgs/nix-git/manifest.json
+++ b/pkgs/nix-git/manifest.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260821010506-649e823",
-  "rev": "649e823fb24ed118d72e613be35fa8ea1b64afe7",
-  "hash": "sha256-Qg9f9td5iphUWSQS6zmvyZWO1F+D7j8Z3U6dGyUTg08=",
-  "lastModifiedDate": "20260821010506"
+  "version": "unstable-20260822103449-88b09c6",
+  "rev": "88b09c64fbea076a0376830d98e5331f70ed31a3",
+  "hash": "sha256-qtDusLx9yn0aME9D9Oe5QhFnmDUaARwMJo/vt4+DtIU=",
+  "lastModifiedDate": "20260822103449"
 }


### PR DESCRIPTION
Automated package bump for `[
  "nix_git"
]`.