### PR TITLE
chore: bump zed-editor_git

### DIFF
--- a/pkgs/zed-editor-git/manifest.json
+++ b/pkgs/zed-editor-git/manifest.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260823192943-6bf539c",
-  "rev": "6bf539cd52126974eb0dbff667de02a696a737ec",
-  "hash": "sha256-S/KRG2xRVSE+1lubUBnTogxHSzT26WJhc+BiCZKAy0k=",
-  "cargoHash": "sha256-Le7txmbo/EfFcBBbAZj7LGVFgn5aAemvYMStysX26Mc="
+  "version": "unstable-20260824203244-5631830",
+  "rev": "5631830c564afa89b3aba679f45d9c3345f9460f",
+  "hash": "sha256-1djD9pxi0fQB7xrPMxYxsrdbrYoUZlynK8ISGe0D9e8=",
+  "cargoHash": "sha256-Z39JXELGdyTfRgYH+0vjzh2/s+uoFS9tBItXefjmNz8="
 }


### PR DESCRIPTION
Automated package bump for `[
  "zed-editor_git"
]`.