### PR TITLE
chore: bump zed-editor_git

### DIFF
--- a/pkgs/zed-editor-git/manifest.json
+++ b/pkgs/zed-editor-git/manifest.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260831054547-770aac3",
-  "rev": "770aac345c76d9fcf82c01ba0dea08e5739b27b1",
-  "hash": "sha256-1I35RYUbkphu9zHwxym5KRNhftb0BCdSL0oh+A532Js=",
-  "cargoHash": "sha256-neI30NiuFVdmDy7CW9yufS8ucJ5/mFKRAyH6Hz1/lsk="
+  "version": "unstable-20260831184700-ce48461",
+  "rev": "ce48461eaadd16c65c31f835511ab96bd3b6e746",
+  "hash": "sha256-dWsg2ACvboPGt7Avf2veWpgrDRB3nsQdTEVIQ+BYjhQ=",
+  "cargoHash": "sha256-Nls7niFDbq6N1MWwpyaw/FeD0qMFF/Vl/hdyehBnxmg="
 }


### PR DESCRIPTION
Automated package bump for `[
  "zed-editor_git"
]`.