### PR TITLE
chore: bump tde2e_git

### DIFF
--- a/pkgs/telegram-desktop-git/default.nix
+++ b/pkgs/telegram-desktop-git/default.nix
@@ -5,6 +5,47 @@
   ...
 }:
 
+let
+  tlottie = final.rustPlatform.buildRustPackage {
+    pname = "tlottie";
+    version = "unstable";
+
+    src = final.fetchFromGitHub {
+      owner = "dkaraush";
+      repo = "tlottie";
+      rev = "dev";
+      hash = "sha256-9FxWiJgdCpLRGHfkPD+4tPnMDf3aVQaNWob1qEAlr+8=";
+    };
+
+    cargoHash = "sha256-R/l5zMRB/2/a4Yf6toPBBvJ1SvebWsGeumwW9U6b7So=";
+
+    buildPhase = ''
+      runHook preBuild
+
+      cargo rustc \
+        --release \
+        --features c-api \
+        --lib \
+        --crate-type staticlib
+
+      runHook postBuild
+    '';
+
+    installPhase = ''
+      runHook preInstall
+
+      install -Dm644 \
+        target/release/libtlottie.a \
+        "$out/lib/libtlottie.a"
+
+      install -Dm644 \
+        include/tlottie.h \
+        "$out/include/tlottie/tlottie.h"
+
+      runHook postInstall
+    '';
+  };
+in
 gitOverride {
   newInputs = with final; {
     # I hope I don't go to robot-hell bc of this:
@@ -30,14 +71,17 @@ gitOverride {
 
   postOverride = prevAttrs: {
     patches = [ ];
+
     # AssertIsDebug() is only available in _DEBUG builds, define it away
     env = (prevAttrs.env or { }) // {
       NIX_CFLAGS_COMPILE = (prevAttrs.env.NIX_CFLAGS_COMPILE or "") + " -DAssertIsDebug(...)=;";
     };
+
     buildInputs = prevAttrs.buildInputs ++ [
       final.tde2e_git
       final.minizip
       final.pango
+      tlottie
     ];
   };
 }

--- a/pkgs/telegram-desktop-git/manifest.json
+++ b/pkgs/telegram-desktop-git/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260904105318-8015898",
-  "rev": "80158983dba09d3bf5d96701f21473d6c34bf5f5",
-  "hash": "sha256-5FAJZ+vkIIiJEa/Y2o5FhyyGXNMMT0GHM8ls0TqZJmA="
+  "version": "unstable-20260909070957-efb596a",
+  "rev": "efb596a02ab71f87ce6dba53c526957c19041725",
+  "hash": "sha256-t4FCwmJrjQRbI+0UBAoXxZWwGHXhI7Zs1B0DRUAamxY="
 }


### PR DESCRIPTION
Automated package bump for `[
  "tde2e_git",
  "tg-owt_git",
  "telegram-desktop-unwrapped_git",
  "telegram-desktop_git"
]`.