### PR TITLE
chore: bump openrgb_git

### DIFF
--- a/pkgs/openrgb-git/manifest.json
+++ b/pkgs/openrgb-git/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260902035944-88af061",
-  "rev": "88af06182ac26589af2d7bc794f5f192f2d563bc",
-  "hash": "sha256-ouuxwT4/wSWqVDTDNwCnKMHaJgQUojI7rBkYh2/lrtM="
+  "version": "unstable-20260903002950-7fed68c",
+  "rev": "7fed68ccf1a2413b9bd38a70e266b12cb2d59c26",
+  "hash": "sha256-7jLV0UDNJuZAOnUtLY+DdDBhNN1mmnOLHavYuC1+cQc="
 }


### PR DESCRIPTION
Automated package bump for `[
  "openrgb_git"
]`.