### PR TITLE
chore: bump libdrm_git

### DIFF
--- a/pkgs/mesa-git/manifest.json
+++ b/pkgs/mesa-git/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260830042921-06ec2d8",
-  "rev": "06ec2d8e5f676b5071c204c58c9a524713d923da",
-  "hash": "sha256-RJc2be52jX5hZoWC5Z1ZUmNDIppgZmHnvatVFQA1tYk="
+  "version": "unstable-20260831061901-8507e71",
+  "rev": "8507e71ddb2bf820029717f875087cc5a8b5e2ca",
+  "hash": "sha256-u5Sl70ujsqgIVA9hKmApB+FL7td8zEjlLig3KDf8cBo="
 }

--- a/pkgs/wayland-git/manifest.json
+++ b/pkgs/wayland-git/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260827155020-bd616d4",
-  "rev": "bd616d428acc804ab1e2245cf44431184ff2c8a9",
-  "hash": "sha256-besT9XlnZMcIaIB3qt7EAeYPdBIK9+77gPREQHEjNeg="
+  "version": "unstable-20260830130314-381af21",
+  "rev": "381af21cf84f13be0ca24aed756a9cded3290d49",
+  "hash": "sha256-HGZx4f3HM+6APICDorqUyYO8YW6x97J2yO9HlH540Lg="
 }


### PR DESCRIPTION
Automated package bump for `[
  "libdrm_git",
  "wayland-protocols_git",
  "mesa_git",
  "wayland_git",
  "wlroots_git",
  "sway-unwrapped_git",
  "xdg-desktop-portal-wlr_git"
]`.