### PR TITLE
chore: bump libdrm_git

### DIFF
--- a/pkgs/mesa-git/default.nix
+++ b/pkgs/mesa-git/default.nix
@@ -15,8 +15,8 @@ let
     domain = "gitlab.freedesktop.org";
     owner = "virgl";
     repo = "venus-protocol";
-    rev = "v1.1.1";
-    hash = "sha256-VHn2UVpDB3UiJItFMh3/yndztIKZvHClVZDlTHztW7g=";
+    rev = "v1.1.2";
+    hash = "sha256-AQMuAnYI/LZutHqzERpkS4fs8vLfTNADZLFPFwBKVYE=";
   };
 in
 gitOverride (current: {

--- a/pkgs/mesa-git/manifest.json
+++ b/pkgs/mesa-git/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260904230749-23373e9",
-  "rev": "23373e9fce2af674bd61a2501548be2ed035880b",
-  "hash": "sha256-ACE+VOEJ5EWum/wqmGCtzhY0WyU4g7+WoSVJcoGvZwk="
+  "version": "unstable-20260905154428-86158b8",
+  "rev": "86158b8c7467cadcd24f8a8cf02aa3bc748f7e3f",
+  "hash": "sha256-gfmaF3uWvIQTZ4eXNZQwHkGrsEE9LTCPK6DJJYicTFg="
 }


### PR DESCRIPTION
Automated package bump for `[
  "libdrm_git",
  "wayland-protocols_git",
  "mesa_git",
  "wayland_git",
  "wlroots_git",
  "sway-unwrapped_git",
  "xdg-desktop-portal-wlr_git"
]`.