### PR TITLE
chore: bump zed-editor_git

### DIFF
--- a/pkgs/zed-editor-git/manifest.json
+++ b/pkgs/zed-editor-git/manifest.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260907204219-6f73c7d",
-  "rev": "6f73c7d0a4aae8e32afb5d01b0fcb89e5e3642ff",
-  "hash": "sha256-waobe1Kv/uhvjPGZ+aat9UazAvJdJ1YlSeicCmIqBpI=",
+  "version": "unstable-20260908214406-f29c8ea",
+  "rev": "f29c8eaf13682ef5a4a70a81eb4838b247cf7211",
+  "hash": "sha256-ORkO9lj0l4mRFuEeSifwP22e3WpeYZqVSrK/mQFrqbE=",
   "cargoHash": "sha256-vE707MHoaxBzayPxOLQmitMGrozNyb3MgLLnmIPkGJ8="
 }


### PR DESCRIPTION
Automated package bump for `[
  "zed-editor_git"
]`.