### PR TITLE
chore: bump openrgb_git

### DIFF
--- a/pkgs/openrgb-git/manifest.json
+++ b/pkgs/openrgb-git/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260822171749-3b4a660",
-  "rev": "3b4a66096a3c6b5486ae4854f7afdf009249b294",
-  "hash": "sha256-3nryHpQcM7ml7gpKh20XMdOOoe8W6ld1sfZyrMFAtXA="
+  "version": "unstable-20260823204234-9695f9d",
+  "rev": "9695f9d00b3a3a958cd7f5d92fe96f85bd26f6cb",
+  "hash": "sha256-cdU1L6SV+VnFq0Th9fZKW4PRWxuxr7FBuaNmmJo4FPY="
 }


### PR DESCRIPTION
Automated package bump for `[
  "openrgb_git"
]`.