### PR TITLE
chore: bump zed-editor_git

### DIFF
--- a/pkgs/zed-editor-git/manifest.json
+++ b/pkgs/zed-editor-git/manifest.json
@@ -1,6 +1,6 @@
 {
-  "version": "unstable-20260911111044-3cef316",
-  "rev": "3cef31688ae2df816c9ce04fc254c172764485e8",
-  "hash": "sha256-TUE99W0VNsOtdLNjsSm4iiTrC312q5YKF/XVxbIqaeQ=",
-  "cargoHash": "sha256-SErMMlXdfv0/zhzep0MKc1CJw98UPkqXDNhtnm24dtY="
+  "version": "unstable-20260912032552-3db02c2",
+  "rev": "3db02c2c77659ad29810594e6249287ea1e791f7",
+  "hash": "sha256-DwFR8lOrKXdUTBlof824fkXWfsFjGRauJ53tIW/fWHQ=",
+  "cargoHash": "sha256-Fy4aPZr/b33Tvt7TyDl0CXYOxtJ9QXWkhOFUDNVdG1k="
 }


### PR DESCRIPTION
Automated package bump for `[
  "zed-editor_git"
]`.