### PR TITLE
chore: bump pcsx2_git

### DIFF
--- a/pkgs/pcsx2-git/manifest.json
+++ b/pkgs/pcsx2-git/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260901192005-67aadac",
-  "rev": "67aadac40cff9245c93c0eb0b61fcc9b38596296",
-  "hash": "sha256-IikkCn0y5M0whLryoxkxz+ALkQIdhr9/QsMuaDn4XM8="
+  "version": "unstable-20260904000437-c475c75",
+  "rev": "c475c752bfab4053880a955ef19c52a4051a2725",
+  "hash": "sha256-I2noipOhVEAZ1w6tsG7rhGC7Zw6G4mvlf4rt2xsWrsc="
 }


### PR DESCRIPTION
Automated package bump for `[
  "pcsx2_git"
]`.