### PR TITLE
chore: bump tde2e_git

### DIFF
--- a/pkgs/telegram-desktop-git/manifest.json
+++ b/pkgs/telegram-desktop-git/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260831073020-f0ee75e",
-  "rev": "f0ee75edef45fc1d6f3828e56a5d7600643136a2",
-  "hash": "sha256-EHuXdVLnBBqfKl+2KeSa3a0iRlyFZjjKb1IqrRzQGM4="
+  "version": "unstable-20260901172743-54dd015",
+  "rev": "54dd015786ad9a36ee02e6b892fee0ba7de77f26",
+  "hash": "sha256-xMLRquIF/Io133cRlvW629S/yckSdIj2gPq+a5AIFY4="
 }


### PR DESCRIPTION
Automated package bump for `[
  "tde2e_git",
  "tg-owt_git",
  "telegram-desktop-unwrapped_git",
  "telegram-desktop_git"
]`.