### PR TITLE
chore: bump zed-editor_git

### DIFF
--- a/pkgs/zed-editor-git/manifest.json
+++ b/pkgs/zed-editor-git/manifest.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260902050327-97b1e64",
-  "rev": "97b1e64a177a2fe3c2803e323087b5c2fa6fff1e",
-  "hash": "sha256-uypu2RmptRpnR1SDtfnpdqHVTUoVSGOtYC6WMUqFtvQ=",
-  "cargoHash": "sha256-vSCpE7ar0SDclSIzW3AL1FSOLQCiAZ1ukJl1Zv+h8sM="
+  "version": "unstable-20260902231540-b1a7ef0",
+  "rev": "b1a7ef0cf66dfbf9d7661170c96d97c7df916c68",
+  "hash": "sha256-l2z4PYRHmk+Mu+4Ap+3qT7SInY5sh7eqdx9E7bxjp7c=",
+  "cargoHash": "sha256-TyL4sv9ZyeXz/sDpmD68nMdh3/dVYV5JpEWX7WQckco="
 }


### PR DESCRIPTION
Automated package bump for `[
  "zed-editor_git"
]`.