### PR TITLE
chore: bump libdrm_git

### DIFF
--- a/pkgs/mesa-git/manifest.json
+++ b/pkgs/mesa-git/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260910045938-1775b1f",
-  "rev": "1775b1fffa90ab04219cac48a5b0a6c0c6d7b45b",
-  "hash": "sha256-hGVvDRqQdb19EQsYo964dUep20/u764LexzgiJEMNpk="
+  "version": "unstable-20260911075415-aed26d2",
+  "rev": "aed26d2b59e730e1d2e00829f07160b7d06762c3",
+  "hash": "sha256-pZIJRAj4APP7Y+w8dZQkOjShDyjaxNue2p4j0hDrwYI="
 }

--- a/pkgs/sway-unwrapped-git/manifest.json
+++ b/pkgs/sway-unwrapped-git/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260731114707-5bc72de",
-  "rev": "5bc72dee4771a2d2d2648b8f69d30e0747f263f6",
-  "hash": "sha256-wzuESkvvb6r+BSVcOayRMSfKRDyAvrjqpr63vVi9eSY="
+  "version": "unstable-20260911094039-793a1f0",
+  "rev": "793a1f0c4702e2223bded3e01623aeb5a442a3ca",
+  "hash": "sha256-ymJkCbGYkuiI5a4ngD4el6oTIhjZ4qC9lygLdY1beEg="
 }

--- a/pkgs/wayland-protocols-git/manifest.json
+++ b/pkgs/wayland-protocols-git/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260903235617-5a430a6",
-  "rev": "5a430a6d52f811720b11234c19690b70106d970b",
-  "hash": "sha256-CArog1ptoc4Smu4NhWsdZqPPbcq0imKACbH3RIkmgdw="
+  "version": "unstable-20260909141743-819004a",
+  "rev": "819004adb3ab7e46f3fa3caef05b96e20434b244",
+  "hash": "sha256-Fal+LAXzxouWmm+u8Dfi+G69eKsbTeMN+yMkv7/C9BQ="
 }

--- a/pkgs/wlroots-git/manifest.json
+++ b/pkgs/wlroots-git/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260903172427-8697752",
-  "rev": "8697752bbebcf3b7e0c3af9f15296653d838cdef",
-  "hash": "sha256-B693M2HKdXoXX8aRK45OBPJef7IXUoha36ilkKzsTzI="
+  "version": "unstable-20260910134240-e5a6890",
+  "rev": "e5a6890e0f4be8bf29fb70224dcc2e78c0689672",
+  "hash": "sha256-zp5nXfGznPKgJsa7rwVlIEAwAgY25qizuVthKdkduxk="
 }


### PR DESCRIPTION
Automated package bump for `[
  "libdrm_git",
  "wayland-protocols_git",
  "mesa_git",
  "wayland_git",
  "wlroots_git",
  "sway-unwrapped_git",
  "xdg-desktop-portal-wlr_git"
]`.