### PR TITLE
chore: bump nix_git

### DIFF
--- a/pkgs/nix-git/manifest.json
+++ b/pkgs/nix-git/manifest.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260822103449-88b09c6",
-  "rev": "88b09c64fbea076a0376830d98e5331f70ed31a3",
-  "hash": "sha256-qtDusLx9yn0aME9D9Oe5QhFnmDUaARwMJo/vt4+DtIU=",
-  "lastModifiedDate": "20260822103449"
+  "version": "unstable-20260823233217-1036b10",
+  "rev": "1036b10ba5051c891d5c9dbf8795ce118bf40467",
+  "hash": "sha256-aDUcV63TOTGiBaLq69He+DkGEpTZaSq3wasLTCnnqbc=",
+  "lastModifiedDate": "20260823233217"
 }


### PR DESCRIPTION
Automated package bump for `[
  "nix_git"
]`.