### PR TITLE
chore: bump nix_git

### DIFF
--- a/pkgs/nix-git/manifest.json
+++ b/pkgs/nix-git/manifest.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260907234845-77101ed",
-  "rev": "77101ed397ba50a2fc55fd41667aa92ca99e4797",
-  "hash": "sha256-U46MLCURycBWglP8q/DLApjEZ72hjqM2rU5ajQX0rlQ=",
-  "lastModifiedDate": "20260907234845"
+  "version": "unstable-20260909021818-415988d",
+  "rev": "415988dafab28b37c8f92afeda2a5f371388f747",
+  "hash": "sha256-3mGmVfCtfjQYBgW5pPPlNaGZe2rpunvrsKb2PKgtgYc=",
+  "lastModifiedDate": "20260909021818"
 }


### PR DESCRIPTION
Automated package bump for `[
  "nix_git"
]`.