### PR TITLE
chore: bump openrgb_git

### DIFF
--- a/pkgs/openrgb-git/manifest.json
+++ b/pkgs/openrgb-git/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260830060240-cfdd06e",
-  "rev": "cfdd06e1f4fea26639c3aaeb8e13f8b18c463561",
-  "hash": "sha256-8J3NxkjtGNCAIf9OhBItEpIjkJp/4acsjAhrUq84PjQ="
+  "version": "unstable-20260831055211-d623e76",
+  "rev": "d623e76d25a95d0caf40a7e0074ee0275259fc8a",
+  "hash": "sha256-0Ib1l/Va/BoNmAmfnb5KR1iNbRC5h89yO/iHFpAYKGo="
 }


### PR DESCRIPTION
Automated package bump for `[
  "openrgb_git"
]`.