### PR TITLE
chore: bump zed-editor_git

### DIFF
--- a/pkgs/zed-editor-git/manifest.json
+++ b/pkgs/zed-editor-git/manifest.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260904030213-1057c2c",
-  "rev": "1057c2cf3d5b4aefd04755e1387c7826a4d7fba6",
-  "hash": "sha256-gKCsbn5KBrVpGn1Oj5S4jBwqNGULFZR29IqX1mcVKjU=",
-  "cargoHash": "sha256-2kTOL0H7q85AgoAxyTMJn5ccWcOPiyngAFPuJrqRepE="
+  "version": "unstable-20260904225409-5a9b955",
+  "rev": "5a9b9558db01a6b906cec2fb70a797affdc58cdd",
+  "hash": "sha256-Orcua7p/wj1qh2b0fQ1+PUdLwTRPJ7vpBjkBQ7NQl5E=",
+  "cargoHash": "sha256-z+TIKhymaDeqhX/HIclxTlPXthdQ2QH+svoVMn1M+EM="
 }


### PR DESCRIPTION
Automated package bump for `[
  "zed-editor_git"
]`.