### PR TITLE
chore: bump nss_git

### DIFF
--- a/pkgs/firefox-nightly/manifest.json
+++ b/pkgs/firefox-nightly/manifest.json
@@ -1,7 +1,7 @@
 {
   "version": "156.0a1",
-  "rev": "44e151427db27db6b789e3be5439f0edbcf446de",
-  "buildId": "20260822212138",
-  "hash": "sha256-kAiVDEGJf+QA+RTTYFIPY4c9d3DIRLNZ5T9iwgjO/aU=",
+  "rev": "092b4be38e4fa42c638ff6700e3f833f71085fd2",
+  "buildId": "20260823213825",
+  "hash": "sha256-FhJNDOpxKWCsj50OcZmB6v2OiGEbvF1oATC0tJqqMdQ=",
   "newtabNpmDepsHash": "sha256-6NhZWVpbB0kX3d+9QaxFIgGeCfhqusNTANI6pwROWWw="
 }


### PR DESCRIPTION
Automated package bump for `[
  "nss_git",
  "firefox-unwrapped_nightly"
]`.