### PR TITLE
chore: bump zed-editor_git

### DIFF
--- a/pkgs/zed-editor-git/manifest.json
+++ b/pkgs/zed-editor-git/manifest.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260828223533-e3adf43",
-  "rev": "e3adf43f37d7a2a9c165a78b255d293b0848d2d0",
-  "hash": "sha256-DPVki9iGIYchYMa9X+rGeXZBCeBh9I3ZTElgoexh1xs=",
-  "cargoHash": "sha256-FXuRcaTq6PfTXz3orW0UDvDT83UxooytjMOVAw/BU/Q="
+  "version": "unstable-20260829225120-399258f",
+  "rev": "399258feeaf90ad8a3a208c99221ee87b6452f38",
+  "hash": "sha256-JFB+grRKmgK8iZGMsMjQiv6Yr825ui5TtzAZjQNjh/A=",
+  "cargoHash": "sha256-9UDzIanfBaWcotpE7FeriBh1Czhokf7llkq75BXtmpc="
 }


### PR DESCRIPTION
Automated package bump for `[
  "zed-editor_git"
]`.