### PR TITLE
chore: bump openrgb_git

### DIFF
--- a/pkgs/openrgb-git/manifest.json
+++ b/pkgs/openrgb-git/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260829060850-e958e01",
-  "rev": "e958e0132e66b2bf01a5f365bbc72a965dd42456",
-  "hash": "sha256-DNcdEW6/tE22toA2lQIGnGHzw2nOClMP1B9FMc/OQSI="
+  "version": "unstable-20260830060240-cfdd06e",
+  "rev": "cfdd06e1f4fea26639c3aaeb8e13f8b18c463561",
+  "hash": "sha256-8J3NxkjtGNCAIf9OhBItEpIjkJp/4acsjAhrUq84PjQ="
 }


### PR DESCRIPTION
Automated package bump for `[
  "openrgb_git"
]`.