### PR TITLE
chore: bump shadps4_git

### DIFF
--- a/pkgs/shadps4-git/manifest.json
+++ b/pkgs/shadps4-git/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260829220743-297551e",
-  "rev": "297551e00c1cbecb1ac14b79e0e91573c1bb8a55",
-  "hash": "sha256-BKvBMco4WBUqC1fh1apG9VuyOS81ognXkorMZ9KoLmw="
+  "version": "unstable-20260831052603-0134143",
+  "rev": "0134143b6d3c1cf0f6a66045bcf59ed296be5433",
+  "hash": "sha256-HIzSJu4p2ZJAa/s4zJTQTIoo5JC8B7sY6mRayGxsKUk="
 }


### PR DESCRIPTION
Automated package bump for `[
  "shadps4_git"
]`.