### PR TITLE
chore: bump zed-editor_git

### DIFF
--- a/pkgs/zed-editor-git/manifest.json
+++ b/pkgs/zed-editor-git/manifest.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260824203244-5631830",
-  "rev": "5631830c564afa89b3aba679f45d9c3345f9460f",
-  "hash": "sha256-1djD9pxi0fQB7xrPMxYxsrdbrYoUZlynK8ISGe0D9e8=",
-  "cargoHash": "sha256-Z39JXELGdyTfRgYH+0vjzh2/s+uoFS9tBItXefjmNz8="
+  "version": "unstable-20260825232119-55007f5",
+  "rev": "55007f518bc1d49e6b3291c5eaa1aabf649b36fd",
+  "hash": "sha256-N1hzUg/OHsBn6aX0AeRsuvMO4lc9b8b8m7wGrAz2LYw=",
+  "cargoHash": "sha256-7UDMG+8BC2tvPHppFnbnAc0OpFwDNMAavrbSS2wqrWo="
 }


### PR DESCRIPTION
Automated package bump for `[
  "zed-editor_git"
]`.