### PR TITLE
chore: bump evil-helix_git

### DIFF
--- a/pkgs/helix-git/manifest-evil.json
+++ b/pkgs/helix-git/manifest-evil.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260404210404-a034ec2",
-  "rev": "a034ec2f6abd82be44d8eddb6ef74444108fce29",
-  "hash": "sha256-debbUtuOO7sEvKfCVV2MUGiYag193bDg78HuVbvuVUw=",
+  "version": "unstable-20260831150816-50bf201",
+  "rev": "50bf2010eec939bf7bde7f8b062c2a183181f996",
+  "hash": "sha256-mZDxtKxbZlKyTQworvaqJzW0fMl5Z/LYzKJL+j3Hhhk=",
   "cargoHash": "sha256-Mf0nrgMk1MlZkSyUN6mlM5lmTcrOHn3xBNzmVGtApEU="
 }


### PR DESCRIPTION
Automated package bump for `[
  "evil-helix_git"
]`.