### PR TITLE
chore: bump nix_git

### DIFF
--- a/pkgs/nix-git/manifest.json
+++ b/pkgs/nix-git/manifest.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260911094258-d262d70",
-  "rev": "d262d70a49e3e303151831cf268a7241abe85ae0",
-  "hash": "sha256-CseGo1qZwlEXtJntemD4a+xVz/WxQuzVkWfP0IfviQE=",
-  "lastModifiedDate": "20260911094258"
+  "version": "unstable-20260912011736-203f85b",
+  "rev": "203f85b2e851fc52e253e8e33eff5fb92936736a",
+  "hash": "sha256-ahm58Y+ASv19VGVzC2IwNsQpkVR8rgEwwHDYwnMadkI=",
+  "lastModifiedDate": "20260912011736"
 }


### PR DESCRIPTION
Automated package bump for `[
  "nix_git"
]`.