### PR TITLE
chore: bump tde2e_git

### DIFF
--- a/pkgs/telegram-desktop-git/manifest.json
+++ b/pkgs/telegram-desktop-git/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260901172743-54dd015",
-  "rev": "54dd015786ad9a36ee02e6b892fee0ba7de77f26",
-  "hash": "sha256-xMLRquIF/Io133cRlvW629S/yckSdIj2gPq+a5AIFY4="
+  "version": "unstable-20260902101023-954f756",
+  "rev": "954f75623dd0e98a1d3c7831df35bc30d694083e",
+  "hash": "sha256-FbenDWiv4fxb6GHHsP0P7VLoMk6h+BYcfpomvS22b/c="
 }


### PR DESCRIPTION
Automated package bump for `[
  "tde2e_git",
  "tg-owt_git",
  "telegram-desktop-unwrapped_git",
  "telegram-desktop_git"
]`.