### PR TITLE
chore: bump tde2e_git

### DIFF
--- a/pkgs/telegram-desktop-git/manifest.json
+++ b/pkgs/telegram-desktop-git/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260828092138-abc5110",
-  "rev": "abc51104a9c63c1dae4cff0b3605ee2d04440578",
-  "hash": "sha256-ytLbbqoKZt5oCxsTnwXU2ssucA3jr911aHB8y2AAmgA="
+  "version": "unstable-20260828191752-087b18b",
+  "rev": "087b18b89194ab474526ca61b7992f32f52c983b",
+  "hash": "sha256-Kbx1aFmZHXH2Rc4Tte17ZRieT+iltlR6zTYgERGrfRc="
 }


### PR DESCRIPTION
Automated package bump for `[
  "tde2e_git",
  "tg-owt_git",
  "telegram-desktop-unwrapped_git",
  "telegram-desktop_git"
]`.