### PR TITLE
chore: bump shadps4_git

### DIFF
--- a/pkgs/shadps4-git/manifest.json
+++ b/pkgs/shadps4-git/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260907182458-63cc326",
-  "rev": "63cc326dc5f549b3523215b056fbc01bf77e599a",
-  "hash": "sha256-NuYZGcLonn6CxkMbFHvf+DT+1xXT9aIy9mo6jsqlt8E="
+  "version": "unstable-20260908160702-507464a",
+  "rev": "507464a531c0e8ddb4308f9cad6a73ab413f92d3",
+  "hash": "sha256-uzx4bFwHqEuDJV77Jdhop7KbF8Geb0yZDOl7Cv38jUk="
 }


### PR DESCRIPTION
Automated package bump for `[
  "shadps4_git"
]`.