### PR TITLE
chore: bump shadps4_git

### DIFF
--- a/pkgs/shadps4-git/manifest.json
+++ b/pkgs/shadps4-git/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260826205706-54ec7d0",
-  "rev": "54ec7d00a054e5263388719f05a0d34e01d40fdd",
-  "hash": "sha256-GmLD7fWwBhB1k7Q7pXB/7hubwz+J5M8j5KGeS2ff4So="
+  "version": "unstable-20260827151542-388cff5",
+  "rev": "388cff5177f82e75a667d529212d34f3c255b7fc",
+  "hash": "sha256-6xQqz1iMn+KMb81CtfmVsmi1eMZcgMMz7360m215U7g="
 }


### PR DESCRIPTION
Automated package bump for `[
  "shadps4_git"
]`.