### PR TITLE
chore: bump libdrm_git

### DIFF
--- a/pkgs/mesa-git/manifest.json
+++ b/pkgs/mesa-git/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260826001830-28ce274",
-  "rev": "28ce274f4e5b0da78025b36c32f239549e09d012",
-  "hash": "sha256-8t6+1tCzs4vdfUx4NDdWUdzuESN+qJIP2rRHRqFa2Ng="
+  "version": "unstable-20260827103104-9855279",
+  "rev": "985527987ae3a0605f8e6b11a0f721a0c52cb06c",
+  "hash": "sha256-1uaWPhZLHERUEOItqJSXu3l5FlWJb/dU210aYl1oKSM="
 }

--- a/pkgs/wlroots-git/manifest.json
+++ b/pkgs/wlroots-git/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260822204336-728bd33",
-  "rev": "728bd33c12459f58312a31eae9acd947488515f1",
-  "hash": "sha256-t0pSgxw9j9JyCbCUBgF0PHMADkzAPErAxW3rUw/C9VM="
+  "version": "unstable-20260826080901-5e9e7ee",
+  "rev": "5e9e7ee895b464d439fa7e35998eb86dddad2e03",
+  "hash": "sha256-ANpVa3y+xKhw1Z8fQ4NuyLeccVSj2VtDfsXcUgYp3Xs="
 }


### PR DESCRIPTION
Automated package bump for `[
  "libdrm_git",
  "wayland-protocols_git",
  "mesa_git",
  "wayland_git",
  "wlroots_git",
  "sway-unwrapped_git",
  "xdg-desktop-portal-wlr_git"
]`.