### PR TITLE
chore: bump shadps4_git

### DIFF
--- a/pkgs/shadps4-git/manifest.json
+++ b/pkgs/shadps4-git/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260822204204-f512999",
-  "rev": "f51299942c6f98159232ce69840cd06cd26431fc",
-  "hash": "sha256-RNM1aS2Tls/4rFR8Jg+CfL3No1uVsQHYzrHI/h4a1dw="
+  "version": "unstable-20260823164326-7fb1a53",
+  "rev": "7fb1a530c15415097836521fec6f3483e27c81ae",
+  "hash": "sha256-PeWu4xCoRsRab4Px9T5Bs4thwAeX0mARyEoivO0/7XE="
 }


### PR DESCRIPTION
Automated package bump for `[
  "shadps4_git"
]`.