### PR TITLE
Fix GE Proton for real this time

### DIFF
--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -361,7 +361,7 @@ in
     tarballSuffix = ".tar.gz";
     toolPattern = "GE-Proton.*";
     releasePrefix = "GE-Proton";
-    releaseSuffix = "";
+    releaseSuffix = "-x86_64";
     manifestFilename = "ge-manifest.json";
     owner = "GloriousEggroll";
     repo = "proton-ge-custom";

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -361,7 +361,7 @@ in
     tarballSuffix = "-x86_64.tar.gz";
     toolPattern = "GE-Proton.*";
     releasePrefix = "GE-Proton";
-    releaseSuffix = "-x86_64";
+    releaseSuffix = "";
     manifestFilename = "ge-manifest.json";
     owner = "GloriousEggroll";
     repo = "proton-ge-custom";

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -358,10 +358,10 @@ in
 
   proton-ge-custom = final.callPackage ../pkgs/proton-bin {
     toolTitle = "Proton-GE";
-    tarballSuffix = ".tar.gz";
+    tarballSuffix = "-x86_64.tar.gz";
     toolPattern = "GE-Proton.*";
     releasePrefix = "GE-Proton";
-    releaseSuffix = "-x86_64";
+    releaseSuffix = "";
     manifestFilename = "ge-manifest.json";
     owner = "GloriousEggroll";
     repo = "proton-ge-custom";

--- a/pkgs/proton-bin/ge-manifest.json
+++ b/pkgs/proton-bin/ge-manifest.json
@@ -1,5 +1,5 @@
 {
   "base": "11",
-  "release": "3",
-  "hash": "sha256-hhwu3I1A0FH7HnppLeuVO+Ur0znEbZDyt93lDdrZEmY="
+  "release": "6",
+  "hash": "sha256-ZZ+NcfL3hlk0ASCyDBxaFGSqE4k5MyoTdt6iL20twuQ="
 }


### PR DESCRIPTION
GE-Proton added -x86_64 to their x86_64 releases at 11-4
First version added "-x86_64" to the releaseSuffix, but this seems to have confused the updater script

Move "-x86_64" to the tarballSuffix, matching cachyos proton
