### PR TITLE
chore: bump spirv-headers_git

### DIFF
--- a/pkgs/spirv-headers-git/manifest.json
+++ b/pkgs/spirv-headers-git/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260814155455-0d25db9",
-  "rev": "0d25db97cb9b8f725e4c95e4553001710e7fc39d",
-  "hash": "sha256-HvdKHnraSSWBriVgiNfhnC60moYRseDb3aRxxoANX1I="
+  "version": "unstable-20260826184122-4965431",
+  "rev": "496543121ce6419f23d6fa5d7194ba66c36212d2",
+  "hash": "sha256-PTD3GxQnENDngl6bf9YCmCVmvRgdBZczBosFCOCYEXU="
 }


### PR DESCRIPTION
Automated package bump for `[
  "spirv-headers_git"
]`.