### PR TITLE
chore: bump pcsx2_git

### DIFF
--- a/pkgs/pcsx2-git/manifest.json
+++ b/pkgs/pcsx2-git/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260828201805-c10a5c9",
-  "rev": "c10a5c9ad951c517dc48b722b5b84eb9bf7fdb42",
-  "hash": "sha256-qXOcGe5zLmX0vfr5+7tg2KbIVXko99BrfMK95KeyAuA="
+  "version": "unstable-20260830192457-d073d75",
+  "rev": "d073d75010090186b58eb38bfc78dfc2f3acd8c7",
+  "hash": "sha256-07HUaJImMihNHyeFrNJ9L4GuL67nRyYbAozI+Iu5o4o="
 }


### PR DESCRIPTION
Automated package bump for `[
  "pcsx2_git"
]`.