### PR TITLE
chore: bump libportal_git

### DIFF
--- a/pkgs/libportal-git/manifest.json
+++ b/pkgs/libportal-git/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260809192800-4260f07",
-  "rev": "4260f07d3f6c0a85d1ecf9b85881fc57c96dadd5",
-  "hash": "sha256-BTBf4EiztPWBCF6X4uLP7sA9Njs/jPkccznOplUfyqU="
+  "version": "unstable-20260824121403-4779b54",
+  "rev": "4779b5473a8eb6091d2837edbd4c09dd3536dc02",
+  "hash": "sha256-CeZdWaLA4wYAQZFHiVqXy4av8oh3N2L+m7AHee7w30M="
 }


### PR DESCRIPTION
Automated package bump for `[
  "libportal_git"
]`.