### PR TITLE
chore: bump openrgb_git

### DIFF
--- a/pkgs/openrgb-git/manifest.json
+++ b/pkgs/openrgb-git/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260909052548-e6ea038",
-  "rev": "e6ea038ac8bd49e8cb4dc80476aaaa0dfe7f33ad",
-  "hash": "sha256-KEYxsWHRKwj5fCGfGzlCKbI9uGAztbOUfJ2dX2GHEjs="
+  "version": "unstable-20260910021408-84fb7d1",
+  "rev": "84fb7d18d0836d4a66c616ee5f0fe9068d557cdd",
+  "hash": "sha256-jwH7b67wcKD5by5loOQ8Q4PSH0o8VgQpqCh4bmqiddc="
 }


### PR DESCRIPTION
Automated package bump for `[
  "openrgb_git"
]`.