### PR TITLE
chore: bump libdrm_git

### DIFF
--- a/pkgs/mesa-git/manifest.json
+++ b/pkgs/mesa-git/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260911075415-aed26d2",
-  "rev": "aed26d2b59e730e1d2e00829f07160b7d06762c3",
-  "hash": "sha256-pZIJRAj4APP7Y+w8dZQkOjShDyjaxNue2p4j0hDrwYI="
+  "version": "unstable-20260912033329-7cda785",
+  "rev": "7cda7850edd103ace21aac37d416d2fdf7a282e1",
+  "hash": "sha256-6n2lWh/U8T2ZTxe6ziPXjs8c1JnXjcKUmPzNbzo6osg="
 }


### PR DESCRIPTION
Automated package bump for `[
  "libdrm_git",
  "wayland-protocols_git",
  "mesa_git",
  "wayland_git",
  "wlroots_git",
  "sway-unwrapped_git",
  "xdg-desktop-portal-wlr_git"
]`.