### PR TITLE
chore: bump shadps4_git

### DIFF
--- a/pkgs/shadps4-git/manifest.json
+++ b/pkgs/shadps4-git/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260829074518-391430a",
-  "rev": "391430a9244d20a58494cc5f074ed9992796298f",
-  "hash": "sha256-H5FSgy3fx6Uh/hpShf5208DvrRghCJ6Dm/P0TGImYZM="
+  "version": "unstable-20260829220743-297551e",
+  "rev": "297551e00c1cbecb1ac14b79e0e91573c1bb8a55",
+  "hash": "sha256-BKvBMco4WBUqC1fh1apG9VuyOS81ognXkorMZ9KoLmw="
 }


### PR DESCRIPTION
Automated package bump for `[
  "shadps4_git"
]`.