### PR TITLE
chore: bump zed-editor_git

### DIFF
--- a/pkgs/zed-editor-git/manifest.json
+++ b/pkgs/zed-editor-git/manifest.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260827101349-d84e5d4",
-  "rev": "d84e5d4992bd445b8af8eeaf1717f4cf9c5d5a54",
-  "hash": "sha256-grFtCqZ497BJyaGIzUg2fClKj8Hr1Fa0TuN8yZb6l8c=",
-  "cargoHash": "sha256-O/lvZ5cyYUeN0C30mHN2b3glCjNF/K73MtAExjcxLiI="
+  "version": "unstable-20260828121555-8ee36b6",
+  "rev": "8ee36b682cf1971e51032cbd932dd16def575364",
+  "hash": "sha256-Ou9gEHSInm7/JoY5k/lE01b8HWGkRktK8f93i4eOHnw=",
+  "cargoHash": "sha256-Njw2LrmQdo/t2dLBSK9TyforHnpbMHu2gJhuuhxlf04="
 }


### PR DESCRIPTION
Automated package bump for `[
  "zed-editor_git"
]`.