### PR TITLE
chore: bump spirv-headers_git

### DIFF
--- a/pkgs/spirv-headers-git/manifest.json
+++ b/pkgs/spirv-headers-git/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260826184122-4965431",
-  "rev": "496543121ce6419f23d6fa5d7194ba66c36212d2",
-  "hash": "sha256-PTD3GxQnENDngl6bf9YCmCVmvRgdBZczBosFCOCYEXU="
+  "version": "unstable-20260909154538-04fd3ca",
+  "rev": "04fd3caa1e8267e4d95c806cad901181728e1006",
+  "hash": "sha256-RFOwYoGsiGKwUWQqhq2cruLM5oZZPALShn2cR7aUwGw="
 }


### PR DESCRIPTION
Automated package bump for `[
  "spirv-headers_git"
]`.