### PR TITLE
chore: bump shadps4_git

### DIFF
--- a/pkgs/shadps4-git/manifest.json
+++ b/pkgs/shadps4-git/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260908160702-507464a",
-  "rev": "507464a531c0e8ddb4308f9cad6a73ab413f92d3",
-  "hash": "sha256-uzx4bFwHqEuDJV77Jdhop7KbF8Geb0yZDOl7Cv38jUk="
+  "version": "unstable-20260910051403-a0d0a1d",
+  "rev": "a0d0a1d117254b0c060bee48eaf50812177a7c56",
+  "hash": "sha256-rQzBV05/RbzSoUrO5ICOIxDdgrEM7iTG9co1UF0HkwQ="
 }


### PR DESCRIPTION
Automated package bump for `[
  "shadps4_git"
]`.