### PR TITLE
chore: bump openrgb_git

### DIFF
--- a/pkgs/openrgb-git/manifest.json
+++ b/pkgs/openrgb-git/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260831055211-d623e76",
-  "rev": "d623e76d25a95d0caf40a7e0074ee0275259fc8a",
-  "hash": "sha256-0Ib1l/Va/BoNmAmfnb5KR1iNbRC5h89yO/iHFpAYKGo="
+  "version": "unstable-20260901055359-544fd47",
+  "rev": "544fd4775698b5ae4ffc8ed0ab9908930f41baae",
+  "hash": "sha256-bbxlO9nUfYltpGwklMNOFuIQIo7Emj1hyDjYWLZufPg="
 }


### PR DESCRIPTION
Automated package bump for `[
  "openrgb_git"
]`.