### PR TITLE
chore: bump zed-editor_git

### DIFF
--- a/pkgs/zed-editor-git/manifest.json
+++ b/pkgs/zed-editor-git/manifest.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260821213155-fd82517",
-  "rev": "fd82517a115d97a07835b52f0512b22b38e38ccf",
-  "hash": "sha256-reR0OSQXSnDocPZ6t8BVMXyHp9nyegIhvwLwFRNiSH8=",
+  "version": "unstable-20260822205812-d9ad6af",
+  "rev": "d9ad6aff67e47de43abb270d22de75dd950f1b48",
+  "hash": "sha256-McpqJGvHyd+2A/Hb+BOZiDO2hc/lA4hFUQXP+tEGTJM=",
   "cargoHash": "sha256-Le7txmbo/EfFcBBbAZj7LGVFgn5aAemvYMStysX26Mc="
 }


### PR DESCRIPTION
Automated package bump for `[
  "zed-editor_git"
]`.