### PR TITLE
chore: bump zed-editor_git

### DIFF
--- a/pkgs/zed-editor-git/manifest.json
+++ b/pkgs/zed-editor-git/manifest.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260829225120-399258f",
-  "rev": "399258feeaf90ad8a3a208c99221ee87b6452f38",
-  "hash": "sha256-JFB+grRKmgK8iZGMsMjQiv6Yr825ui5TtzAZjQNjh/A=",
-  "cargoHash": "sha256-9UDzIanfBaWcotpE7FeriBh1Czhokf7llkq75BXtmpc="
+  "version": "unstable-20260831054547-770aac3",
+  "rev": "770aac345c76d9fcf82c01ba0dea08e5739b27b1",
+  "hash": "sha256-1I35RYUbkphu9zHwxym5KRNhftb0BCdSL0oh+A532Js=",
+  "cargoHash": "sha256-neI30NiuFVdmDy7CW9yufS8ucJ5/mFKRAyH6Hz1/lsk="
 }


### PR DESCRIPTION
Automated package bump for `[
  "zed-editor_git"
]`.