### PR TITLE
chore: bump nix_git

### DIFF
--- a/pkgs/nix-git/manifest.json
+++ b/pkgs/nix-git/manifest.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260823233217-1036b10",
-  "rev": "1036b10ba5051c891d5c9dbf8795ce118bf40467",
-  "hash": "sha256-aDUcV63TOTGiBaLq69He+DkGEpTZaSq3wasLTCnnqbc=",
-  "lastModifiedDate": "20260823233217"
+  "version": "unstable-20260831003152-b983ba8",
+  "rev": "b983ba81582a30085a6e8f66d50b97ecfe5acce7",
+  "hash": "sha256-pCbuVA9LVjBY+j7XyTTWu2judbZa+yTdV9BKVUzqAdQ=",
+  "lastModifiedDate": "20260831003152"
 }


### PR DESCRIPTION
Automated package bump for `[
  "nix_git"
]`.