### PR TITLE
mesa-git: remove anti-lag layer (already enabled upstream)

### DIFF
--- a/pkgs/mesa-git/default.nix
+++ b/pkgs/mesa-git/default.nix
@@ -24,9 +24,6 @@ gitOverride (current: {
     if final.stdenv.hostPlatform.isLinux then
       {
         wayland-protocols = final64.wayland-protocols_git;
-        vulkanLayers = prev.mesa.vulkanLayers ++ [
-          "anti-lag"
-        ];
       }
       // (
         if is32bit then


### PR DESCRIPTION
### :fish: What?

Small cleanup

### :fishing_pole_and_fish: Why?

Because it's already done upstream since https://github.com/NixOS/nixpkgs/commit/ae921d60d393bafb77901a08beaf93fef7409afc

### :whale: Extras

- Reverts #1129
