### PR TITLE
chore: bump shadps4_git

### DIFF
--- a/pkgs/shadps4-git/manifest.json
+++ b/pkgs/shadps4-git/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260903004603-473633c",
-  "rev": "473633c31a6a2f485af8b8692d4662a5cd71e2dc",
-  "hash": "sha256-DYi3sQ0mtVjzb32BRTZyvLdHmGcOpeL7vK6FI6BTCIc="
+  "version": "unstable-20260903124023-2eca0b5",
+  "rev": "2eca0b5f0b7555c7ca67e043fbbc03ac4b2f7f9d",
+  "hash": "sha256-QPLLKPfFzkx/8caP+DSiHDUq9hYSAYEigYrGxNHWcDc="
 }


### PR DESCRIPTION
Automated package bump for `[
  "shadps4_git"
]`.