### PR TITLE
chore: bump openrgb_git

### DIFF
--- a/pkgs/openrgb-git/manifest.json
+++ b/pkgs/openrgb-git/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260905024839-ed3d789",
-  "rev": "ed3d7894c80fbfd396c1a662478bb2cc0a5bf844",
-  "hash": "sha256-uHt5pVStuPQWRxMQC+seBKC55bVfAiIVcb00d5itNjo="
+  "version": "unstable-20260905233834-523bdb9",
+  "rev": "523bdb96f8ec14a9834c8f3b539c34109a1d6f95",
+  "hash": "sha256-myJ79u66te4y+UxVjriLL4Tr8qztdemZkR2LxKWy2fQ="
 }


### PR DESCRIPTION
Automated package bump for `[
  "openrgb_git"
]`.