### PR TITLE
chore: bump openrgb_git

### DIFF
--- a/pkgs/openrgb-git/manifest.json
+++ b/pkgs/openrgb-git/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260828050106-b087a65",
-  "rev": "b087a65f3c0a0e9d763308fc17846394b5794d50",
-  "hash": "sha256-p5Fd9RAMMmZ+eW7mXVqLP0NTMNXAmAVlUKjMtVZHcRk="
+  "version": "unstable-20260829060850-e958e01",
+  "rev": "e958e0132e66b2bf01a5f365bbc72a965dd42456",
+  "hash": "sha256-DNcdEW6/tE22toA2lQIGnGHzw2nOClMP1B9FMc/OQSI="
 }


### PR DESCRIPTION
Automated package bump for `[
  "openrgb_git"
]`.