### PR TITLE
chore: bump nss_git

### DIFF
--- a/pkgs/firefox-nightly/manifest.json
+++ b/pkgs/firefox-nightly/manifest.json
@@ -1,7 +1,7 @@
 {
   "version": "157.0a1",
-  "rev": "14d1609f773de02558060ba431880c4e82d93465",
-  "buildId": "20260906203723",
-  "hash": "sha256-Kkt06eO7Fc/nEYIiRnz172YUP+ckLJ8CjWoSmBNdYEs=",
+  "rev": "61c7b6d2fe5fc598e573df6528447ab48bc027b3",
+  "buildId": "20260907210752",
+  "hash": "sha256-wbDcYeqRsIlrBopP2QkulcqriM/pooYgN22gdPAN/78=",
   "newtabNpmDepsHash": "sha256-6NhZWVpbB0kX3d+9QaxFIgGeCfhqusNTANI6pwROWWw="
 }

--- a/pkgs/nss-git/manifest.json
+++ b/pkgs/nss-git/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260903105110-7db8de4",
-  "rev": "7db8de42431841b214b49fd2cb7122a07aa631b8",
-  "hash": "sha256-41xJUv9GXKNUc9fs7aazQuwlyHrR1F9Up5zxB2GerRE="
+  "version": "unstable-20260907121808-608388e",
+  "rev": "608388e43408a9e834af24b93a83bddcbd58ba89",
+  "hash": "sha256-EvJLMWuDwG+UzKDk0qsMyFe8uFclPjDSPdiAVyCp/i0="
 }


### PR DESCRIPTION
Automated package bump for `[
  "nss_git",
  "firefox-unwrapped_nightly"
]`.