### PR TITLE
chore: bump pcsx2_git

### DIFF
--- a/pkgs/pcsx2-git/manifest.json
+++ b/pkgs/pcsx2-git/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260906031442-236f67a",
-  "rev": "236f67a82fd8a37b1e5c128228403fb7b89b3cd8",
-  "hash": "sha256-ayUVI8BZCnP3XIWQxsvkcyTo2PYBGbr28Z2Lp//VrCM="
+  "version": "unstable-20260907003534-4102a0b",
+  "rev": "4102a0bd2c6a7b7d64fe4031d65e5b08aedac2c2",
+  "hash": "sha256-wELviJrGcjzdtL4VeZUxe7NYbAOaoImieskgh5lWkaQ="
 }


### PR DESCRIPTION
Automated package bump for `[
  "pcsx2_git"
]`.