### PR TITLE
chore: bump zed-editor_git

### DIFF
--- a/pkgs/zed-editor-git/manifest.json
+++ b/pkgs/zed-editor-git/manifest.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260828121555-8ee36b6",
-  "rev": "8ee36b682cf1971e51032cbd932dd16def575364",
-  "hash": "sha256-Ou9gEHSInm7/JoY5k/lE01b8HWGkRktK8f93i4eOHnw=",
-  "cargoHash": "sha256-Njw2LrmQdo/t2dLBSK9TyforHnpbMHu2gJhuuhxlf04="
+  "version": "unstable-20260828223533-e3adf43",
+  "rev": "e3adf43f37d7a2a9c165a78b255d293b0848d2d0",
+  "hash": "sha256-DPVki9iGIYchYMa9X+rGeXZBCeBh9I3ZTElgoexh1xs=",
+  "cargoHash": "sha256-FXuRcaTq6PfTXz3orW0UDvDT83UxooytjMOVAw/BU/Q="
 }


### PR DESCRIPTION
Automated package bump for `[
  "zed-editor_git"
]`.