### PR TITLE
chore: bump nss_git

### DIFF
--- a/pkgs/firefox-nightly/manifest.json
+++ b/pkgs/firefox-nightly/manifest.json
@@ -1,7 +1,7 @@
 {
   "version": "156.0a1",
-  "rev": "2c35ff84ed7d1ca088a41f830bfab0be50868536",
-  "buildId": "20260824214432",
-  "hash": "sha256-U+rURpE3EMEG76MsEfn9S2e9skIkZGaCTORMLnDj99A=",
+  "rev": "2aa0bcf95c98681376e30d6a9aa4df2b27885abc",
+  "buildId": "20260825213824",
+  "hash": "sha256-TTeH/GLjLOhOxrYyAs6Yi8UL4rbcH5hIZkwW41oe/LY=",
   "newtabNpmDepsHash": "sha256-6NhZWVpbB0kX3d+9QaxFIgGeCfhqusNTANI6pwROWWw="
 }

--- a/pkgs/nss-git/manifest.json
+++ b/pkgs/nss-git/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260824232822-adc1857",
-  "rev": "adc1857f73c3c7328230b54ede5833d023f944be",
-  "hash": "sha256-/P4e0zKtWmOG5wCoove3+K+yDvB5xL1Xzk0bDzB11Ao="
+  "version": "unstable-20260826001434-1de6006",
+  "rev": "1de60067e396e84ab31fb9ecd689be7b2cceb6bf",
+  "hash": "sha256-EhHVnxvZx6TwsFICAd42r8YVs3+7wLzRKnI7pZ7kLrY="
 }


### PR DESCRIPTION
Automated package bump for `[
  "nss_git",
  "firefox-unwrapped_nightly"
]`.