### PR TITLE
chore: bump libdrm_git

### DIFF
--- a/pkgs/mesa-git/manifest.json
+++ b/pkgs/mesa-git/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260824230350-07646ea",
-  "rev": "07646ea2ab6d09e53b46d33fedfe9ad59a84efcb",
-  "hash": "sha256-tkpz3+5t6GfvjCyhGT0GIt+LMKpWHXrfQoo4n9UtxW4="
+  "version": "unstable-20260826001830-28ce274",
+  "rev": "28ce274f4e5b0da78025b36c32f239549e09d012",
+  "hash": "sha256-8t6+1tCzs4vdfUx4NDdWUdzuESN+qJIP2rRHRqFa2Ng="
 }


### PR DESCRIPTION
Automated package bump for `[
  "libdrm_git",
  "wayland-protocols_git",
  "mesa_git",
  "wayland_git",
  "wlroots_git",
  "sway-unwrapped_git",
  "xdg-desktop-portal-wlr_git"
]`.