### PR TITLE
chore: bump libdrm_git

### DIFF
--- a/pkgs/mesa-git/manifest.json
+++ b/pkgs/mesa-git/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260828122342-4bd190c",
-  "rev": "4bd190c264ff473875ccdb8b5dbf9d9d7d3c841f",
-  "hash": "sha256-Zy/KOwF7U8xazB4SiAs/6O1zrUK5L17e28CQn0Dym8E="
+  "version": "unstable-20260829073052-4a7a29d",
+  "rev": "4a7a29d007446f68ac6ac3633b58282fe99cd700",
+  "hash": "sha256-yaRvr4cUosps7yfT0xNgX1eazAF7Hfv+kJuD5Ps2RX4="
 }


### PR DESCRIPTION
Automated package bump for `[
  "libdrm_git",
  "wayland-protocols_git",
  "mesa_git",
  "wayland_git",
  "wlroots_git",
  "sway-unwrapped_git",
  "xdg-desktop-portal-wlr_git"
]`.