### PR TITLE
chore: bump shadps4_git

### DIFF
--- a/pkgs/shadps4-git/manifest.json
+++ b/pkgs/shadps4-git/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260825161840-c9a5a01",
-  "rev": "c9a5a014de36c0c917509896750dc2982c070e83",
-  "hash": "sha256-cCsF6Q3+NRkQGl1toCcqsqdIQ5YWMdgNnb5zLOq8+Nc="
+  "version": "unstable-20260826205706-54ec7d0",
+  "rev": "54ec7d00a054e5263388719f05a0d34e01d40fdd",
+  "hash": "sha256-GmLD7fWwBhB1k7Q7pXB/7hubwz+J5M8j5KGeS2ff4So="
 }


### PR DESCRIPTION
Automated package bump for `[
  "shadps4_git"
]`.