### PR TITLE
chore: bump openrgb_git

### DIFF
--- a/pkgs/openrgb-git/manifest.json
+++ b/pkgs/openrgb-git/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260911013404-728846f",
-  "rev": "728846f66861dd1cb7dc04835f651830d6ef13ce",
-  "hash": "sha256-lG228fjbeU1+6uQ2Aaf+RUVQYtcuJfNhjCJy3I15tBU="
+  "version": "unstable-20260911230658-81bbe18",
+  "rev": "81bbe18a84c2e507006f19dd252e397e40a56bfe",
+  "hash": "sha256-623tJu5RYa1530xRtkRb1g62ANJCmRv1do0Ck4YzEYo="
 }


### PR DESCRIPTION
Automated package bump for `[
  "openrgb_git"
]`.