### PR TITLE
Fix ``firefox_nightly`` & ``nss_git``

### DIFF
--- a/maintenance/failures.x86_64-linux.nix
+++ b/maintenance/failures.x86_64-linux.nix
@@ -1,6 +1,4 @@
 {
-  "firefox-unwrapped_nightly" = "/nix/store/2b8q29w0h4f3wf0f73x6f26f9caizvr9-firefox-nightly-unwrapped-156.0a1-20260825213824-2aa0bcf";
-  "firefox_nightly" = "/nix/store/2n8mrvy8cndh9sl91dlrbsgy27gqyyr0-firefox-nightly-156.0a1-20260825213824-2aa0bcf";
   "linuxPackages_cachyos.ajantv2" = "/nix/store/1cxhlr0qcc399vr9gfdymq2k5c0k42ap-17.5.0-17.5.0-7.2.3-x86_64-unknown-linux-gnu";
   "linuxPackages_cachyos.amdgpu-i2c" = "/nix/store/752hddb5argjsjs403pjym6np783dsjd-amdgpu-i2c-x86_64-unknown-linux-gnu-0-unstable-2024-12-16";
   "linuxPackages_cachyos.bcachefs" = "/nix/store/fnvagwpggw44gbvwk1inhyc7k1vkyf61-bcachefs-x86_64-unknown-linux-gnu-7.2.3-1.39.2";

--- a/pkgs/firefox-nightly/default.nix
+++ b/pkgs/firefox-nightly/default.nix
@@ -4,38 +4,34 @@
   current ? importJSON ./manifest.json,
   buildMozillaMach,
   callPackage,
+  fetchFromGitHub,
   fetchNpmDeps,
-  fetchurl,
-  nodejs,
   npmHooks,
   nss_git,
   nyxUtils,
   python314,
   stdenv,
 
-  # Platform-specific:
-  apple-sdk_26,
-
   # Temporary fixes:
-  fetchFromGitHub,
   rust-cbindgen,
   rustPlatform,
 }:
 
 let
-  firefoxRepo = "mozilla-firefox/firefox";
-  firefoxSourceRepo = "https://github.com/${firefoxRepo}";
+  firefoxOwner = "mozilla-firefox";
+  firefoxRepo = "firefox";
+  firefoxSourceRepo = "https://github.com/${firefoxOwner}/${firefoxRepo}";
+  newtabPath = "browser/extensions/newtab";
   binaryName = "firefox-nightly";
   version = "${current.version}-${current.buildId}-${builtins.substring 0 7 current.rev}";
-  firefoxSrc = fetchurl {
-    inherit (current) hash;
-    url = "https://codeload.github.com/${firefoxRepo}/tar.gz/${current.rev}";
-    name = "firefox.tar.gz";
+  firefoxSrc = fetchFromGitHub {
+    inherit (current) hash rev;
+    owner = firefoxOwner;
+    repo = firefoxRepo;
   };
 
   newtabNpmDeps = fetchNpmDeps {
-    src = firefoxSrc;
-    sourceRoot = "firefox-${current.rev}/browser/extensions/newtab";
+    src = "${firefoxSrc}/${newtabPath}";
     hash = current.newtabNpmDepsHash;
   };
 
@@ -68,25 +64,12 @@ let
   removedPatches = [
     "133-env-var-for-system-dir.patch"
     "136-no-buildconfig.patch"
-    "139-wayland-drag-animation.patch"
-    "140-bindgen-string-view.patch"
-    "153-cbindgen-0.29.4-compat.patch"
   ];
 
   addedPatches = [
     ./env_var_for_system_dir-ff-unstable.patch
     ./no-buildconfig-ffx-unstable.patch
   ];
-
-  isRustCbindgen =
-    pkg:
-    (pkg.outPath or null) == (rust-cbindgen.outPath or null)
-    || lib.elem (pkg.pname or "") [
-      "rust-cbindgen"
-      "cbindgen"
-    ];
-
-  replaceRustCbindgen = pkg: if isRustCbindgen pkg then rust-cbindgen_latest else pkg;
 
   mach =
     (buildMozillaMach {
@@ -99,6 +82,41 @@ let
       applicationName = "Firefox Nightly";
       branding = "browser/branding/nightly";
       src = firefoxSrc;
+      extraPatches = addedPatches;
+      extraPostPatch = ''
+        (
+          readonly newtab_root="$PWD/${newtabPath}"
+
+          export npmDeps=${newtabNpmDeps}
+          export npmRoot="$newtab_root"
+
+          source ${npmHooks.npmConfigHook}/nix-support/setup-hook
+          npmConfigHook
+
+          ${lib.getExe python314} -c ${lib.escapeShellArg ''
+            import hashlib
+            import sys
+            from pathlib import Path
+
+            newtab_root = Path(sys.argv[1])
+            lockfile = newtab_root / "package-lock.json"
+            stamp = newtab_root / "node_modules" / ".newtab-install-stamp"
+
+            with lockfile.open("rb") as lockfile_stream:
+                digest = hashlib.file_digest(lockfile_stream, "sha256").digest()
+
+            stamp.write_bytes(digest)
+          ''} "$newtab_root"
+
+          test -f "$newtab_root/node_modules/webpack/bin/webpack.js"
+        )
+      '';
+
+      extraPassthru = {
+        inherit newtabNpmDeps;
+        rust-cbindgen = rust-cbindgen_latest;
+      };
+
       meta = {
         description = "Web browser built from Firefox Nightly source tree";
         homepage = "https://www.firefox.com/";
@@ -117,64 +135,24 @@ let
     }).override
       {
         enableAddonSigning = false;
+        nss_latest = nss_git;
+        rust-cbindgen = rust-cbindgen_latest;
       };
-
-  postOverride = prevAttrs: {
-    patches = nyxUtils.removeByBaseNames removedPatches (prevAttrs.patches or [ ]) ++ addedPatches;
-
-    env = (prevAttrs.env or { }) // {
-      MOZ_SOURCE_REPO = firefoxSourceRepo;
-      MOZ_SOURCE_CHANGESET = current.rev;
-      MOZ_INCLUDE_SOURCE_INFO = "1";
-    };
-
-    nativeBuildInputs = map replaceRustCbindgen (prevAttrs.nativeBuildInputs or [ ]) ++ [
-      nodejs
-    ];
-
-    buildInputs =
-      (prevAttrs.buildInputs or [ ]) ++ lib.optional stdenv.hostPlatform.isDarwin apple-sdk_26;
-
-    preBuild = (prevAttrs.preBuild or "") + ''
-      (
-        readonly newtab_root="''${MOZ_OBJDIR%/*}/browser/extensions/newtab"
-
-        export npmDeps=${newtabNpmDeps}
-        export npmRoot="$newtab_root"
-
-        source ${npmHooks.npmConfigHook}/nix-support/setup-hook
-        npmConfigHook
-
-        ${lib.getExe python314} -c ${lib.escapeShellArg ''
-          import hashlib
-          import sys
-          from pathlib import Path
-
-          newtab_root = Path(sys.argv[1])
-          lockfile = newtab_root / "package-lock.json"
-          stamp = newtab_root / "node_modules" / ".newtab-install-stamp"
-
-          with lockfile.open("rb") as lockfile_stream:
-              digest = hashlib.file_digest(lockfile_stream, "sha256").digest()
-
-          stamp.write_bytes(digest)
-        ''} "$newtab_root"
-
-        test -f "$newtab_root/node_modules/webpack/bin/webpack.js"
-      )
-    '';
-
-    passthru = (prevAttrs.passthru or { }) // {
-      inherit
-        newtabNpmDeps
-        updateScript
-        ;
-      rust-cbindgen = rust-cbindgen_latest;
-    };
-  };
-
-  newInputs = {
-    nss_latest = nss_git;
-  };
 in
-nyxUtils.multiOverride mach newInputs postOverride
+mach.overrideAttrs (prevAttrs: {
+  configureFlags = lib.filter (
+    flag:
+    !lib.elem flag [
+      "--disable-ffmpeg"
+      "--enable-ffmpeg"
+    ]
+  ) (prevAttrs.configureFlags or [ ]);
+
+  env = (prevAttrs.env or { }) // {
+    MOZ_SOURCE_REPO = firefoxSourceRepo;
+    MOZ_SOURCE_CHANGESET = current.rev;
+    MOZ_INCLUDE_SOURCE_INFO = "1";
+  };
+
+  patches = nyxUtils.removeByBaseNames removedPatches (prevAttrs.patches or [ ]);
+})

--- a/pkgs/firefox-nightly/manifest.json
+++ b/pkgs/firefox-nightly/manifest.json
@@ -1,7 +1,7 @@
 {
-  "version": "156.0a1",
-  "rev": "2aa0bcf95c98681376e30d6a9aa4df2b27885abc",
-  "buildId": "20260825213824",
-  "hash": "sha256-TTeH/GLjLOhOxrYyAs6Yi8UL4rbcH5hIZkwW41oe/LY=",
+  "version": "157.0a1",
+  "rev": "ae0bb53a873d228e4e61b796e184dc3c687ff82e",
+  "buildId": "20260906093052",
+  "hash": "sha256-S7xvqNiAPAoMJjGi1d5nS/rvvGq9rXR/DbPYRc82nWE=",
   "newtabNpmDepsHash": "sha256-6NhZWVpbB0kX3d+9QaxFIgGeCfhqusNTANI6pwROWWw="
 }

--- a/pkgs/firefox-nightly/update.nix
+++ b/pkgs/firefox-nightly/update.nix
@@ -24,15 +24,29 @@ let
   ];
 
   text = ''
-    PATH="${path}:$PATH"
+    set -euo pipefail
 
-    readonly manifest_json="''${MANIFEST_JSON:-pkgs/firefox-nightly/manifest.json}"
+    export PATH="${path}:$PATH"
+
     readonly buildhub_url="https://buildhub.moz.tools/api/search"
     readonly hg_repo="https://hg.mozilla.org/mozilla-central"
     readonly github_repo="mozilla-firefox/firefox"
 
+    die() {
+      printf 'error: %s\n' "$*" >&2
+      exit 1
+    }
+
     fetch_json() {
-      curl -fsSL "$@"
+      curl \
+        --fail \
+        --silent \
+        --show-error \
+        --location \
+        --retry 3 \
+        --retry-all-errors \
+        --retry-delay 1 \
+        "$@"
     }
 
     json_field() {
@@ -43,9 +57,65 @@ let
       printf '%.9s' "$1"
     }
 
-    if [ ! -f "$manifest_json" ]; then
-      echo "error: manifest not found: $manifest_json" >&2
-      exit 1
+    validate_build_id() {
+      local label="$1"
+      local value="$2"
+
+      [[ "$value" =~ ^[0-9]{14}$ ]] \
+        || die "$label must be a 14-digit Mozilla build ID (got: $value)"
+    }
+
+    validate_revision() {
+      local label="$1"
+      local value="$2"
+
+      [[ "$value" =~ ^[0-9a-fA-F]{40}$ ]] \
+        || die "$label must be a 40-character hexadecimal revision: $value"
+    }
+
+    validate_sha256() {
+      local label="$1"
+      local value="$2"
+
+      [[ "$value" =~ ^sha256-[A-Za-z0-9+/]{43}=$ ]] \
+        || die "$label must be a SHA-256 SRI hash: $value"
+    }
+
+    repo_root=$(git rev-parse --show-toplevel 2>/dev/null) \
+      || die "not inside a Git repository"
+
+    repo_root=$(realpath -e -- "$repo_root") \
+      || die "failed to resolve Git repository root"
+
+    readonly repo_root
+
+    if [ -n "''${MANIFEST_JSON:-}" ]; then
+      manifest_json=$(realpath -e -- "$MANIFEST_JSON") \
+        || die "manifest not found: $MANIFEST_JSON"
+    else
+      manifest_json=$(realpath -e -- "$repo_root/pkgs/firefox-nightly/manifest.json") \
+        || die "manifest not found: $repo_root/pkgs/firefox-nightly/manifest.json"
+    fi
+
+    readonly manifest_json
+
+    manifest_rel=$(realpath --relative-to="$repo_root" -- "$manifest_json") \
+      || die "failed to resolve manifest path relative to repository"
+
+    readonly manifest_rel
+
+    if [[ "$manifest_rel" == ".." || "$manifest_rel" == ../* ]]; then
+      die "manifest must be inside the Git repository: $manifest_json"
+    fi
+
+    git -C "$repo_root" \
+      ls-files --error-unmatch -- "$manifest_rel" \
+      >/dev/null 2>&1 \
+      || die "manifest is not tracked by Git: $manifest_rel"
+
+    if ! git -C "$repo_root" diff --quiet -- "$manifest_rel" \
+      || ! git -C "$repo_root" diff --cached --quiet -- "$manifest_rel"; then
+      die "manifest has uncommitted changes: $manifest_rel"
     fi
 
     local_version=$(json_field '.version' <"$manifest_json")
@@ -53,6 +123,11 @@ let
     local_build_id=$(json_field '.buildId' <"$manifest_json")
     local_hash=$(json_field '.hash' <"$manifest_json")
     local_newtab_npm_deps_hash=$(json_field '.newtabNpmDepsHash' <"$manifest_json")
+
+    validate_revision "manifest rev" "$local_rev"
+    validate_build_id "manifest buildId" "$local_build_id"
+    validate_sha256 "manifest hash" "$local_hash"
+    validate_sha256 "manifest newtabNpmDepsHash" "$local_newtab_npm_deps_hash"
 
     buildhub_json=$(
       fetch_json \
@@ -121,6 +196,9 @@ let
         json_field '.hits.hits[0]._source.source.revision'
     )
 
+    validate_build_id "Buildhub build ID" "$latest_build_id"
+    validate_revision "Buildhub Mercurial revision" "$latest_hg_rev"
+
     pushlog_json=$(
       fetch_json "$hg_repo/json-pushes?changeset=$latest_hg_rev&version=2"
     )
@@ -149,34 +227,32 @@ let
           '
     )
 
-    if [ "$local_version" = "$latest_version" ] \
-      && [ "$local_rev" = "$latest_rev" ] \
-      && [ "$local_build_id" = "$latest_build_id" ]; then
+    validate_revision "Mozilla Git revision" "$latest_rev"
+
+    if [ "$local_build_id" = "$latest_build_id" ]; then
+      if [ "$local_version" != "$latest_version" ] \
+        || [ "$local_rev" != "$latest_rev" ]; then
+        die "Buildhub metadata conflicts with local manifest for build ID $local_build_id"
+      fi
+
       echo "firefox-nightly is already up to date: $local_version-$local_build_id-$(git_short "$local_rev")"
       exit 0
     fi
 
-    latest_url="https://codeload.github.com/$github_repo/tar.gz/$latest_rev"
-
-    if [ "$local_rev" = "$latest_rev" ]; then
-      latest_hash="$local_hash"
-    else
-      latest_hash=$(
-        nix --extra-experimental-features nix-command \
-          store prefetch-file \
-          --json \
-          --hash-type sha256 \
-          --name "firefox.tar.gz" \
-          "$latest_url" |
-          json_field '.hash'
-      )
+    if [[ "$latest_build_id" < "$local_build_id" ]]; then
+      die "Buildhub returned older build $latest_build_id; refusing to downgrade from $local_build_id"
     fi
 
-    tmpdir=$(mktemp -d)
+    latest_hash="$local_hash"
+    latest_newtab_npm_deps_hash="$local_newtab_npm_deps_hash"
+
+    tmpdir=""
     tmp_manifest=""
 
     cleanup() {
-      rm -rf -- "$tmpdir"
+      if [ -n "$tmpdir" ]; then
+        rm -rf -- "$tmpdir"
+      fi
 
       if [ -n "$tmp_manifest" ]; then
         rm -f -- "$tmp_manifest"
@@ -185,32 +261,45 @@ let
 
     trap cleanup EXIT
 
-    latest_lock="$tmpdir/package-lock.json"
-    local_lock="$tmpdir/local-package-lock.json"
+    if [ "$local_rev" != "$latest_rev" ]; then
+      latest_url="https://github.com/$github_repo/archive/$latest_rev.tar.gz"
 
-    fetch_json \
-      "https://raw.githubusercontent.com/$github_repo/$latest_rev/browser/extensions/newtab/package-lock.json" \
-      >"$latest_lock"
-
-    latest_newtab_npm_deps_hash=""
-
-    if fetch_json \
-      "https://raw.githubusercontent.com/$github_repo/$local_rev/browser/extensions/newtab/package-lock.json" \
-      >"$local_lock" \
-      && cmp -s "$local_lock" "$latest_lock"; then
-      latest_newtab_npm_deps_hash="$local_newtab_npm_deps_hash"
-    fi
-
-    if [ -z "$latest_newtab_npm_deps_hash" ]; then
-      latest_newtab_npm_deps_hash=$(
-        prefetch-npm-deps "$latest_lock" |
-          tail -n 1
+      latest_hash=$(
+        nix --extra-experimental-features nix-command \
+          store prefetch-file \
+          --json \
+          --hash-type sha256 \
+          --unpack \
+          "$latest_url" |
+          json_field '.hash'
       )
-    fi
 
-    if [[ ! "$latest_newtab_npm_deps_hash" =~ ^sha256-[A-Za-z0-9+/]+=*$ ]]; then
-      echo "error: invalid newtab npm dependency hash: $latest_newtab_npm_deps_hash" >&2
-      exit 1
+      validate_sha256 "prefetched Firefox source hash" "$latest_hash"
+
+      tmpdir=$(mktemp -d)
+
+      latest_lock="$tmpdir/package-lock.json"
+      local_lock="$tmpdir/local-package-lock.json"
+
+      fetch_json \
+        "https://raw.githubusercontent.com/$github_repo/$latest_rev/browser/extensions/newtab/package-lock.json" \
+        >"$latest_lock"
+
+      if fetch_json \
+        "https://raw.githubusercontent.com/$github_repo/$local_rev/browser/extensions/newtab/package-lock.json" \
+        >"$local_lock" \
+        && cmp -s "$local_lock" "$latest_lock"; then
+        latest_newtab_npm_deps_hash="$local_newtab_npm_deps_hash"
+      else
+        latest_newtab_npm_deps_hash=$(
+          prefetch-npm-deps "$latest_lock" |
+            tail -n 1
+        )
+      fi
+
+      validate_sha256 \
+        "prefetched New Tab npm dependency hash" \
+        "$latest_newtab_npm_deps_hash"
     fi
 
     tmp_manifest=$(mktemp -- "$manifest_json.XXXXXX")
@@ -237,14 +326,17 @@ let
     mv -- "$tmp_manifest" "$manifest_json"
     tmp_manifest=""
 
+    if git -C "$repo_root" diff --quiet -- "$manifest_rel"; then
+      die "manifest did not change despite a newer Buildhub build"
+    fi
+
     commit_message="firefox_nightly: $local_version-$local_build_id-$(git_short "$local_rev") -> $latest_version-$latest_build_id-$(git_short "$latest_rev")"
 
-    git commit \
+    git -C "$repo_root" commit \
       --only \
       --message "$commit_message" \
       -- \
-      "$manifest_json"
+      "$manifest_rel"
   '';
-
 in
 writeShellScript name text

--- a/pkgs/nss-git/default.nix
+++ b/pkgs/nss-git/default.nix
@@ -1,24 +1,30 @@
-{ prev, gitOverride, ... }:
+{
+  gitOverride,
+  nyxUtils,
+  prev,
+  ...
+}:
 
 gitOverride {
   nyxKey = "nss_git";
   prev = prev.nss_latest;
-
   manifestPath = "pkgs/nss-git/manifest.json";
   fetcher = "fetchFromGitHub";
   fetcherData = {
-    owner = "nss-dev";
+    owner = "mozilla";
     repo = "nss";
   };
   ref = "master";
 
   postOverride = prevAttrs: {
-    patches =
-      (builtins.filter (p: !prev.lib.hasSuffix "85_security_load_3.85+.patch" (toString p)) (
-        prevAttrs.patches or [ ]
-      ))
+    patches = nyxUtils.removeByBaseName "85_security_load_3.85+.patch" (prevAttrs.patches or [ ]) ++ [
+      # Fix build.sh with external NSPR by avoiding a lookup of a local nspr.pc
+      # that is not generated when NSS is built with --with-nspr.
+      ./fix-external-nspr-pkg-config.patch
+
       # Add NIX_NSS_LIBDIR fallback for loading libsoftokn3.so and related libs
       # when standard library paths are unavailable (e.g., in Nix isolated environments).
-      ++ [ ./nss-nix-path-PR.patch ];
+      ./nss-nix-path-PR.patch
+    ];
   };
 }

--- a/pkgs/nss-git/fix-external-nspr-pkg-config.patch
+++ b/pkgs/nss-git/fix-external-nspr-pkg-config.patch
@@ -1,0 +1,17 @@
+diff --git a/build.sh b/build.sh
+--- a/build.sh
++++ b/build.sh
+@@ -306,8 +306,11 @@ generate_pkg_config()
+     vpatch=$(sed -n 's/^#define NSS_VPATCH \([0-9]*\).*/\1/p' "$nss_h")
+     [ -n "$vmajor" ] || return 0
+ 
+-    nspr_version=$(sed -n 's/^Version: *//p' \
+-        "$obj_dir/lib/pkgconfig/nspr.pc" 2>/dev/null)
++    nspr_version=
++    if [ -f "$obj_dir/lib/pkgconfig/nspr.pc" ]; then
++        nspr_version=$(sed -n 's/^Version: *//p' \
++            "$obj_dir/lib/pkgconfig/nspr.pc")
++    fi
+     : "${nspr_version:=4.32}"
+     mkdir -p "$obj_dir/lib/pkgconfig"
+     sed -e "s|%prefix%|$obj_dir|g" \

--- a/pkgs/nss-git/manifest.json
+++ b/pkgs/nss-git/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260826001434-1de6006",
-  "rev": "1de60067e396e84ab31fb9ecd689be7b2cceb6bf",
-  "hash": "sha256-EhHVnxvZx6TwsFICAd42r8YVs3+7wLzRKnI7pZ7kLrY="
+  "version": "unstable-20260903105110-7db8de4",
+  "rev": "7db8de42431841b214b49fd2cb7122a07aa631b8",
+  "hash": "sha256-41xJUv9GXKNUc9fs7aazQuwlyHrR1F9Up5zxB2GerRE="
 }


### PR DESCRIPTION
What the tin says practically,  I also updated update.nix and the firefox nightly drv itself to use ``fetchFromGithub`` instead of ``fetchurl``. I made the updater also more robust in general adding more checks to make sure it's not scewing up. I made nss_git use the ``removeByBaseName`` util and changed the fetcher from using ``nss-dev`` to ``mozilla``.