### PR TITLE
chore: bump shadps4_git

### DIFF
--- a/pkgs/shadps4-git/manifest.json
+++ b/pkgs/shadps4-git/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "unstable-20260911102117-dbc1c40",
-  "rev": "dbc1c40f3220f9c8eda24f0d08d6c1070362401b",
-  "hash": "sha256-gxUmgAsLY5YsqL5w63R0xR3qWe1Bc2z2Ei2fv/QF7aM="
+  "version": "unstable-20260911152433-5a2b826",
+  "rev": "5a2b8261865a815ed0eef5c108f07a155ba8fb95",
+  "hash": "sha256-E+v+QyComQwIffZl1VdXU7gaNS62xxLGuPuLfRKVGf4="
 }


### PR DESCRIPTION
Automated package bump for `[
  "shadps4_git"
]`.