### PR TITLE
chore: bump zed-editor_git

### DIFF
--- a/pkgs/zed-editor-git/manifest.json
+++ b/pkgs/zed-editor-git/manifest.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260831184700-ce48461",
-  "rev": "ce48461eaadd16c65c31f835511ab96bd3b6e746",
-  "hash": "sha256-dWsg2ACvboPGt7Avf2veWpgrDRB3nsQdTEVIQ+BYjhQ=",
-  "cargoHash": "sha256-Nls7niFDbq6N1MWwpyaw/FeD0qMFF/Vl/hdyehBnxmg="
+  "version": "unstable-20260902050327-97b1e64",
+  "rev": "97b1e64a177a2fe3c2803e323087b5c2fa6fff1e",
+  "hash": "sha256-uypu2RmptRpnR1SDtfnpdqHVTUoVSGOtYC6WMUqFtvQ=",
+  "cargoHash": "sha256-vSCpE7ar0SDclSIzW3AL1FSOLQCiAZ1ukJl1Zv+h8sM="
 }


### PR DESCRIPTION
Automated package bump for `[
  "zed-editor_git"
]`.