### PR TITLE
chore: bump tde2e_git

### DIFF
--- a/pkgs/telegram-desktop-git/manifest.json
+++ b/pkgs/telegram-desktop-git/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260902101023-954f756",
-  "rev": "954f75623dd0e98a1d3c7831df35bc30d694083e",
-  "hash": "sha256-FbenDWiv4fxb6GHHsP0P7VLoMk6h+BYcfpomvS22b/c="
+  "version": "unstable-20260903182626-e09ce72",
+  "rev": "e09ce727ff9358bade6a6ec1bf39d233b5b6564c",
+  "hash": "sha256-8gtQ6SI27Pfrjt2J/A/8ODhYeo8Hofp5skwgJ63Femw="
 }


### PR DESCRIPTION
Automated package bump for `[
  "tde2e_git",
  "tg-owt_git",
  "telegram-desktop-unwrapped_git",
  "telegram-desktop_git"
]`.