### PR TITLE
chore: bump zed-editor_git

### DIFF
--- a/pkgs/zed-editor-git/manifest.json
+++ b/pkgs/zed-editor-git/manifest.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260904225409-5a9b955",
-  "rev": "5a9b9558db01a6b906cec2fb70a797affdc58cdd",
-  "hash": "sha256-Orcua7p/wj1qh2b0fQ1+PUdLwTRPJ7vpBjkBQ7NQl5E=",
+  "version": "unstable-20260907000029-1870e26",
+  "rev": "1870e269ad88802147f2baec3086abb67d17260a",
+  "hash": "sha256-JLDoy2ZVjJmdANAkAIh9CoFHiN0iStkDQgRqg7fKLG8=",
   "cargoHash": "sha256-z+TIKhymaDeqhX/HIclxTlPXthdQ2QH+svoVMn1M+EM="
 }


### PR DESCRIPTION
Automated package bump for `[
  "zed-editor_git"
]`.