### PR TITLE
chore: bump shadps4_git

### DIFF
--- a/pkgs/shadps4-git/manifest.json
+++ b/pkgs/shadps4-git/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260901214609-2b4592b",
-  "rev": "2b4592b77c3bd4fa0a680f0a7aa8b8e6a24abdea",
-  "hash": "sha256-KNvzZweBwWiV7ZcDgzIngT6Lb0Y48Ms7icbia0zMFhQ="
+  "version": "unstable-20260903004603-473633c",
+  "rev": "473633c31a6a2f485af8b8692d4662a5cd71e2dc",
+  "hash": "sha256-DYi3sQ0mtVjzb32BRTZyvLdHmGcOpeL7vK6FI6BTCIc="
 }


### PR DESCRIPTION
Automated package bump for `[
  "shadps4_git"
]`.