### PR TITLE
chore: bump nss_git

### DIFF
--- a/pkgs/firefox-nightly/manifest.json
+++ b/pkgs/firefox-nightly/manifest.json
@@ -1,7 +1,7 @@
 {
   "version": "157.0a1",
-  "rev": "ae0bb53a873d228e4e61b796e184dc3c687ff82e",
-  "buildId": "20260906093052",
-  "hash": "sha256-S7xvqNiAPAoMJjGi1d5nS/rvvGq9rXR/DbPYRc82nWE=",
+  "rev": "14d1609f773de02558060ba431880c4e82d93465",
+  "buildId": "20260906203723",
+  "hash": "sha256-Kkt06eO7Fc/nEYIiRnz172YUP+ckLJ8CjWoSmBNdYEs=",
   "newtabNpmDepsHash": "sha256-6NhZWVpbB0kX3d+9QaxFIgGeCfhqusNTANI6pwROWWw="
 }


### PR DESCRIPTION
Automated package bump for `[
  "nss_git",
  "firefox-unwrapped_nightly"
]`.