### PR TITLE
chore: bump pcsx2_git

### DIFF
--- a/pkgs/pcsx2-git/manifest.json
+++ b/pkgs/pcsx2-git/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260911094156-4cdda8d",
-  "rev": "4cdda8d99ba12090bde7cfc58bb2bc410af75499",
-  "hash": "sha256-DgWyJBPoIN3ndHmN1kwigE7Q7kRham04lanWbepCTmA="
+  "version": "unstable-20260911125216-37a8be7",
+  "rev": "37a8be7b42d22960c82043ad4e394944df7b085e",
+  "hash": "sha256-cnXNNNARKytORiq/3OFOlL6GcKBycGh8SPOJZxLSaHM="
 }


### PR DESCRIPTION
Automated package bump for `[
  "pcsx2_git"
]`.