### PR TITLE
chore: bump zed-editor_git

### DIFF
--- a/pkgs/zed-editor-git/manifest.json
+++ b/pkgs/zed-editor-git/manifest.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260822205812-d9ad6af",
-  "rev": "d9ad6aff67e47de43abb270d22de75dd950f1b48",
-  "hash": "sha256-McpqJGvHyd+2A/Hb+BOZiDO2hc/lA4hFUQXP+tEGTJM=",
+  "version": "unstable-20260823192943-6bf539c",
+  "rev": "6bf539cd52126974eb0dbff667de02a696a737ec",
+  "hash": "sha256-S/KRG2xRVSE+1lubUBnTogxHSzT26WJhc+BiCZKAy0k=",
   "cargoHash": "sha256-Le7txmbo/EfFcBBbAZj7LGVFgn5aAemvYMStysX26Mc="
 }


### PR DESCRIPTION
Automated package bump for `[
  "zed-editor_git"
]`.