### PR TITLE
chore: bump shadps4_git

### DIFF
--- a/pkgs/shadps4-git/manifest.json
+++ b/pkgs/shadps4-git/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260905011046-1cf28cb",
-  "rev": "1cf28cbc96c062a255e25f319026d1eb86721237",
-  "hash": "sha256-Wzw3hOVZR6eL3X/u9WMrmSMe4iLuDti7SsLDYg2frWM="
+  "version": "unstable-20260905221837-17ca670",
+  "rev": "17ca6700f5ec7befdcbbeda446f8fbab97deffbf",
+  "hash": "sha256-iJjIHcG+8u2XfYLYIZ3ITiiyOe3XxKXWjhWtmEO68Tc="
 }


### PR DESCRIPTION
Automated package bump for `[
  "shadps4_git"
]`.