### PR TITLE
chore: bump nix_git

### DIFF
--- a/pkgs/nix-git/manifest.json
+++ b/pkgs/nix-git/manifest.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260904200258-0765ffa",
-  "rev": "0765ffa540e2adfda7b69efafdbac821ebc48034",
-  "hash": "sha256-MYUUwkSnDt+Hn5HUvPJ7f54umm/XGrRFVtLR52tWy2o=",
-  "lastModifiedDate": "20260904200258"
+  "version": "unstable-20260906214453-cc06c40",
+  "rev": "cc06c406c06e3cc93b138457843657bf4831f39e",
+  "hash": "sha256-ZxIJVCghE2Oj0wyW8kR2TM2NOiNQWVuAIhold41Tq7k=",
+  "lastModifiedDate": "20260906214453"
 }


### PR DESCRIPTION
Automated package bump for `[
  "nix_git"
]`.