### PR TITLE
Fix GE proton URL

### DIFF
--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -361,7 +361,7 @@ in
     tarballSuffix = ".tar.gz";
     toolPattern = "GE-Proton.*";
     releasePrefix = "GE-Proton";
-    releaseSuffix = "";
+    releaseSuffix = "-x86_64";
     manifestFilename = "ge-manifest.json";
     owner = "GloriousEggroll";
     repo = "proton-ge-custom";


### PR DESCRIPTION
GE Proton added -x86_64 as a suffix to their x86_64 releases