### PR TITLE
chore: bump openrgb_git

### DIFF
--- a/pkgs/openrgb-git/manifest.json
+++ b/pkgs/openrgb-git/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260904051532-1103a56",
-  "rev": "1103a567dac52519be5af6f53395fab0323ee7af",
-  "hash": "sha256-M6XwtAVlf3kYzfx4vnQM+YJIJ9py7LElUWmDQk4oWb8="
+  "version": "unstable-20260905024839-ed3d789",
+  "rev": "ed3d7894c80fbfd396c1a662478bb2cc0a5bf844",
+  "hash": "sha256-uHt5pVStuPQWRxMQC+seBKC55bVfAiIVcb00d5itNjo="
 }


### PR DESCRIPTION
Automated package bump for `[
  "openrgb_git"
]`.