### PR TITLE
chore: bump shadps4_git

### DIFF
--- a/pkgs/shadps4-git/manifest.json
+++ b/pkgs/shadps4-git/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260827151542-388cff5",
-  "rev": "388cff5177f82e75a667d529212d34f3c255b7fc",
-  "hash": "sha256-6xQqz1iMn+KMb81CtfmVsmi1eMZcgMMz7360m215U7g="
+  "version": "unstable-20260829074518-391430a",
+  "rev": "391430a9244d20a58494cc5f074ed9992796298f",
+  "hash": "sha256-H5FSgy3fx6Uh/hpShf5208DvrRghCJ6Dm/P0TGImYZM="
 }


### PR DESCRIPTION
Automated package bump for `[
  "shadps4_git"
]`.