### PR TITLE
chore: bump shadps4_git

### DIFF
--- a/pkgs/shadps4-git/manifest.json
+++ b/pkgs/shadps4-git/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260831052603-0134143",
-  "rev": "0134143b6d3c1cf0f6a66045bcf59ed296be5433",
-  "hash": "sha256-HIzSJu4p2ZJAa/s4zJTQTIoo5JC8B7sY6mRayGxsKUk="
+  "version": "unstable-20260831092548-e29cf71",
+  "rev": "e29cf7199663b0dd45079b661b0be3e32f83cb4b",
+  "hash": "sha256-kvk5blsWJ0I+0eYd6qdTTO3Nu7Hk9FbysP/WZj9Lp3M="
 }


### PR DESCRIPTION
Automated package bump for `[
  "shadps4_git"
]`.