### PR TITLE
chore: bump libdrm_git

### DIFF
--- a/pkgs/mesa-git/default.nix
+++ b/pkgs/mesa-git/default.nix
@@ -15,8 +15,8 @@ let
     domain = "gitlab.freedesktop.org";
     owner = "virgl";
     repo = "venus-protocol";
-    rev = "e94b12f301b9eb27ebead757128a18420b4f7994";
-    hash = "sha256-bRpb8eSgfbOdfKOlxA4P23yEAr0Q7Iq3fh34gZnwKjQ=";
+    rev = "v1.1.1";
+    hash = "sha256-VHn2UVpDB3UiJItFMh3/yndztIKZvHClVZDlTHztW7g=";
   };
 in
 gitOverride (current: {

--- a/pkgs/mesa-git/manifest.json
+++ b/pkgs/mesa-git/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260831061901-8507e71",
-  "rev": "8507e71ddb2bf820029717f875087cc5a8b5e2ca",
-  "hash": "sha256-u5Sl70ujsqgIVA9hKmApB+FL7td8zEjlLig3KDf8cBo="
+  "version": "unstable-20260902030040-d870cef",
+  "rev": "d870cef8b7c8a4a11edc669669c9f18ae402314a",
+  "hash": "sha256-edjLEzxMvfWEDNE/sLRtMB6Wu8hAlqbmlWJr4g5xD2I="
 }

--- a/pkgs/wlroots-git/manifest.json
+++ b/pkgs/wlroots-git/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260827135252-bd75ebf",
-  "rev": "bd75ebfe96a41b3764b90b54d60b92fa6175cfed",
-  "hash": "sha256-R4sPZK9FGzxmPcnDWbIPWfPaPdtaLCLWVIAthbYbbZE="
+  "version": "unstable-20260901211001-c686329",
+  "rev": "c686329b7d61f6959222317680a6a75e8c5247a8",
+  "hash": "sha256-ID0PmnUkrKenHbuEG7+oSIi2ZOxiCCPfUjYaxB614+I="
 }


### PR DESCRIPTION
Automated package bump for `[
  "libdrm_git",
  "wayland-protocols_git",
  "mesa_git",
  "wayland_git",
  "wlroots_git",
  "sway-unwrapped_git",
  "xdg-desktop-portal-wlr_git"
]`.