### PR TITLE
chore: bump zed-editor_git

### DIFF
--- a/pkgs/zed-editor-git/manifest.json
+++ b/pkgs/zed-editor-git/manifest.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260825232119-55007f5",
-  "rev": "55007f518bc1d49e6b3291c5eaa1aabf649b36fd",
-  "hash": "sha256-N1hzUg/OHsBn6aX0AeRsuvMO4lc9b8b8m7wGrAz2LYw=",
-  "cargoHash": "sha256-7UDMG+8BC2tvPHppFnbnAc0OpFwDNMAavrbSS2wqrWo="
+  "version": "unstable-20260827101349-d84e5d4",
+  "rev": "d84e5d4992bd445b8af8eeaf1717f4cf9c5d5a54",
+  "hash": "sha256-grFtCqZ497BJyaGIzUg2fClKj8Hr1Fa0TuN8yZb6l8c=",
+  "cargoHash": "sha256-O/lvZ5cyYUeN0C30mHN2b3glCjNF/K73MtAExjcxLiI="
 }


### PR DESCRIPTION
Automated package bump for `[
  "zed-editor_git"
]`.