### PR TITLE
chore: bump libdrm_git

### DIFF
--- a/pkgs/mesa-git/default.nix
+++ b/pkgs/mesa-git/default.nix
@@ -15,8 +15,8 @@ let
     domain = "gitlab.freedesktop.org";
     owner = "virgl";
     repo = "venus-protocol";
-    rev = "v1.1.2";
-    hash = "sha256-AQMuAnYI/LZutHqzERpkS4fs8vLfTNADZLFPFwBKVYE=";
+    rev = "v1.1.3";
+    hash = "sha256-epSb26uLAbHYBDr+ju6rzFu4ozD/LUpRuou6hA/BFRM=";
   };
 in
 gitOverride (current: {

--- a/pkgs/mesa-git/manifest.json
+++ b/pkgs/mesa-git/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260906140812-c3b008c",
-  "rev": "c3b008c1ba01d455351b762253ef44c3ca19653f",
-  "hash": "sha256-i8KdU00dk+8vvE5hZEHI66L8D+LK1DfhYZ9O6/n4L/k="
+  "version": "unstable-20260910045938-1775b1f",
+  "rev": "1775b1fffa90ab04219cac48a5b0a6c0c6d7b45b",
+  "hash": "sha256-hGVvDRqQdb19EQsYo964dUep20/u764LexzgiJEMNpk="
 }

--- a/pkgs/wayland-protocols-git/manifest.json
+++ b/pkgs/wayland-protocols-git/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260623093033-afb614d",
-  "rev": "afb614d5fcbd02d261a6ae91920aa91cf3915a8a",
-  "hash": "sha256-EgUVZoH2V9suDICELRgrjNi7NqCRu9LjxDSE3VNgSz0="
+  "version": "unstable-20260903235617-5a430a6",
+  "rev": "5a430a6d52f811720b11234c19690b70106d970b",
+  "hash": "sha256-CArog1ptoc4Smu4NhWsdZqPPbcq0imKACbH3RIkmgdw="
 }


### PR DESCRIPTION
Automated package bump for `[
  "libdrm_git",
  "wayland-protocols_git",
  "mesa_git",
  "wayland_git",
  "wlroots_git",
  "sway-unwrapped_git",
  "xdg-desktop-portal-wlr_git"
]`.