### PR TITLE
chore: bump niri_git

### DIFF
--- a/pkgs/niri-git/manifest.json
+++ b/pkgs/niri-git/manifest.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260821184624-dd75865",
-  "rev": "dd75865f547f0eac0e9b6c4d86d2cd00c0744252",
-  "hash": "sha256-BNZUEVR2H96hCKENNKoLSSTFT8W4smp7v94hJc4Ehfc=",
-  "cargoHash": "sha256-aNovCzrTtmqTO33YtZap47npdN73zXC1bap5q5dZvZk="
+  "version": "unstable-20260911065441-a787723",
+  "rev": "a787723fdb6c3a175fef23c572d44293bf08179e",
+  "hash": "sha256-R6PtQuBcfJtmXjSnWYfg+qJ82GbmZaVXMoS+od3mE9Q=",
+  "cargoHash": "sha256-QLV/UIk9nzi9QFI5oewFizLqHLwQwd9CYk8flkwlGfI="
 }


### PR DESCRIPTION
Automated package bump for `[
  "niri_git"
]`.