### PR TITLE
chore: bump libdrm_git

### DIFF
--- a/pkgs/mesa-git/manifest.json
+++ b/pkgs/mesa-git/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260902030040-d870cef",
-  "rev": "d870cef8b7c8a4a11edc669669c9f18ae402314a",
-  "hash": "sha256-edjLEzxMvfWEDNE/sLRtMB6Wu8hAlqbmlWJr4g5xD2I="
+  "version": "unstable-20260902213201-946b15e",
+  "rev": "946b15ec48a54142efc15b97aa44b06df74f2062",
+  "hash": "sha256-DrfVF3/6sRNekIu+hfYzXKp9aPgAb3e/J9oiaHQFFuU="
 }


### PR DESCRIPTION
Automated package bump for `[
  "libdrm_git",
  "wayland-protocols_git",
  "mesa_git",
  "wayland_git",
  "wlroots_git",
  "sway-unwrapped_git",
  "xdg-desktop-portal-wlr_git"
]`.