### PR TITLE
chore: bump qtile-module_git

### DIFF
--- a/pkgs/qtile-git/manifest.json
+++ b/pkgs/qtile-git/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260819075100-287dcec",
-  "rev": "287dcec7a6dc99dab9344af5b83a3cdb883894bc",
-  "hash": "sha256-kH2LtcCsZcxzutbRkDcnib/YXkblkV+FoG3h4QwuMwk="
+  "version": "unstable-20260826081420-e3a78cb",
+  "rev": "e3a78cbfa5fa3285f160afea8c83d59fe72f0443",
+  "hash": "sha256-vH7zzhXI73eo6gIf3cNbLOIctpsnmk9vtoITARY4gPE="
 }


### PR DESCRIPTION
Automated package bump for `[
  "qtile-module_git"
]`.