### PR TITLE
chore: bump zed-editor_git

### DIFF
--- a/pkgs/zed-editor-git/manifest.json
+++ b/pkgs/zed-editor-git/manifest.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260907000029-1870e26",
-  "rev": "1870e269ad88802147f2baec3086abb67d17260a",
-  "hash": "sha256-JLDoy2ZVjJmdANAkAIh9CoFHiN0iStkDQgRqg7fKLG8=",
-  "cargoHash": "sha256-z+TIKhymaDeqhX/HIclxTlPXthdQ2QH+svoVMn1M+EM="
+  "version": "unstable-20260907204219-6f73c7d",
+  "rev": "6f73c7d0a4aae8e32afb5d01b0fcb89e5e3642ff",
+  "hash": "sha256-waobe1Kv/uhvjPGZ+aat9UazAvJdJ1YlSeicCmIqBpI=",
+  "cargoHash": "sha256-vE707MHoaxBzayPxOLQmitMGrozNyb3MgLLnmIPkGJ8="
 }


### PR DESCRIPTION
Automated package bump for `[
  "zed-editor_git"
]`.