### PR TITLE
chore: bump openrgb_git

### DIFF
--- a/pkgs/openrgb-git/manifest.json
+++ b/pkgs/openrgb-git/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260901055359-544fd47",
-  "rev": "544fd4775698b5ae4ffc8ed0ab9908930f41baae",
-  "hash": "sha256-bbxlO9nUfYltpGwklMNOFuIQIo7Emj1hyDjYWLZufPg="
+  "version": "unstable-20260902035944-88af061",
+  "rev": "88af06182ac26589af2d7bc794f5f192f2d563bc",
+  "hash": "sha256-ouuxwT4/wSWqVDTDNwCnKMHaJgQUojI7rBkYh2/lrtM="
 }


### PR DESCRIPTION
Automated package bump for `[
  "openrgb_git"
]`.