### PR TITLE
chore: bump openrgb_git

### DIFF
--- a/pkgs/openrgb-git/manifest.json
+++ b/pkgs/openrgb-git/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260903002950-7fed68c",
-  "rev": "7fed68ccf1a2413b9bd38a70e266b12cb2d59c26",
-  "hash": "sha256-7jLV0UDNJuZAOnUtLY+DdDBhNN1mmnOLHavYuC1+cQc="
+  "version": "unstable-20260904051532-1103a56",
+  "rev": "1103a567dac52519be5af6f53395fab0323ee7af",
+  "hash": "sha256-M6XwtAVlf3kYzfx4vnQM+YJIJ9py7LElUWmDQk4oWb8="
 }


### PR DESCRIPTION
Automated package bump for `[
  "openrgb_git"
]`.