### PR TITLE
chore: bump tde2e_git

### DIFF
--- a/pkgs/telegram-desktop-git/manifest.json
+++ b/pkgs/telegram-desktop-git/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260827055511-2661216",
-  "rev": "2661216c61c4f36df57e8ea265a8b6935081637a",
-  "hash": "sha256-Ome6O+AK6LhjFwAIOHkhu4y/O0lAq3uGtJq5HWK/POU="
+  "version": "unstable-20260828092138-abc5110",
+  "rev": "abc51104a9c63c1dae4cff0b3605ee2d04440578",
+  "hash": "sha256-ytLbbqoKZt5oCxsTnwXU2ssucA3jr911aHB8y2AAmgA="
 }


### PR DESCRIPTION
Automated package bump for `[
  "tde2e_git",
  "tg-owt_git",
  "telegram-desktop-unwrapped_git",
  "telegram-desktop_git"
]`.