### PR TITLE
chore: bump tde2e_git

### DIFF
--- a/pkgs/telegram-desktop-git/manifest.json
+++ b/pkgs/telegram-desktop-git/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260831061635-361f61b",
-  "rev": "361f61b178a46ef5569fb7589329a45ec5a1915f",
-  "hash": "sha256-fOyQf5jsrJ31KVC6CQT8xzXy5RX+GjqD9MCG/a9bY64="
+  "version": "unstable-20260831073020-f0ee75e",
+  "rev": "f0ee75edef45fc1d6f3828e56a5d7600643136a2",
+  "hash": "sha256-EHuXdVLnBBqfKl+2KeSa3a0iRlyFZjjKb1IqrRzQGM4="
 }


### PR DESCRIPTION
Automated package bump for `[
  "tde2e_git",
  "tg-owt_git",
  "telegram-desktop-unwrapped_git",
  "telegram-desktop_git"
]`.