### PR TITLE
chore: bump pcsx2_git

### DIFF
--- a/pkgs/pcsx2-git/manifest.json
+++ b/pkgs/pcsx2-git/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260830192457-d073d75",
-  "rev": "d073d75010090186b58eb38bfc78dfc2f3acd8c7",
-  "hash": "sha256-07HUaJImMihNHyeFrNJ9L4GuL67nRyYbAozI+Iu5o4o="
+  "version": "unstable-20260901000416-00482e8",
+  "rev": "00482e8adadd4baa8ac720e382803d169142a8ad",
+  "hash": "sha256-xwOCZ+/+XkT5XmxubR/iIPV5rStTq6Q3V2Z1turvAcU="
 }


### PR DESCRIPTION
Automated package bump for `[
  "pcsx2_git"
]`.