### PR TITLE
chore: bump shadps4_git

### DIFF
--- a/pkgs/shadps4-git/manifest.json
+++ b/pkgs/shadps4-git/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260903124023-2eca0b5",
-  "rev": "2eca0b5f0b7555c7ca67e043fbbc03ac4b2f7f9d",
-  "hash": "sha256-QPLLKPfFzkx/8caP+DSiHDUq9hYSAYEigYrGxNHWcDc="
+  "version": "unstable-20260905011046-1cf28cb",
+  "rev": "1cf28cbc96c062a255e25f319026d1eb86721237",
+  "hash": "sha256-Wzw3hOVZR6eL3X/u9WMrmSMe4iLuDti7SsLDYg2frWM="
 }


### PR DESCRIPTION
Automated package bump for `[
  "shadps4_git"
]`.