### PR TITLE
chore: bump libportal_git

### DIFF
--- a/pkgs/libportal-git/manifest.json
+++ b/pkgs/libportal-git/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260824121403-4779b54",
-  "rev": "4779b5473a8eb6091d2837edbd4c09dd3536dc02",
-  "hash": "sha256-CeZdWaLA4wYAQZFHiVqXy4av8oh3N2L+m7AHee7w30M="
+  "version": "unstable-20260905005220-280c128",
+  "rev": "280c1281e0d1710574d3409869097df0de61c366",
+  "hash": "sha256-jHuw/KdVCD7u0LNpcNtPlnhALuYbfFIMnHUKpqJ5J2k="
 }


### PR DESCRIPTION
Automated package bump for `[
  "libportal_git"
]`.