### PR TITLE
chore: bump openrgb_git

### DIFF
--- a/pkgs/openrgb-git/manifest.json
+++ b/pkgs/openrgb-git/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260908054317-6ac47cc",
-  "rev": "6ac47cc4f3aecd392acc0f499d44173ebde15c1c",
-  "hash": "sha256-xhdyUCzUMV6k/cNjiaBzShDseuKzKolYNrksr4J7qxc="
+  "version": "unstable-20260909052548-e6ea038",
+  "rev": "e6ea038ac8bd49e8cb4dc80476aaaa0dfe7f33ad",
+  "hash": "sha256-KEYxsWHRKwj5fCGfGzlCKbI9uGAztbOUfJ2dX2GHEjs="
 }


### PR DESCRIPTION
Automated package bump for `[
  "openrgb_git"
]`.