### PR TITLE
chore: bump nix_git

### DIFF
--- a/pkgs/nix-git/manifest.json
+++ b/pkgs/nix-git/manifest.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260903153700-d3bf403",
-  "rev": "d3bf40359442360b5cf93397d042b34ac0b4fb07",
-  "hash": "sha256-hdXEZZfnlPDz2OU6tqusOjtkGFROTYY3Cnf1UW1alow=",
-  "lastModifiedDate": "20260903153700"
+  "version": "unstable-20260904200258-0765ffa",
+  "rev": "0765ffa540e2adfda7b69efafdbac821ebc48034",
+  "hash": "sha256-MYUUwkSnDt+Hn5HUvPJ7f54umm/XGrRFVtLR52tWy2o=",
+  "lastModifiedDate": "20260904200258"
 }


### PR DESCRIPTION
Automated package bump for `[
  "nix_git"
]`.