### PR TITLE
chore: bump libdrm_git

### DIFF
--- a/pkgs/mesa-git/manifest.json
+++ b/pkgs/mesa-git/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260829073052-4a7a29d",
-  "rev": "4a7a29d007446f68ac6ac3633b58282fe99cd700",
-  "hash": "sha256-yaRvr4cUosps7yfT0xNgX1eazAF7Hfv+kJuD5Ps2RX4="
+  "version": "unstable-20260830042921-06ec2d8",
+  "rev": "06ec2d8e5f676b5071c204c58c9a524713d923da",
+  "hash": "sha256-RJc2be52jX5hZoWC5Z1ZUmNDIppgZmHnvatVFQA1tYk="
 }


### PR DESCRIPTION
Automated package bump for `[
  "libdrm_git",
  "wayland-protocols_git",
  "mesa_git",
  "wayland_git",
  "wlroots_git",
  "sway-unwrapped_git",
  "xdg-desktop-portal-wlr_git"
]`.