### PR TITLE
chore: bump libdrm_git

### DIFF
--- a/pkgs/mesa-git/manifest.json
+++ b/pkgs/mesa-git/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260904045637-9311c93",
-  "rev": "9311c93dbef6b87a30bc282c3683efefc5f26f77",
-  "hash": "sha256-8yJMG+uiP/w4dvUBTnu/FOwuh2asz6iwEgoW8B/Ezgk="
+  "version": "unstable-20260904230749-23373e9",
+  "rev": "23373e9fce2af674bd61a2501548be2ed035880b",
+  "hash": "sha256-ACE+VOEJ5EWum/wqmGCtzhY0WyU4g7+WoSVJcoGvZwk="
 }


### PR DESCRIPTION
Automated package bump for `[
  "libdrm_git",
  "wayland-protocols_git",
  "mesa_git",
  "wayland_git",
  "wlroots_git",
  "sway-unwrapped_git",
  "xdg-desktop-portal-wlr_git"
]`.