### PR TITLE
chore: bump zed-editor_git

### DIFF
--- a/pkgs/zed-editor-git/manifest.json
+++ b/pkgs/zed-editor-git/manifest.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260908214406-f29c8ea",
-  "rev": "f29c8eaf13682ef5a4a70a81eb4838b247cf7211",
-  "hash": "sha256-ORkO9lj0l4mRFuEeSifwP22e3WpeYZqVSrK/mQFrqbE=",
-  "cargoHash": "sha256-vE707MHoaxBzayPxOLQmitMGrozNyb3MgLLnmIPkGJ8="
+  "version": "unstable-20260909152330-52b2927",
+  "rev": "52b2927a1bac46be5d50ad341ac00b665e13764b",
+  "hash": "sha256-wE0q7kTIN7ZoMxoSMK56hg5WYa1W9DdXwe+pQUcJNeU=",
+  "cargoHash": "sha256-RuCvG0plUjNFim0zGfJXdARRbBzIWS2d37Lu4Kzn0l8="
 }


### PR DESCRIPTION
Automated package bump for `[
  "zed-editor_git"
]`.