### PR TITLE
chore: bump openrgb_git

### DIFF
--- a/pkgs/openrgb-git/manifest.json
+++ b/pkgs/openrgb-git/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260905233834-523bdb9",
-  "rev": "523bdb96f8ec14a9834c8f3b539c34109a1d6f95",
-  "hash": "sha256-myJ79u66te4y+UxVjriLL4Tr8qztdemZkR2LxKWy2fQ="
+  "version": "unstable-20260906204552-1da6a65",
+  "rev": "1da6a652fd0ee484be5b5844f8673f8590257cbb",
+  "hash": "sha256-Ap64Eskw+G2WIgmvVUtKpKAlwK6hHlPsnB9TDiKXGoE="
 }


### PR DESCRIPTION
Automated package bump for `[
  "openrgb_git"
]`.