### PR TITLE
chore: bump tde2e_git

### DIFF
--- a/pkgs/telegram-desktop-git/manifest.json
+++ b/pkgs/telegram-desktop-git/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260824201506-baef81d",
-  "rev": "baef81d583c26b02adc3c15aecf1a9c23ce1ec29",
-  "hash": "sha256-4RYUG0DEQyblcg/OAZvjS8LGxy22fa9pHj9BfjIMylU="
+  "version": "unstable-20260825161205-b8126b9",
+  "rev": "b8126b97b75b39380ae09e7b930c9e31ae9718ab",
+  "hash": "sha256-7TQt2TSyGVuPQqocIsBhT7Y0Sl71rInpjvMdK4PzMOo="
 }


### PR DESCRIPTION
Automated package bump for `[
  "tde2e_git",
  "tg-owt_git",
  "telegram-desktop-unwrapped_git",
  "telegram-desktop_git"
]`.