### PR TITLE
chore: bump libdrm_git

### DIFF
--- a/pkgs/mesa-git/manifest.json
+++ b/pkgs/mesa-git/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260823183642-899977f",
-  "rev": "899977f924d3af8de70f213a59c4c3731c68bcea",
-  "hash": "sha256-lw6uYpHbIMVBRNUqnJUsTXMJFiv/s0ukDGOTBuF8A9w="
+  "version": "unstable-20260824230350-07646ea",
+  "rev": "07646ea2ab6d09e53b46d33fedfe9ad59a84efcb",
+  "hash": "sha256-tkpz3+5t6GfvjCyhGT0GIt+LMKpWHXrfQoo4n9UtxW4="
 }

--- a/pkgs/wlroots-git/manifest.json
+++ b/pkgs/wlroots-git/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260819123543-329a88e",
-  "rev": "329a88e72424486180ff3339440fa9f8f711af02",
-  "hash": "sha256-f7Bgszop3boeEfvfLDcByDyK8eAnvLWRVmFbk1a8RO0="
+  "version": "unstable-20260822204336-728bd33",
+  "rev": "728bd33c12459f58312a31eae9acd947488515f1",
+  "hash": "sha256-t0pSgxw9j9JyCbCUBgF0PHMADkzAPErAxW3rUw/C9VM="
 }


### PR DESCRIPTION
Automated package bump for `[
  "libdrm_git",
  "wayland-protocols_git",
  "mesa_git",
  "wayland_git",
  "wlroots_git",
  "sway-unwrapped_git",
  "xdg-desktop-portal-wlr_git"
]`.