### PR TITLE
chore: bump openrgb_git

### DIFF
--- a/pkgs/openrgb-git/manifest.json
+++ b/pkgs/openrgb-git/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260910021408-84fb7d1",
-  "rev": "84fb7d18d0836d4a66c616ee5f0fe9068d557cdd",
-  "hash": "sha256-jwH7b67wcKD5by5loOQ8Q4PSH0o8VgQpqCh4bmqiddc="
+  "version": "unstable-20260911013404-728846f",
+  "rev": "728846f66861dd1cb7dc04835f651830d6ef13ce",
+  "hash": "sha256-lG228fjbeU1+6uQ2Aaf+RUVQYtcuJfNhjCJy3I15tBU="
 }


### PR DESCRIPTION
Automated package bump for `[
  "openrgb_git"
]`.