### PR TITLE
chore: bump nix_git

### DIFF
--- a/pkgs/nix-git/manifest.json
+++ b/pkgs/nix-git/manifest.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260831003152-b983ba8",
-  "rev": "b983ba81582a30085a6e8f66d50b97ecfe5acce7",
-  "hash": "sha256-pCbuVA9LVjBY+j7XyTTWu2judbZa+yTdV9BKVUzqAdQ=",
-  "lastModifiedDate": "20260831003152"
+  "version": "unstable-20260831165555-5438b85",
+  "rev": "5438b85837c95849089100b6ee0c7c5e012f3389",
+  "hash": "sha256-mB6epADVPwlD/z4/Eq76HzItMaHE5owzgBtL22/0WSU=",
+  "lastModifiedDate": "20260831165555"
 }


### PR DESCRIPTION
Automated package bump for `[
  "nix_git"
]`.