### PR TITLE
chore: bump pcsx2_git

### DIFF
--- a/pkgs/pcsx2-git/manifest.json
+++ b/pkgs/pcsx2-git/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260909021430-1810140",
-  "rev": "1810140d1df0068c6f55523c457b1caf3a35a506",
-  "hash": "sha256-M6ITM9XPiDcP+Rgx1duNMzShSet4V+hI/Lc0jqYRwRU="
+  "version": "unstable-20260910044715-4a4cbb8",
+  "rev": "4a4cbb875e5cdb123acf2d8b92231f568682d3d9",
+  "hash": "sha256-MkPhXDuRLkcxfoAhxTGzxx9RW6Ckb1tuhacZMgf3JEo="
 }


### PR DESCRIPTION
Automated package bump for `[
  "pcsx2_git"
]`.