### PR TITLE
chore: bump nix_git

### DIFF
--- a/pkgs/nix-git/manifest.json
+++ b/pkgs/nix-git/manifest.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260909021818-415988d",
-  "rev": "415988dafab28b37c8f92afeda2a5f371388f747",
-  "hash": "sha256-3mGmVfCtfjQYBgW5pPPlNaGZe2rpunvrsKb2PKgtgYc=",
-  "lastModifiedDate": "20260909021818"
+  "version": "unstable-20260910001355-f88835d",
+  "rev": "f88835de0971838afb7598a066c92f9464164f54",
+  "hash": "sha256-yZ+T3LZT91aHjAiDpSJ3aTxGeBMiGPTrVq7Z/iwQ+sU=",
+  "lastModifiedDate": "20260910001355"
 }


### PR DESCRIPTION
Automated package bump for `[
  "nix_git"
]`.