### PR TITLE
chore: bump niri_git

### DIFF
--- a/pkgs/niri-git/manifest.json
+++ b/pkgs/niri-git/manifest.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260911065441-a787723",
-  "rev": "a787723fdb6c3a175fef23c572d44293bf08179e",
-  "hash": "sha256-R6PtQuBcfJtmXjSnWYfg+qJ82GbmZaVXMoS+od3mE9Q=",
+  "version": "unstable-20260911115830-9e72e49",
+  "rev": "9e72e4917ca31baf4010496bf7f4aaf78d34d236",
+  "hash": "sha256-3H8HyOjmnLexX5sKfr4DjkIJyjADVLF4NUwpR+Mqnd8=",
   "cargoHash": "sha256-QLV/UIk9nzi9QFI5oewFizLqHLwQwd9CYk8flkwlGfI="
 }


### PR DESCRIPTION
Automated package bump for `[
  "niri_git"
]`.