### PR TITLE
chore: bump libdrm_git

### DIFF
--- a/pkgs/mesa-git/manifest.json
+++ b/pkgs/mesa-git/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260827103104-9855279",
-  "rev": "985527987ae3a0605f8e6b11a0f721a0c52cb06c",
-  "hash": "sha256-1uaWPhZLHERUEOItqJSXu3l5FlWJb/dU210aYl1oKSM="
+  "version": "unstable-20260828122342-4bd190c",
+  "rev": "4bd190c264ff473875ccdb8b5dbf9d9d7d3c841f",
+  "hash": "sha256-Zy/KOwF7U8xazB4SiAs/6O1zrUK5L17e28CQn0Dym8E="
 }

--- a/pkgs/wayland-git/manifest.json
+++ b/pkgs/wayland-git/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260817154057-28e0825",
-  "rev": "28e08252c7dfd71ebc31a0c006d3dad05b0b4c68",
-  "hash": "sha256-ihMVhKQ5iPtko9C1LDmaj+5wAtA09fifex1b+NRV6cU="
+  "version": "unstable-20260827155020-bd616d4",
+  "rev": "bd616d428acc804ab1e2245cf44431184ff2c8a9",
+  "hash": "sha256-besT9XlnZMcIaIB3qt7EAeYPdBIK9+77gPREQHEjNeg="
 }

--- a/pkgs/wlroots-git/manifest.json
+++ b/pkgs/wlroots-git/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260826080901-5e9e7ee",
-  "rev": "5e9e7ee895b464d439fa7e35998eb86dddad2e03",
-  "hash": "sha256-ANpVa3y+xKhw1Z8fQ4NuyLeccVSj2VtDfsXcUgYp3Xs="
+  "version": "unstable-20260827135252-bd75ebf",
+  "rev": "bd75ebfe96a41b3764b90b54d60b92fa6175cfed",
+  "hash": "sha256-R4sPZK9FGzxmPcnDWbIPWfPaPdtaLCLWVIAthbYbbZE="
 }


### PR DESCRIPTION
Automated package bump for `[
  "libdrm_git",
  "wayland-protocols_git",
  "mesa_git",
  "wayland_git",
  "wlroots_git",
  "sway-unwrapped_git",
  "xdg-desktop-portal-wlr_git"
]`.