### PR TITLE
chore: bump nss_git

### DIFF
--- a/pkgs/firefox-nightly/manifest.json
+++ b/pkgs/firefox-nightly/manifest.json
@@ -1,7 +1,7 @@
 {
   "version": "157.0a1",
-  "rev": "93ba10a0a6e4ef012b47d033748f4b7bc317f541",
-  "buildId": "20260908215417",
-  "hash": "sha256-dWP9KriYtKt7tX5CRAA/qWwe77CfxrWBfumnw0/XAtI=",
+  "rev": "f052455619779175711cf8c67b0b77b287dcbd46",
+  "buildId": "20260909211052",
+  "hash": "sha256-vfGdvOeHTEqTzbQqH21TampyLIfR1qOqTnqBo7cj8Tg=",
   "newtabNpmDepsHash": "sha256-6NhZWVpbB0kX3d+9QaxFIgGeCfhqusNTANI6pwROWWw="
 }

--- a/pkgs/nss-git/manifest.json
+++ b/pkgs/nss-git/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260908153547-fc16813",
-  "rev": "fc168131f8a629e30c38b372e08848cabd443194",
-  "hash": "sha256-6hOZmfr6yD+UCiQzqgTIa/K5p9rmrnxijXKEPLUTmGo="
+  "version": "unstable-20260909213223-9e7dc40",
+  "rev": "9e7dc40311bdd2b54925de059405e54c98e4cc6b",
+  "hash": "sha256-rqK8haPy2BG/miMl28JQvVvVvKFFHdj768cO3MjNH3s="
 }


### PR DESCRIPTION
Automated package bump for `[
  "nss_git",
  "firefox-unwrapped_nightly"
]`.