### PR TITLE
chore: bump libdrm_git

### DIFF
--- a/pkgs/mesa-git/manifest.json
+++ b/pkgs/mesa-git/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260905154428-86158b8",
-  "rev": "86158b8c7467cadcd24f8a8cf02aa3bc748f7e3f",
-  "hash": "sha256-gfmaF3uWvIQTZ4eXNZQwHkGrsEE9LTCPK6DJJYicTFg="
+  "version": "unstable-20260906140812-c3b008c",
+  "rev": "c3b008c1ba01d455351b762253ef44c3ca19653f",
+  "hash": "sha256-i8KdU00dk+8vvE5hZEHI66L8D+LK1DfhYZ9O6/n4L/k="
 }


### PR DESCRIPTION
Automated package bump for `[
  "libdrm_git",
  "wayland-protocols_git",
  "mesa_git",
  "wayland_git",
  "wlroots_git",
  "sway-unwrapped_git",
  "xdg-desktop-portal-wlr_git"
]`.