### PR TITLE
chore: bump nix_git

### DIFF
--- a/pkgs/nix-git/manifest.json
+++ b/pkgs/nix-git/manifest.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260901151918-72385de",
-  "rev": "72385de1bef8b8879384b4810e3b0864f4d3c3da",
-  "hash": "sha256-TJ5SnTQh12moALdb5lrGog+K38HdkE770dTenyRFwIQ=",
-  "lastModifiedDate": "20260901151918"
+  "version": "unstable-20260902205234-f4da596",
+  "rev": "f4da5967fe490698d39a86dade91bae933289d53",
+  "hash": "sha256-1VGIct2V5vM6BqcK7gvkmjAAzHnvxm3hFNKZdB8W6P0=",
+  "lastModifiedDate": "20260902205234"
 }


### PR DESCRIPTION
Automated package bump for `[
  "nix_git"
]`.