### PR TITLE
chore: bump shadps4_git

### DIFF
--- a/pkgs/shadps4-git/manifest.json
+++ b/pkgs/shadps4-git/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260823164326-7fb1a53",
-  "rev": "7fb1a530c15415097836521fec6f3483e27c81ae",
-  "hash": "sha256-PeWu4xCoRsRab4Px9T5Bs4thwAeX0mARyEoivO0/7XE="
+  "version": "unstable-20260825161840-c9a5a01",
+  "rev": "c9a5a014de36c0c917509896750dc2982c070e83",
+  "hash": "sha256-cCsF6Q3+NRkQGl1toCcqsqdIQ5YWMdgNnb5zLOq8+Nc="
 }


### PR DESCRIPTION
Automated package bump for `[
  "shadps4_git"
]`.