### PR TITLE
chore: bump zed-editor_git

### DIFF
--- a/pkgs/zed-editor-git/manifest.json
+++ b/pkgs/zed-editor-git/manifest.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260909152330-52b2927",
-  "rev": "52b2927a1bac46be5d50ad341ac00b665e13764b",
-  "hash": "sha256-wE0q7kTIN7ZoMxoSMK56hg5WYa1W9DdXwe+pQUcJNeU=",
-  "cargoHash": "sha256-RuCvG0plUjNFim0zGfJXdARRbBzIWS2d37Lu4Kzn0l8="
+  "version": "unstable-20260911111044-3cef316",
+  "rev": "3cef31688ae2df816c9ce04fc254c172764485e8",
+  "hash": "sha256-TUE99W0VNsOtdLNjsSm4iiTrC312q5YKF/XVxbIqaeQ=",
+  "cargoHash": "sha256-SErMMlXdfv0/zhzep0MKc1CJw98UPkqXDNhtnm24dtY="
 }


### PR DESCRIPTION
Automated package bump for `[
  "zed-editor_git"
]`.