### PR TITLE
chore: bump shadps4_git

### DIFF
--- a/pkgs/shadps4-git/manifest.json
+++ b/pkgs/shadps4-git/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260821162712-500f413",
-  "rev": "500f413735595a8c6d0c2dac5ad93568aeb04c1b",
-  "hash": "sha256-ikgIIhTvxB9RcvgWrTAM7bCzcGc9bDI2lr2LM8yXpVQ="
+  "version": "unstable-20260822204204-f512999",
+  "rev": "f51299942c6f98159232ce69840cd06cd26431fc",
+  "hash": "sha256-RNM1aS2Tls/4rFR8Jg+CfL3No1uVsQHYzrHI/h4a1dw="
 }


### PR DESCRIPTION
Automated package bump for `[
  "shadps4_git"
]`.