### PR TITLE
chore: bump pcsx2_git

### DIFF
--- a/pkgs/pcsx2-git/manifest.json
+++ b/pkgs/pcsx2-git/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260907003534-4102a0b",
-  "rev": "4102a0bd2c6a7b7d64fe4031d65e5b08aedac2c2",
-  "hash": "sha256-wELviJrGcjzdtL4VeZUxe7NYbAOaoImieskgh5lWkaQ="
+  "version": "unstable-20260907160909-9869773",
+  "rev": "98697735f1bb1a1452d975251269abd1019876d1",
+  "hash": "sha256-00Fj7cLMX9ZHnU5BdAPIdcJgaEO1Yj/DgeEHzgAA/Bk="
 }


### PR DESCRIPTION
Automated package bump for `[
  "pcsx2_git"
]`.