### PR TITLE
chore: bump nss_git

### DIFF
--- a/pkgs/nss-git/manifest.json
+++ b/pkgs/nss-git/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260826001434-1de6006",
-  "rev": "1de60067e396e84ab31fb9ecd689be7b2cceb6bf",
-  "hash": "sha256-EhHVnxvZx6TwsFICAd42r8YVs3+7wLzRKnI7pZ7kLrY="
+  "version": "unstable-20260903105110-7db8de4",
+  "rev": "7db8de42431841b214b49fd2cb7122a07aa631b8",
+  "hash": "sha256-41xJUv9GXKNUc9fs7aazQuwlyHrR1F9Up5zxB2GerRE="
 }


### PR DESCRIPTION
Automated package bump for `[
  "nss_git",
  "firefox-unwrapped_nightly"
]`.