### PR TITLE
applet-window-title: update to 0.9.0 and patch for KDE 6

### DIFF
--- a/pkgs/applet-window-title/default.nix
+++ b/pkgs/applet-window-title/default.nix
@@ -5,14 +5,18 @@
 }:
 stdenvNoCC.mkDerivation rec {
   pname = "applet-window-title";
-  version = "0.5";
+  version = "0.9.0";
 
   src = fetchFromGitHub {
     owner = "dhruv8sh";
     repo = "plasma6-window-title-applet";
     rev = "v${version}";
-    hash = "sha256-p10sHXsuAgbeOaTAYysxnkOwz3Vlh6Bl8S5lGHMvads=";
+    hash = "sha256-pFXVySorHq5EpgsBz01vZQ0sLAy2UrF4VADMjyz2YLs=";
   };
+
+  patches = [
+    ./plasma-6.6-remove-appmenu-import.patch
+  ];
 
   propagatedBuildInputs = [ ];
 
@@ -20,13 +24,13 @@ stdenvNoCC.mkDerivation rec {
     runHook preInstall
     install -d $out/share/plasma/plasmoids/org.kde.windowtitle
     cp -r * $out/share/plasma/plasmoids/org.kde.windowtitle
-    rm $out/share/plasma/plasmoids/org.kde.windowtitle/{CHANGELOG.md,LICENSE,README.md}
+    rm $out/share/plasma/plasmoids/org.kde.windowtitle/{LICENSE,README.md}
     runHook postInstall
   '';
 
   meta = with lib; {
     description = "Plasma 6 applet that shows the application title and icon for active window";
-    homepage = "https://github.com/psifidotos/applet-window-title";
+    homepage = "https://github.com/dhruv8sh/plasma6-window-title-applet";
     license = licenses.gpl2Plus;
     maintainers = [ maintainers.dr460nf1r3 ];
     platforms = platforms.linux;

--- a/pkgs/applet-window-title/plasma-6.6-remove-appmenu-import.patch
+++ b/pkgs/applet-window-title/plasma-6.6-remove-appmenu-import.patch
@@ -1,0 +1,12 @@
+diff --git a/contents/ui/main.qml b/contents/ui/main.qml
+index 3107699..fe66e03 100644
+--- a/contents/ui/main.qml
++++ b/contents/ui/main.qml
+@@ -9,7 +9,6 @@ import org.kde.taskmanager       as TaskManager
+ import org.kde.kirigami          as Kirigami
+ import org.kde.activities        as Activities
+ import "../tools/Tools.js"       as Tools
+-import org.kde.plasma.private.appmenu 1.0 as AppMenuPrivate
+ 
+ PlasmoidItem {
+     id: root


### PR DESCRIPTION
### :fish: What?

Updated applet-window-title and fixed it for KDE 6.

### :fishing_pole_and_fish: Why?

Was not working correctly. 

### :fish_cake: Pending

- [ ] Complain with linter;
