### PR TITLE
chore: bump zed-editor_git

### DIFF
--- a/pkgs/zed-editor-git/manifest.json
+++ b/pkgs/zed-editor-git/manifest.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260902231540-b1a7ef0",
-  "rev": "b1a7ef0cf66dfbf9d7661170c96d97c7df916c68",
-  "hash": "sha256-l2z4PYRHmk+Mu+4Ap+3qT7SInY5sh7eqdx9E7bxjp7c=",
-  "cargoHash": "sha256-TyL4sv9ZyeXz/sDpmD68nMdh3/dVYV5JpEWX7WQckco="
+  "version": "unstable-20260904030213-1057c2c",
+  "rev": "1057c2cf3d5b4aefd04755e1387c7826a4d7fba6",
+  "hash": "sha256-gKCsbn5KBrVpGn1Oj5S4jBwqNGULFZR29IqX1mcVKjU=",
+  "cargoHash": "sha256-2kTOL0H7q85AgoAxyTMJn5ccWcOPiyngAFPuJrqRepE="
 }


### PR DESCRIPTION
Automated package bump for `[
  "zed-editor_git"
]`.