### PR TITLE
chore: bump nss_git

### DIFF
--- a/pkgs/firefox-nightly/manifest.json
+++ b/pkgs/firefox-nightly/manifest.json
@@ -1,7 +1,7 @@
 {
   "version": "156.0a1",
-  "rev": "22598deb7560ad7baef8c8f5082dcfc1e92efd54",
-  "buildId": "20260821213723",
-  "hash": "sha256-KHKSKnm/6DXE864gaiF1UglpqLMhQ2AnVtRyrSQ2i6M=",
+  "rev": "44e151427db27db6b789e3be5439f0edbcf446de",
+  "buildId": "20260822212138",
+  "hash": "sha256-kAiVDEGJf+QA+RTTYFIPY4c9d3DIRLNZ5T9iwgjO/aU=",
   "newtabNpmDepsHash": "sha256-6NhZWVpbB0kX3d+9QaxFIgGeCfhqusNTANI6pwROWWw="
 }


### PR DESCRIPTION
Automated package bump for `[
  "nss_git",
  "firefox-unwrapped_nightly"
]`.