### PR TITLE
chore: bump shadps4_git

### DIFF
--- a/pkgs/shadps4-git/manifest.json
+++ b/pkgs/shadps4-git/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260906153848-3303b03",
-  "rev": "3303b03e5bc3ede66abd24c5aa8b51926c29c86c",
-  "hash": "sha256-/whSgGXw/CtOz91yknJ+lpGSQ2ER060Sx4BaSN5cBnQ="
+  "version": "unstable-20260907182458-63cc326",
+  "rev": "63cc326dc5f549b3523215b056fbc01bf77e599a",
+  "hash": "sha256-NuYZGcLonn6CxkMbFHvf+DT+1xXT9aIy9mo6jsqlt8E="
 }


### PR DESCRIPTION
Automated package bump for `[
  "shadps4_git"
]`.