### PR TITLE
chore: bump pcsx2_git

### DIFF
--- a/pkgs/pcsx2-git/manifest.json
+++ b/pkgs/pcsx2-git/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260901000416-00482e8",
-  "rev": "00482e8adadd4baa8ac720e382803d169142a8ad",
-  "hash": "sha256-xwOCZ+/+XkT5XmxubR/iIPV5rStTq6Q3V2Z1turvAcU="
+  "version": "unstable-20260901192005-67aadac",
+  "rev": "67aadac40cff9245c93c0eb0b61fcc9b38596296",
+  "hash": "sha256-IikkCn0y5M0whLryoxkxz+ALkQIdhr9/QsMuaDn4XM8="
 }


### PR DESCRIPTION
Automated package bump for `[
  "pcsx2_git"
]`.