### PR TITLE
chore: bump openrgb_git

### DIFF
--- a/pkgs/openrgb-git/manifest.json
+++ b/pkgs/openrgb-git/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260906204552-1da6a65",
-  "rev": "1da6a652fd0ee484be5b5844f8673f8590257cbb",
-  "hash": "sha256-Ap64Eskw+G2WIgmvVUtKpKAlwK6hHlPsnB9TDiKXGoE="
+  "version": "unstable-20260908054317-6ac47cc",
+  "rev": "6ac47cc4f3aecd392acc0f499d44173ebde15c1c",
+  "hash": "sha256-xhdyUCzUMV6k/cNjiaBzShDseuKzKolYNrksr4J7qxc="
 }


### PR DESCRIPTION
Automated package bump for `[
  "openrgb_git"
]`.