### PR TITLE
chore: bump nss_git

### DIFF
--- a/pkgs/firefox-nightly/manifest.json
+++ b/pkgs/firefox-nightly/manifest.json
@@ -1,7 +1,7 @@
 {
   "version": "157.0a1",
-  "rev": "61c7b6d2fe5fc598e573df6528447ab48bc027b3",
-  "buildId": "20260907210752",
-  "hash": "sha256-wbDcYeqRsIlrBopP2QkulcqriM/pooYgN22gdPAN/78=",
+  "rev": "93ba10a0a6e4ef012b47d033748f4b7bc317f541",
+  "buildId": "20260908215417",
+  "hash": "sha256-dWP9KriYtKt7tX5CRAA/qWwe77CfxrWBfumnw0/XAtI=",
   "newtabNpmDepsHash": "sha256-6NhZWVpbB0kX3d+9QaxFIgGeCfhqusNTANI6pwROWWw="
 }

--- a/pkgs/nss-git/manifest.json
+++ b/pkgs/nss-git/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260907121808-608388e",
-  "rev": "608388e43408a9e834af24b93a83bddcbd58ba89",
-  "hash": "sha256-EvJLMWuDwG+UzKDk0qsMyFe8uFclPjDSPdiAVyCp/i0="
+  "version": "unstable-20260908153547-fc16813",
+  "rev": "fc168131f8a629e30c38b372e08848cabd443194",
+  "hash": "sha256-6hOZmfr6yD+UCiQzqgTIa/K5p9rmrnxijXKEPLUTmGo="
 }


### PR DESCRIPTION
Automated package bump for `[
  "nss_git",
  "firefox-unwrapped_nightly"
]`.