### PR TITLE
chore: bump shadps4_git

### DIFF
--- a/pkgs/shadps4-git/manifest.json
+++ b/pkgs/shadps4-git/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260910051403-a0d0a1d",
-  "rev": "a0d0a1d117254b0c060bee48eaf50812177a7c56",
-  "hash": "sha256-rQzBV05/RbzSoUrO5ICOIxDdgrEM7iTG9co1UF0HkwQ="
+  "version": "unstable-20260911102117-dbc1c40",
+  "rev": "dbc1c40f3220f9c8eda24f0d08d6c1070362401b",
+  "hash": "sha256-gxUmgAsLY5YsqL5w63R0xR3qWe1Bc2z2Ei2fv/QF7aM="
 }


### PR DESCRIPTION
Automated package bump for `[
  "shadps4_git"
]`.