### PR TITLE
chore: bump libdrm_git

### DIFF
--- a/pkgs/mesa-git/manifest.json
+++ b/pkgs/mesa-git/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260822120728-ebcfbe6",
-  "rev": "ebcfbe601daeb0eb2854e5a3da7f6f3b597b4976",
-  "hash": "sha256-FlwpiGMeoET02M838x9j8NJBrqOOg/HyrOmqdSXN4sc="
+  "version": "unstable-20260823183642-899977f",
+  "rev": "899977f924d3af8de70f213a59c4c3731c68bcea",
+  "hash": "sha256-lw6uYpHbIMVBRNUqnJUsTXMJFiv/s0ukDGOTBuF8A9w="
 }


### PR DESCRIPTION
Automated package bump for `[
  "libdrm_git",
  "wayland-protocols_git",
  "mesa_git",
  "wayland_git",
  "wlroots_git",
  "sway-unwrapped_git",
  "xdg-desktop-portal-wlr_git"
]`.