### PR TITLE
chore: bump nix_git

### DIFF
--- a/pkgs/nix-git/manifest.json
+++ b/pkgs/nix-git/manifest.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260902205234-f4da596",
-  "rev": "f4da5967fe490698d39a86dade91bae933289d53",
-  "hash": "sha256-1VGIct2V5vM6BqcK7gvkmjAAzHnvxm3hFNKZdB8W6P0=",
-  "lastModifiedDate": "20260902205234"
+  "version": "unstable-20260903153700-d3bf403",
+  "rev": "d3bf40359442360b5cf93397d042b34ac0b4fb07",
+  "hash": "sha256-hdXEZZfnlPDz2OU6tqusOjtkGFROTYY3Cnf1UW1alow=",
+  "lastModifiedDate": "20260903153700"
 }


### PR DESCRIPTION
Automated package bump for `[
  "nix_git"
]`.