### PR TITLE
chore: bump nix_git

### DIFF
--- a/pkgs/nix-git/manifest.json
+++ b/pkgs/nix-git/manifest.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260910001355-f88835d",
-  "rev": "f88835de0971838afb7598a066c92f9464164f54",
-  "hash": "sha256-yZ+T3LZT91aHjAiDpSJ3aTxGeBMiGPTrVq7Z/iwQ+sU=",
-  "lastModifiedDate": "20260910001355"
+  "version": "unstable-20260911094258-d262d70",
+  "rev": "d262d70a49e3e303151831cf268a7241abe85ae0",
+  "hash": "sha256-CseGo1qZwlEXtJntemD4a+xVz/WxQuzVkWfP0IfviQE=",
+  "lastModifiedDate": "20260911094258"
 }


### PR DESCRIPTION
Automated package bump for `[
  "nix_git"
]`.