### PR TITLE
chore: bump libdrm_git

### DIFF
--- a/pkgs/mesa-git/manifest.json
+++ b/pkgs/mesa-git/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260821210437-00e42c5",
-  "rev": "00e42c51b10d8e0769489156fa414f111897d515",
-  "hash": "sha256-fW9RDInG7zBtXR1UolAijKxv6GBTALxsD60uu76NwQQ="
+  "version": "unstable-20260822120728-ebcfbe6",
+  "rev": "ebcfbe601daeb0eb2854e5a3da7f6f3b597b4976",
+  "hash": "sha256-FlwpiGMeoET02M838x9j8NJBrqOOg/HyrOmqdSXN4sc="
 }


### PR DESCRIPTION
Automated package bump for `[
  "libdrm_git",
  "wayland-protocols_git",
  "mesa_git",
  "wayland_git",
  "wlroots_git",
  "sway-unwrapped_git",
  "xdg-desktop-portal-wlr_git"
]`.