### PR TITLE
chore: bump libdrm_git

### DIFF
--- a/pkgs/mesa-git/manifest.json
+++ b/pkgs/mesa-git/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260902213201-946b15e",
-  "rev": "946b15ec48a54142efc15b97aa44b06df74f2062",
-  "hash": "sha256-DrfVF3/6sRNekIu+hfYzXKp9aPgAb3e/J9oiaHQFFuU="
+  "version": "unstable-20260904045637-9311c93",
+  "rev": "9311c93dbef6b87a30bc282c3683efefc5f26f77",
+  "hash": "sha256-8yJMG+uiP/w4dvUBTnu/FOwuh2asz6iwEgoW8B/Ezgk="
 }

--- a/pkgs/wlroots-git/manifest.json
+++ b/pkgs/wlroots-git/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260901211001-c686329",
-  "rev": "c686329b7d61f6959222317680a6a75e8c5247a8",
-  "hash": "sha256-ID0PmnUkrKenHbuEG7+oSIi2ZOxiCCPfUjYaxB614+I="
+  "version": "unstable-20260903172427-8697752",
+  "rev": "8697752bbebcf3b7e0c3af9f15296653d838cdef",
+  "hash": "sha256-B693M2HKdXoXX8aRK45OBPJef7IXUoha36ilkKzsTzI="
 }


### PR DESCRIPTION
Automated package bump for `[
  "libdrm_git",
  "wayland-protocols_git",
  "mesa_git",
  "wayland_git",
  "wlroots_git",
  "sway-unwrapped_git",
  "xdg-desktop-portal-wlr_git"
]`.