### PR TITLE
chore: bump tde2e_git

### DIFF
--- a/pkgs/telegram-desktop-git/manifest.json
+++ b/pkgs/telegram-desktop-git/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260825161205-b8126b9",
-  "rev": "b8126b97b75b39380ae09e7b930c9e31ae9718ab",
-  "hash": "sha256-7TQt2TSyGVuPQqocIsBhT7Y0Sl71rInpjvMdK4PzMOo="
+  "version": "unstable-20260827055511-2661216",
+  "rev": "2661216c61c4f36df57e8ea265a8b6935081637a",
+  "hash": "sha256-Ome6O+AK6LhjFwAIOHkhu4y/O0lAq3uGtJq5HWK/POU="
 }


### PR DESCRIPTION
Automated package bump for `[
  "tde2e_git",
  "tg-owt_git",
  "telegram-desktop-unwrapped_git",
  "telegram-desktop_git"
]`.