### PR TITLE
chore: bump pcsx2_git

### DIFF
--- a/pkgs/pcsx2-git/manifest.json
+++ b/pkgs/pcsx2-git/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260904000437-c475c75",
-  "rev": "c475c752bfab4053880a955ef19c52a4051a2725",
-  "hash": "sha256-I2noipOhVEAZ1w6tsG7rhGC7Zw6G4mvlf4rt2xsWrsc="
+  "version": "unstable-20260905000801-450a39a",
+  "rev": "450a39a37cb2353da7ae3a492cfb038af65bc46c",
+  "hash": "sha256-6C5ultwt+w3uk3p9twAf8crE8iQ7WUqVwC10oJ4oL50="
 }


### PR DESCRIPTION
Automated package bump for `[
  "pcsx2_git"
]`.