### PR TITLE
chore: bump mangohud_git

### DIFF
--- a/pkgs/mangohud-git/manifest.json
+++ b/pkgs/mangohud-git/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260904053237-076a01c",
-  "rev": "076a01c9ebb7975968f8d6de5a53aefadab3ef6d",
-  "hash": "sha256-JMLKtlBqOKYSXTwZCDK2wnTLsezDn2MoUmcxl1JI/pU="
+  "version": "unstable-20260908125344-28c7915",
+  "rev": "28c79155b347a38046a0233c5da82742d0da78e7",
+  "hash": "sha256-BpyqzNk8kBzTfat/TbA/x6VD7j1K1feuv8gGRYKLLxM="
 }


### PR DESCRIPTION
Automated package bump for `[
  "mangohud_git"
]`.