### PR TITLE
chore: bump nss_git

### DIFF
--- a/pkgs/firefox-nightly/manifest.json
+++ b/pkgs/firefox-nightly/manifest.json
@@ -1,7 +1,7 @@
 {
   "version": "156.0a1",
-  "rev": "092b4be38e4fa42c638ff6700e3f833f71085fd2",
-  "buildId": "20260823213825",
-  "hash": "sha256-FhJNDOpxKWCsj50OcZmB6v2OiGEbvF1oATC0tJqqMdQ=",
+  "rev": "2c35ff84ed7d1ca088a41f830bfab0be50868536",
+  "buildId": "20260824214432",
+  "hash": "sha256-U+rURpE3EMEG76MsEfn9S2e9skIkZGaCTORMLnDj99A=",
   "newtabNpmDepsHash": "sha256-6NhZWVpbB0kX3d+9QaxFIgGeCfhqusNTANI6pwROWWw="
 }

--- a/pkgs/nss-git/manifest.json
+++ b/pkgs/nss-git/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260821083530-6ca13d9",
-  "rev": "6ca13d99c4a3517d84a0b68a7a7132821d3e0591",
-  "hash": "sha256-c2exHTl8Tiuc7pFHeveW5PvjRtFMGnZQ76PCPOYYHc8="
+  "version": "unstable-20260824232822-adc1857",
+  "rev": "adc1857f73c3c7328230b54ede5833d023f944be",
+  "hash": "sha256-/P4e0zKtWmOG5wCoove3+K+yDvB5xL1Xzk0bDzB11Ao="
 }


### PR DESCRIPTION
Automated package bump for `[
  "nss_git",
  "firefox-unwrapped_nightly"
]`.