### PR TITLE
chore: bump tde2e_git

### DIFF
--- a/pkgs/telegram-desktop-git/manifest.json
+++ b/pkgs/telegram-desktop-git/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260828191752-087b18b",
-  "rev": "087b18b89194ab474526ca61b7992f32f52c983b",
-  "hash": "sha256-Kbx1aFmZHXH2Rc4Tte17ZRieT+iltlR6zTYgERGrfRc="
+  "version": "unstable-20260831061635-361f61b",
+  "rev": "361f61b178a46ef5569fb7589329a45ec5a1915f",
+  "hash": "sha256-fOyQf5jsrJ31KVC6CQT8xzXy5RX+GjqD9MCG/a9bY64="
 }


### PR DESCRIPTION
Automated package bump for `[
  "tde2e_git",
  "tg-owt_git",
  "telegram-desktop-unwrapped_git",
  "telegram-desktop_git"
]`.