### PR TITLE
chore: bump shadps4_git

### DIFF
--- a/pkgs/shadps4-git/manifest.json
+++ b/pkgs/shadps4-git/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260905221837-17ca670",
-  "rev": "17ca6700f5ec7befdcbbeda446f8fbab97deffbf",
-  "hash": "sha256-iJjIHcG+8u2XfYLYIZ3ITiiyOe3XxKXWjhWtmEO68Tc="
+  "version": "unstable-20260906153848-3303b03",
+  "rev": "3303b03e5bc3ede66abd24c5aa8b51926c29c86c",
+  "hash": "sha256-/whSgGXw/CtOz91yknJ+lpGSQ2ER060Sx4BaSN5cBnQ="
 }


### PR DESCRIPTION
Automated package bump for `[
  "shadps4_git"
]`.