### PR TITLE
chore: bump nix_git

### DIFF
--- a/pkgs/nix-git/manifest.json
+++ b/pkgs/nix-git/manifest.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260906214453-cc06c40",
-  "rev": "cc06c406c06e3cc93b138457843657bf4831f39e",
-  "hash": "sha256-ZxIJVCghE2Oj0wyW8kR2TM2NOiNQWVuAIhold41Tq7k=",
-  "lastModifiedDate": "20260906214453"
+  "version": "unstable-20260907234845-77101ed",
+  "rev": "77101ed397ba50a2fc55fd41667aa92ca99e4797",
+  "hash": "sha256-U46MLCURycBWglP8q/DLApjEZ72hjqM2rU5ajQX0rlQ=",
+  "lastModifiedDate": "20260907234845"
 }


### PR DESCRIPTION
Automated package bump for `[
  "nix_git"
]`.