### PR TITLE
chore: bump libportal_git

### DIFF
--- a/pkgs/libportal-git/manifest.json
+++ b/pkgs/libportal-git/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260905005220-280c128",
-  "rev": "280c1281e0d1710574d3409869097df0de61c366",
-  "hash": "sha256-jHuw/KdVCD7u0LNpcNtPlnhALuYbfFIMnHUKpqJ5J2k="
+  "version": "unstable-20260905154158-a1a15cc",
+  "rev": "a1a15cccafb153bec2d4f47d5933a2cbeb74f5f3",
+  "hash": "sha256-g3kepulHiQ8PlJeEPrKqiCMOWa+e89PiNRFwgtPiCy8="
 }


### PR DESCRIPTION
Automated package bump for `[
  "libportal_git"
]`.