### PR TITLE
chore: bump qtile-module_git

### DIFF
--- a/pkgs/qtile-git/manifest.json
+++ b/pkgs/qtile-git/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260826081420-e3a78cb",
-  "rev": "e3a78cbfa5fa3285f160afea8c83d59fe72f0443",
-  "hash": "sha256-vH7zzhXI73eo6gIf3cNbLOIctpsnmk9vtoITARY4gPE="
+  "version": "unstable-20260901073845-bf73145",
+  "rev": "bf73145d81aafe150e1d0eefce04451e8fa4051e",
+  "hash": "sha256-XBiJOB1ASvN1YNlMwIcwdRm0ATNh4DvJWvzCXlSZqoU="
 }


### PR DESCRIPTION
Automated package bump for `[
  "qtile-module_git"
]`.